### PR TITLE
fix(architecture): keep provenance filtering database-side

### DIFF
--- a/packages/core/contextmine_core/architecture/facts.py
+++ b/packages/core/contextmine_core/architecture/facts.py
@@ -19,7 +19,10 @@ from contextmine_core.models import (
     TwinScenario,
 )
 from contextmine_core.twin.grouping import canonical_file_path_from_meta, derive_arch_group
-from contextmine_core.twin.service import get_full_scenario_graph, get_scenario_provenance_node_ids
+from contextmine_core.twin.service import (
+    get_full_scenario_graph,
+    scenario_provenance_node_ids_select,
+)
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -637,7 +640,7 @@ async def build_architecture_facts(
         )
     )
 
-    scenario_knowledge_node_ids = await get_scenario_provenance_node_ids(session, scenario_id)
+    scenario_knowledge_node_ids = scenario_provenance_node_ids_select(scenario_id)
     kg_nodes = (
         (
             await session.execute(

--- a/packages/core/contextmine_core/exports/mermaid_c4.py
+++ b/packages/core/contextmine_core/exports/mermaid_c4.py
@@ -23,7 +23,10 @@ from contextmine_core.twin.projections import (
     GraphProjection,
     build_inferred_architecture_projection,
 )
-from contextmine_core.twin.service import get_full_scenario_graph, get_scenario_provenance_node_ids
+from contextmine_core.twin.service import (
+    get_full_scenario_graph,
+    scenario_provenance_node_ids_select,
+)
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -205,9 +208,7 @@ async def _load_recovered_architecture_model(
     scenario_id: UUID,
     collection_id: UUID,
 ) -> RecoveredArchitectureModel:
-    scenario_knowledge_node_ids = await get_scenario_provenance_node_ids(session, scenario_id)
-    if not scenario_knowledge_node_ids:
-        return RecoveredArchitectureModel()
+    scenario_knowledge_node_ids = scenario_provenance_node_ids_select(scenario_id)
 
     kg_nodes = (
         (

--- a/packages/core/contextmine_core/twin/__init__.py
+++ b/packages/core/contextmine_core/twin/__init__.py
@@ -60,6 +60,7 @@ from contextmine_core.twin.service import (
     list_scenario_patches,
     refresh_metric_snapshots,
     repair_twin_file_path_canonicalization,
+    scenario_provenance_node_ids_select,
     seed_scenario_from_knowledge_graph,
     submit_intent,
 )
@@ -92,6 +93,7 @@ __all__ = [
     "get_cfg",
     "get_cfg_multi",
     "get_scenario_provenance_node_ids",
+    "scenario_provenance_node_ids_select",
     "get_scenario_graph",
     "get_variable_flow",
     "get_variable_flow_multi",

--- a/packages/core/contextmine_core/twin/service.py
+++ b/packages/core/contextmine_core/twin/service.py
@@ -53,6 +53,7 @@ from sqlalchemy import delete, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
+from sqlalchemy.sql import Select
 
 logger = logging.getLogger(__name__)
 
@@ -144,14 +145,17 @@ async def get_scenario_provenance_node_ids(
     scenario_id: UUID,
 ) -> set[UUID]:
     """Return active knowledge-node provenance IDs that are present in a scenario."""
-    rows = await session.execute(
-        select(TwinNode.provenance_node_id).where(
-            TwinNode.scenario_id == scenario_id,
-            TwinNode.is_active.is_(True),
-            TwinNode.provenance_node_id.is_not(None),
-        )
-    )
+    rows = await session.execute(scenario_provenance_node_ids_select(scenario_id))
     return {node_id for node_id in rows.scalars().all() if node_id is not None}
+
+
+def scenario_provenance_node_ids_select(scenario_id: UUID) -> Select[tuple[UUID | None]]:
+    """Build a database-side selector for active scenario provenance IDs."""
+    return select(TwinNode.provenance_node_id).where(
+        TwinNode.scenario_id == scenario_id,
+        TwinNode.is_active.is_(True),
+        TwinNode.provenance_node_id.is_not(None),
+    )
 
 
 async def seed_scenario_from_knowledge_graph(

--- a/packages/core/tests/test_architecture_decision_recovery.py
+++ b/packages/core/tests/test_architecture_decision_recovery.py
@@ -126,14 +126,14 @@ async def test_recovered_decisions_flow_through_architecture_facts(
     async def _fake_c4(*_args, **_kwargs):
         return SimpleNamespace(content="C4Context", warnings=[])
 
-    async def _fake_node_ids(*_args, **_kwargs):
+    def _fake_node_ids(*_args, **_kwargs):
         return {endpoint.id, symbol.id}
 
     async def _fake_evidence(*_args, **_kwargs):
         return {}
 
     monkeypatch.setattr(architecture_facts, "export_mermaid_c4_result", _fake_c4)
-    monkeypatch.setattr(architecture_facts, "get_scenario_provenance_node_ids", _fake_node_ids)
+    monkeypatch.setattr(architecture_facts, "scenario_provenance_node_ids_select", _fake_node_ids)
     monkeypatch.setattr(architecture_facts, "_load_node_evidence", _fake_evidence)
     monkeypatch.setattr(
         architecture_facts, "recover_architecture_model", lambda *_args, **_kwargs: model
@@ -220,7 +220,7 @@ async def test_default_pipeline_loads_persisted_adr_docs_into_recovery(
     async def _fake_c4(*_args, **_kwargs):
         return SimpleNamespace(content="C4Context", warnings=[])
 
-    async def _fake_node_ids(*_args, **_kwargs):
+    def _fake_node_ids(*_args, **_kwargs):
         return {adr_file.id, api_symbol.id, worker_job.id}
 
     async def _fake_evidence(*_args, **_kwargs):
@@ -234,7 +234,7 @@ async def test_default_pipeline_loads_persisted_adr_docs_into_recovery(
     )
 
     monkeypatch.setattr(architecture_facts, "export_mermaid_c4_result", _fake_c4)
-    monkeypatch.setattr(architecture_facts, "get_scenario_provenance_node_ids", _fake_node_ids)
+    monkeypatch.setattr(architecture_facts, "scenario_provenance_node_ids_select", _fake_node_ids)
     monkeypatch.setattr(architecture_facts, "_load_node_evidence", _fake_evidence)
     bundle = await architecture_facts.build_architecture_facts(
         session,

--- a/packages/core/tests/test_architecture_facts_recovery_integration.py
+++ b/packages/core/tests/test_architecture_facts_recovery_integration.py
@@ -216,7 +216,7 @@ def _install_common_patches(
     async def _fake_projection(**_kwargs):
         return {"nodes": [], "edges": [], "grouping_strategy": "heuristic"}
 
-    async def _fake_node_ids(*_args, **_kwargs):
+    def _fake_node_ids(*_args, **_kwargs):
         return {endpoint.id, symbol.id, table.id}
 
     async def _fake_evidence(*_args, **_kwargs):
@@ -224,7 +224,7 @@ def _install_common_patches(
 
     monkeypatch.setattr(architecture_facts, "export_mermaid_c4_result", _fake_c4)
     monkeypatch.setattr(architecture_facts, "get_full_scenario_graph", _fake_projection)
-    monkeypatch.setattr(architecture_facts, "get_scenario_provenance_node_ids", _fake_node_ids)
+    monkeypatch.setattr(architecture_facts, "scenario_provenance_node_ids_select", _fake_node_ids)
     monkeypatch.setattr(architecture_facts, "_load_node_evidence", _fake_evidence)
 
 
@@ -275,7 +275,7 @@ async def test_build_architecture_facts_is_recovered_first_without_legacy_projec
     async def _fake_c4(*_args, **_kwargs):
         return SimpleNamespace(content="C4Context", warnings=[])
 
-    async def _fake_node_ids(*_args, **_kwargs):
+    def _fake_node_ids(*_args, **_kwargs):
         return {endpoint.id, symbol.id, table.id}
 
     async def _fake_evidence(*_args, **_kwargs):
@@ -290,7 +290,7 @@ async def test_build_architecture_facts_is_recovered_first_without_legacy_projec
     monkeypatch.setattr(
         architecture_facts, "get_full_scenario_graph", _legacy_projection_should_not_be_used
     )
-    monkeypatch.setattr(architecture_facts, "get_scenario_provenance_node_ids", _fake_node_ids)
+    monkeypatch.setattr(architecture_facts, "scenario_provenance_node_ids_select", _fake_node_ids)
     monkeypatch.setattr(architecture_facts, "_load_node_evidence", _fake_evidence)
     monkeypatch.setattr(
         architecture_facts,

--- a/packages/core/tests/test_architecture_quality_gates.py
+++ b/packages/core/tests/test_architecture_quality_gates.py
@@ -330,7 +330,7 @@ async def test_no_silent_reduction_of_multi_membership_to_single_membership(
     async def _fake_c4(*_args, **_kwargs):
         return SimpleNamespace(content="C4Context", warnings=[])
 
-    async def _fake_node_ids(*_args, **_kwargs):
+    def _fake_node_ids(*_args, **_kwargs):
         return {endpoint.id, symbol.id, table.id}
 
     async def _fake_evidence(*_args, **_kwargs):
@@ -339,7 +339,8 @@ async def test_no_silent_reduction_of_multi_membership_to_single_membership(
     monkeypatch.setattr(mermaid_export, "export_mermaid_c4_result", _fake_c4)
     monkeypatch.setattr("contextmine_core.architecture.facts.export_mermaid_c4_result", _fake_c4)
     monkeypatch.setattr(
-        "contextmine_core.architecture.facts.get_scenario_provenance_node_ids", _fake_node_ids
+        "contextmine_core.architecture.facts.scenario_provenance_node_ids_select",
+        _fake_node_ids,
     )
     monkeypatch.setattr("contextmine_core.architecture.facts._load_node_evidence", _fake_evidence)
     monkeypatch.setattr(

--- a/packages/core/tests/test_mermaid_c4_export.py
+++ b/packages/core/tests/test_mermaid_c4_export.py
@@ -436,10 +436,10 @@ async def test_load_recovered_architecture_model_includes_persisted_docs(
         last_seen_at=datetime.now(UTC),
     )
 
-    async def _fake_node_ids(*_args, **_kwargs):
+    def _fake_node_ids(*_args, **_kwargs):
         return {adr_file.id, api_symbol.id, worker_job.id}
 
-    monkeypatch.setattr(mermaid_export, "get_scenario_provenance_node_ids", _fake_node_ids)
+    monkeypatch.setattr(mermaid_export, "scenario_provenance_node_ids_select", _fake_node_ids)
 
     model = await mermaid_export._load_recovered_architecture_model(
         _FakeSession(

--- a/packages/core/tests/test_twin_service.py
+++ b/packages/core/tests/test_twin_service.py
@@ -16,6 +16,7 @@ from contextmine_core.architecture_intents import IntentRisk
 from contextmine_core.models import (
     IntentRiskLevel,
     KnowledgeEdgeKind,
+    KnowledgeNode,
     TwinLayer,
 )
 from contextmine_core.semantic_snapshot.models import RelationKind
@@ -26,11 +27,26 @@ from contextmine_core.twin.service import (
     _risk_to_model,
     infer_edge_layers,
     infer_node_layers,
+    scenario_provenance_node_ids_select,
 )
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
 
 # ---------------------------------------------------------------------------
 # _relation_to_edge_kind
 # ---------------------------------------------------------------------------
+
+
+def test_scenario_provenance_selector_stays_database_side() -> None:
+    scenario_id = uuid4()
+    statement = select(KnowledgeNode.id).where(
+        KnowledgeNode.id.in_(scenario_provenance_node_ids_select(scenario_id))
+    )
+
+    compiled = statement.compile(dialect=postgresql.dialect())
+
+    assert list(compiled.params.values()) == [scenario_id]
+    assert "SELECT twin_nodes.provenance_node_id" in str(compiled)
 
 
 class TestRelationToEdgeKind:


### PR DESCRIPTION
## Summary

- keep active scenario provenance filtering inside PostgreSQL through a reusable SQL selector
- use the selector for architecture fact extraction and recovered C4 model loading
- preserve the existing set-returning service API for callers that need materialized IDs
- add a regression test proving that query parameter count is independent of scenario size

The previous implementation loaded every provenance UUID into Python and expanded the set into `IN (...)` bind parameters. Large scenarios could exceed the asyncpg limit of 32,767 query arguments.

## Verification

- 177 architecture, twin-service, recovery, quality-gate, and C4 export tests passed
- Ruff lint and format checks for all changed files
- `git diff --check`
- root cause reproduced with an Apache Superset scenario containing more than 200,000 provenance-backed nodes