### PR TITLE
chore(compose): make CodeCharta port configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,10 @@ DEBUG=true
 API_HOST=0.0.0.0
 API_PORT=8000
 
-# CodeCharta visualization host port
+# CodeCharta visualization host port used by Docker Compose and the Vite dev proxy
 CODECHARTA_PORT=9001
+# Optional full Vite proxy target; overrides the URL derived from CODECHARTA_PORT
+# VITE_CODECHARTA_URL=http://localhost:9001
 
 # Database
 # For local development with Docker Compose:

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ DEBUG=true
 API_HOST=0.0.0.0
 API_PORT=8000
 
+# CodeCharta visualization host port
+CODECHARTA_PORT=9001
+
 # Database
 # For local development with Docker Compose:
 DATABASE_URL=postgresql+asyncpg://contextmine:contextmine@localhost:5432/contextmine

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ Copy `.env.example` to `.env` and configure these variables:
 | `GEMINI_API_KEY` | Alternative to OpenAI for embeddings |
 | `ANTHROPIC_API_KEY` | For deep_research agent (uses Claude) |
 | `MCP_ALLOWED_ORIGINS` | CORS origins for MCP in production |
+| `CODECHARTA_PORT` | Local CodeCharta host port used by Docker Compose and the Vite dev proxy (default: `9001`) |
+| `VITE_CODECHARTA_URL` | Optional full CodeCharta dev-proxy target overriding `CODECHARTA_PORT` |
 | `POSTGRES_PLATFORM` | Docker Compose postgres image platform override (default: `linux/amd64`) |
 | `METRICS_STRICT_MODE` | Enforce strict real metrics gate for GitHub syncs (default: `true`) |
 | `METRICS_LANGUAGES` | Metrics language scope (default: `python,typescript,javascript,java,php`) |

--- a/apps/web/config/codecharta.ts
+++ b/apps/web/config/codecharta.ts
@@ -1,0 +1,3 @@
+export function resolveCodechartaUrl(env: Record<string, string | undefined>): string {
+  return env.VITE_CODECHARTA_URL || `http://localhost:${env.CODECHARTA_PORT || '9001'}`
+}

--- a/apps/web/src/vite-config.test.ts
+++ b/apps/web/src/vite-config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCodechartaUrl } from '../config/codecharta'
+
+describe('resolveCodechartaUrl', () => {
+  it('uses the Docker Compose default port', () => {
+    expect(resolveCodechartaUrl({})).toBe('http://localhost:9001')
+  })
+
+  it('uses the configured Docker Compose host port', () => {
+    expect(resolveCodechartaUrl({ CODECHARTA_PORT: '9002' })).toBe('http://localhost:9002')
+  })
+
+  it('prefers an explicit proxy target', () => {
+    expect(
+      resolveCodechartaUrl({
+        CODECHARTA_PORT: '9002',
+        VITE_CODECHARTA_URL: 'https://codecharta.example.com',
+      }),
+    ).toBe('https://codecharta.example.com')
+  })
+})

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,44 +1,52 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// API URL for proxying - defaults to localhost for local dev
-const apiUrl = process.env.VITE_API_URL || 'http://localhost:8000'
-const codechartaUrl = process.env.VITE_CODECHARTA_URL || 'http://localhost:9000'
+import { resolveCodechartaUrl } from './config/codecharta'
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url))
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      reportsDirectory: 'coverage',
-      include: ['src/**/*.{ts,tsx}'],
-      exclude: ['src/**/*.test.{ts,tsx}', 'src/test/**'],
-    },
-  },
-  server: {
-    port: 5173,
-    host: true, // Allow external connections (needed for Docker)
-    proxy: {
-      '/api': {
-        target: apiUrl,
-        changeOrigin: true,
-      },
-      '/mcp': {
-        target: apiUrl,
-        changeOrigin: true,
-      },
-      '/codecharta': {
-        target: codechartaUrl,
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/codecharta/, ''),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, repositoryRoot, ['CODECHARTA_', 'VITE_'])
+  const apiUrl = env.VITE_API_URL || 'http://localhost:8000'
+  const codechartaUrl = resolveCodechartaUrl(env)
+
+  return {
+    plugins: [react()],
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./src/test/setup.ts'],
+      include: ['src/**/*.test.{ts,tsx}'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov'],
+        reportsDirectory: 'coverage',
+        include: ['src/**/*.{ts,tsx}'],
+        exclude: ['src/**/*.test.{ts,tsx}', 'src/test/**'],
       },
     },
-  },
+    server: {
+      port: 5173,
+      host: true, // Allow external connections (needed for Docker)
+      proxy: {
+        '/api': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
+        '/mcp': {
+          target: apiUrl,
+          changeOrigin: true,
+        },
+        '/codecharta': {
+          target: codechartaUrl,
+          changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/codecharta/, ''),
+        },
+      },
+    },
+  }
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   codecharta:
     image: codecharta/codecharta-visualization:latest
     ports:
-      - "9001:80"
+      - "${CODECHARTA_PORT:-9001}:80"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost/"]
       interval: 10s

--- a/docs/development.md
+++ b/docs/development.md
@@ -90,9 +90,13 @@ For hot-reloading frontend development:
 # Terminal 1: API server
 uv run uvicorn apps.api.app.main:app --reload --port 8000
 
-# Terminal 2: Frontend dev server (proxies to :8000)
+# Terminal 2: Frontend dev server (proxies the API and local CodeCharta instance)
 cd apps/web && npm run dev
 ```
+
+The CodeCharta proxy derives its local target from `CODECHARTA_PORT` in the repository-root
+`.env` file (default: `9001`). Set `VITE_CODECHARTA_URL` only when the proxy should use a
+different full URL.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary

- make the CodeCharta host port configurable through `CODECHARTA_PORT`
- retain port `9001` as the backward-compatible default
- derive the Vite development proxy target from the same repository-root setting
- keep `VITE_CODECHARTA_URL` as an explicit full-URL override
- document and test the configuration precedence

## Verification

- `docker compose config` resolves the default host port to `9001`
- `CODECHARTA_PORT=9002 docker compose config` resolves the host port to `9002`
- Vite resolves the proxy target to `http://localhost:9001` by default
- Vite resolves `CODECHARTA_PORT=9002` to `http://localhost:9002`
- `VITE_CODECHARTA_URL` overrides the derived target
- `npm test` (`473 passed`)
- targeted ESLint for the changed TypeScript files
- `npm run build`
- `git diff --check`
