### PR TITLE
fix(github-sync): avoid duplicate chunk queue entries

### DIFF
--- a/apps/worker/contextmine_worker/flows.py
+++ b/apps/worker/contextmine_worker/flows.py
@@ -3528,6 +3528,7 @@ async def _gh_upsert_document(
 
 async def _gh_recover_unchunked_documents(ctx: _SyncGitHubCtx) -> None:
     """Find documents missing chunks and add them to the chunking queue."""
+    queued_document_ids = {doc_id for doc_id, _, _ in ctx.docs_to_chunk}
     async with get_session() as session:
         docs_with_chunks = select(Chunk.document_id).distinct().subquery()
         result = await session.execute(
@@ -3541,9 +3542,11 @@ async def _gh_recover_unchunked_documents(ctx: _SyncGitHubCtx) -> None:
         unchunked_docs = result.all()
 
         for doc_id, content, uri in unchunked_docs:
-            if content:
+            doc_id_str = str(doc_id)
+            if content and doc_id_str not in queued_document_ids:
                 file_path = uri.split("?")[0].split("/", 5)[-1] if "/" in uri else None
-                ctx.docs_to_chunk.append((str(doc_id), content, file_path))
+                ctx.docs_to_chunk.append((doc_id_str, content, file_path))
+                queued_document_ids.add(doc_id_str)
 
         ctx.unchunked_docs_count = len(unchunked_docs)
 

--- a/apps/worker/tests/test_flows_unit.py
+++ b/apps/worker/tests/test_flows_unit.py
@@ -613,6 +613,44 @@ class TestMaterializeSurfaceCatalog:
         assert result["surface_files_scanned"] == 0
 
 
+class TestRecoverUnchunkedDocuments:
+    async def test_does_not_queue_new_document_twice(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        queued_id = uuid.uuid4()
+        recovered_id = uuid.uuid4()
+        source_id = uuid.uuid4()
+        ctx = SimpleNamespace(
+            source=SimpleNamespace(id=source_id),
+            docs_to_chunk=[(str(queued_id), "queued", "src/queued.py")],
+            unchunked_docs_count=0,
+        )
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [
+            (
+                queued_id,
+                "queued",
+                "git://github.com/owner/repo/src/queued.py?ref=main",
+            ),
+            (
+                recovered_id,
+                "recovered",
+                "git://github.com/owner/repo/src/recovered.py?ref=main",
+            ),
+        ]
+        session = AsyncMock()
+        session.execute = AsyncMock(return_value=mock_result)
+        session_cm = MagicMock()
+        session_cm.__aenter__ = AsyncMock(return_value=session)
+        session_cm.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(flows, "get_session", lambda: session_cm)
+
+        await flows._gh_recover_unchunked_documents(ctx)
+
+        assert [item[0] for item in ctx.docs_to_chunk].count(str(queued_id)) == 1
+        assert [item[0] for item in ctx.docs_to_chunk].count(str(recovered_id)) == 1
+        assert ctx.unchunked_docs_count == 2
+
+
 # ---------------------------------------------------------------------------
 # get_embedding_model_for_collection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- seed unchunked-document recovery with IDs that are already queued for chunking
- append each recovered document at most once
- preserve the existing unchunked-document diagnostic count

Newly inserted documents can still appear in the recovery query before chunk creation. Without this guard they are scheduled twice in the same sync run.

## Verification

- `pytest apps/worker/tests/test_flows_unit.py::TestRecoverUnchunkedDocuments -q` (2 passed)
- Ruff lint and format checks for the changed files
- exercised while syncing the Apache Superset repository