### PR TITLE
perf(surface): prefilter non-OpenAPI documents

### DIFF
--- a/packages/core/contextmine_core/analyzer/extractors/surface.py
+++ b/packages/core/contextmine_core/analyzer/extractors/surface.py
@@ -116,6 +116,11 @@ class SurfaceCatalogExtractor:
         if not file_path.endswith((*_YAML_EXTENSIONS, ".json")):
             return None
 
+        # Most large repositories contain many unrelated JSON/YAML files. Avoid
+        # feeding all of them through the comparatively expensive YAML parser.
+        if "openapi" not in content and "swagger" not in content:
+            return None
+
         try:
             parsed = yaml.safe_load(content)
         except (yaml.YAMLError, json.JSONDecodeError):

--- a/packages/core/tests/test_surface_extractors.py
+++ b/packages/core/tests/test_surface_extractors.py
@@ -1,5 +1,6 @@
 """Tests for System Surface Catalog extractors."""
 
+from unittest.mock import patch
 from uuid import uuid4
 
 from contextmine_core.analyzer.extractors.graphql import extract_from_graphql
@@ -512,6 +513,17 @@ settings:
         result = extractor.add_file("config.yaml", content)
         assert result is False
         assert len(extractor.catalog.openapi_specs) == 0
+
+    def test_unrelated_json_skips_yaml_parser(self) -> None:
+        """Large non-spec JSON files should be rejected before YAML parsing."""
+        extractor = SurfaceCatalogExtractor()
+        with patch(
+            "contextmine_core.analyzer.extractors.surface.yaml.safe_load",
+            side_effect=AssertionError("parser must not run"),
+        ):
+            result = extractor.add_file("translations.json", '{"messages": {"ok": "OK"}}')
+
+        assert result is False
 
     def test_invalid_yaml_returns_false(self) -> None:
         """Malformed YAML is gracefully rejected."""


### PR DESCRIPTION
## Summary

- reject unrelated JSON and YAML files before invoking the YAML parser
- keep the existing OpenAPI and Swagger structural validation unchanged
- reduce deterministic surface-extraction work in repositories with many configuration and translation files

## Verification

- `pytest packages/core/tests/test_surface_extractors.py -q` (32 passed)
- Ruff lint and format checks for the changed files
- validated against the JSON and YAML workload observed in Apache Superset