### PR TITLE
fix: use /mcp base_url for OAuth metadata endpoints

### DIFF
--- a/apps/api/app/mcp_auth.py
+++ b/apps/api/app/mcp_auth.py
@@ -142,9 +142,10 @@ class ContextMineGitHubProvider(GitHubProvider):
         super().__init__(
             client_id=settings.github_client_id,
             client_secret=settings.github_client_secret,
-            # Use /api path so OAuth callbacks go to the unified /api/auth/callback
-            # The callback handler forwards MCP flows to /mcp/auth/callback
-            base_url=AnyHttpUrl(f"{settings.mcp_oauth_base_url}/api"),
+            # Use /mcp path to match the MCP sub-app mount point in main.py.
+            # This ensures OAuth metadata endpoints (authorize, token, register)
+            # resolve to /mcp/... where FastMCP actually serves them.
+            base_url=AnyHttpUrl(f"{settings.mcp_oauth_base_url}/mcp"),
             # Enable consent screen for security (protects against confused deputy)
             require_authorization_consent=True,
             # Request scopes needed for user info


### PR DESCRIPTION
## Summary

- Fix OAuth `base_url` in `ContextMineGitHubProvider` to use `/mcp` instead of `/api`
- OAuth metadata now returns correct endpoint URLs matching the MCP mount point

## Problem

The OAuth authorization server metadata returned endpoint URLs under `/api/...`:
```json
{
  "authorization_endpoint": "http://localhost:8000/api/authorize",
  "token_endpoint": "http://localhost:8000/api/token",
  "registration_endpoint": "http://localhost:8000/api/register"
}
```

But the actual endpoints served by FastMCP are at `/mcp/...` (where the MCP sub-app is mounted). This caused MCP clients to fail during OAuth client registration:
```
POST /api/register → 405 Method Not Allowed
POST /mcp/register → Works correctly
```

## Fix

Changed `base_url` from `{mcp_oauth_base_url}/api` to `{mcp_oauth_base_url}/mcp` in `apps/api/app/mcp_auth.py`.

## Test plan

- [ ] Start ContextMine with GitHub OAuth configured
- [ ] Verify `GET /mcp/.well-known/oauth-authorization-server` returns URLs under `/mcp/...`
- [ ] Verify `POST /mcp/register` works with the metadata-advertised URL
- [ ] Verify MCP client (mcp-remote) can complete OAuth registration step

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)