### PR TITLE
fix: add root-level .well-known routes for MCP OAuth discovery

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -111,12 +111,16 @@ def create_app() -> FastAPI:
     # catch-all intercepts .well-known requests and returns index.html.
     @app.get("/.well-known/{well_known_type}")
     @app.get("/.well-known/{well_known_type}/{path:path}")
-    async def forward_well_known(request: Request, well_known_type: str, path: str = "") -> JSONResponse:
+    async def forward_well_known(
+        request: Request, well_known_type: str, path: str = ""
+    ) -> JSONResponse:
         """Forward .well-known requests to MCP sub-app for OAuth discovery."""
         import httpx
 
         # Build the internal URL to the MCP sub-app's .well-known endpoint
-        mcp_url = f"http://localhost:{os.getenv('API_PORT', '8000')}/mcp/.well-known/{well_known_type}"
+        mcp_url = (
+            f"http://localhost:{os.getenv('API_PORT', '8000')}/mcp/.well-known/{well_known_type}"
+        )
         try:
             async with httpx.AsyncClient() as client:
                 resp = await client.get(mcp_url, timeout=5.0)


### PR DESCRIPTION
## Summary

- Add forwarding routes for `.well-known` OAuth discovery at the root level
- Prevents SPA catch-all from intercepting OAuth metadata requests

## Problem

MCP clients (per [RFC 8414](https://tools.ietf.org/html/rfc8414)) look for OAuth metadata at root-level `.well-known` paths:
- `/.well-known/oauth-authorization-server`
- `/.well-known/oauth-protected-resource`

Since FastMCP is mounted as a sub-app at `/mcp`, these endpoints are served at `/mcp/.well-known/...` instead. The SPA catch-all route `/{path:path}` intercepts root-level `.well-known` requests and returns `index.html`, causing JSON parse errors:

```
SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
```

## Fix

Added forwarding routes in `main.py` that proxy `.well-known` requests from root level to the MCP sub-app's actual endpoints at `/mcp/.well-known/...`. These routes are registered before the SPA catch-all.

## Test plan

- [ ] Verify `GET /.well-known/oauth-authorization-server` returns JSON (not HTML)
- [ ] Verify `GET /.well-known/oauth-protected-resource` returns JSON (not HTML)
- [ ] Verify SPA still works for all other non-API routes
- [ ] Verify MCP client (mcp-remote) can discover OAuth configuration

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)