### PR TITLE
fix(github-sync): sanitize NUL bytes in source files

### DIFF
--- a/apps/worker/contextmine_worker/github_sync.py
+++ b/apps/worker/contextmine_worker/github_sync.py
@@ -1091,11 +1091,16 @@ def _numstat_path_variants(raw_path: str) -> list[str]:
 
 
 def read_file_content(repo_path: Path, file_path: str) -> str | None:
-    """Read file content, returning None if not readable."""
+    """Read file content, returning None if not readable.
+
+    PostgreSQL text columns reject NUL bytes even when the surrounding file is
+    otherwise valid UTF-8. Preserve the byte's meaning as a visible escape so
+    one unusual source file cannot abort an entire repository sync.
+    """
     full_path = repo_path / file_path
     try:
         content = full_path.read_text(encoding="utf-8")
-        return content
+        return content.replace("\x00", "\\0")
     except (OSError, UnicodeDecodeError):
         return None
 

--- a/apps/worker/tests/test_github_sync_coverage.py
+++ b/apps/worker/tests/test_github_sync_coverage.py
@@ -18,7 +18,16 @@ from contextmine_worker.github_sync import (
     SyncStats,
     _path_is_within,
     is_eligible_file,
+    read_file_content,
 )
+
+
+class TestReadFileContent:
+    def test_escapes_nul_bytes_for_postgres_text(self, tmp_path: Path) -> None:
+        source = tmp_path / "source.ts"
+        source.write_bytes(b"const separator = '\x00';\n")
+
+        assert read_file_content(tmp_path, "source.ts") == "const separator = '\\0';\n"
 
 
 class TestIsEligibleFile:


### PR DESCRIPTION
## Summary

- replace embedded NUL characters in UTF-8 source files with visible `\0` escapes before persistence
- prevent PostgreSQL `text` writes from aborting an entire repository sync
- retain the surrounding source content instead of dropping the file

## Verification

- `pytest apps/worker/tests/test_github_sync_coverage.py -q` (26 passed)
- Ruff lint and format checks for the changed files
- reproduced and exercised during a full Apache Superset repository sync