### PR TITLE
fix(worker): await behavioral materialization before sync completion

### DIFF
--- a/apps/worker/contextmine_worker/flows.py
+++ b/apps/worker/contextmine_worker/flows.py
@@ -268,15 +268,6 @@ async def _run_blocking_with_timeout(
         raise RuntimeError(f"STEP_TIMEOUT: {step_name} exceeded {int(timeout_seconds)}s") from exc
 
 
-def _log_background_task_failure(task: "asyncio.Task[object]") -> None:
-    if task.cancelled():
-        logger.warning("Behavioral layer background extraction task was cancelled.")
-        return
-    exc = task.exception()
-    if exc:
-        logger.warning("Behavioral layer background extraction failed: %s", exc)
-
-
 def _uri_to_file_path(uri: str) -> str:
     """Normalize document URI to repo-relative file path."""
     return uri.split("?")[0].split("/", 5)[-1] if "/" in uri else uri
@@ -2203,6 +2194,32 @@ async def materialize_behavioral_layers(
         raise
 
 
+async def _run_behavioral_materialization(
+    *,
+    source_id: str,
+    collection_id: str,
+    scenario_id: str,
+    source_version_id: str | None,
+    deleted_file_paths: list[str] | None,
+) -> dict[str, object]:
+    """Await advisory behavioral extraction before the parent sync can finish."""
+    try:
+        return await materialize_behavioral_layers.fn(
+            source_id=source_id,
+            collection_id=collection_id,
+            scenario_id=scenario_id,
+            source_version_id=source_version_id,
+            deleted_file_paths=deleted_file_paths,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Behavioral layer extraction failed: %s", exc)
+        return {
+            "behavioral_layers_status": "failed",
+            "last_behavioral_materialized_at": None,
+            "deep_warnings": [str(exc)],
+        }
+
+
 def _build_scip_index_config():
     """Build IndexConfig from settings.
 
@@ -2585,6 +2602,7 @@ class _SyncGitHubCtx:
     kg_stats: dict[str, Any] = field(default_factory=dict)
     surface_stats: dict[str, int] = field(default_factory=dict)
     twin_stats: dict[str, Any] = field(default_factory=dict)
+    behavioral_stats: dict[str, object] = field(default_factory=dict)
 
 
 def _default_scip_stats() -> dict[str, Any]:
@@ -3675,6 +3693,16 @@ def _compute_metrics_gate(twin_stats: dict[str, Any]) -> str:
     return "pass" if mapped >= requested else "fail"
 
 
+def _behavioral_stats_subset(stats: dict[str, object]) -> dict[str, object]:
+    """Normalize behavioral materialization status for run/version stats."""
+    return {
+        "behavioral_layers_status": stats.get("behavioral_layers_status", "not_run"),
+        "last_behavioral_materialized_at": stats.get("last_behavioral_materialized_at"),
+        "deep_warnings": list(stats.get("deep_warnings", []) or []),
+        "behavioral_extract": dict(stats.get("behavioral_extract", {}) or {}),
+    }
+
+
 def _build_source_version_stats(
     ctx: _SyncGitHubCtx, scenario_id_raw: object, scenario_version: int | None
 ) -> dict[str, Any]:
@@ -3713,6 +3741,7 @@ def _build_source_version_stats(
         "metrics_gate": _compute_metrics_gate(ctx.twin_stats),
         "scenario_id": scenario_id_raw,
         "scenario_version": scenario_version,
+        **_behavioral_stats_subset(ctx.behavioral_stats),
     }
 
 
@@ -3815,11 +3844,29 @@ def _build_sync_run_stats(ctx: _SyncGitHubCtx) -> dict[str, Any]:
         "surface_proto_nodes": ctx.surface_stats.get("proto_nodes", 0),
         "surface_job_nodes": ctx.surface_stats.get("job_nodes", 0),
         "surface_edges_created": ctx.surface_stats.get("edges_created", 0),
+        **_behavioral_stats_subset(ctx.behavioral_stats),
     }
 
 
 async def _gh_phase_finalize(ctx: _SyncGitHubCtx) -> None:
-    """Save sync run stats, mark source version ready, schedule behavioral layers."""
+    """Finish behavioral materialization, then persist terminal sync state."""
+    collection_id_str = str(ctx.source.collection_id)
+    scenario_id_raw = ctx.twin_stats.get("twin_asis_scenario_id")
+    scenario_for_behavioral = str(scenario_id_raw or "")
+    if scenario_for_behavioral:
+        await update_progress_artifact(  # type: ignore[misc]
+            ctx.progress_id,
+            progress=97,
+            description="Materializing behavioral layers...",
+        )
+        ctx.behavioral_stats = await _run_behavioral_materialization(
+            source_id=str(ctx.source.id),
+            collection_id=collection_id_str,
+            scenario_id=scenario_for_behavioral,
+            source_version_id=(str(ctx.source_version_id) if ctx.source_version_id else None),
+            deleted_file_paths=ctx.deleted_file_paths,
+        )
+
     await update_progress_artifact(ctx.progress_id, progress=98, description="Saving results...")  # type: ignore[misc]
 
     from contextmine_core.twin import record_twin_event, set_source_version_status
@@ -3834,7 +3881,6 @@ async def _gh_phase_finalize(ctx: _SyncGitHubCtx) -> None:
         db_run.status = SyncRunStatus.SUCCESS
         db_run.finished_at = datetime.now(UTC)
         scenario_version = None
-        scenario_id_raw = ctx.twin_stats.get("twin_asis_scenario_id")
         if scenario_id_raw:
             scenario = (
                 await session.execute(
@@ -3891,20 +3937,6 @@ async def _gh_phase_finalize(ctx: _SyncGitHubCtx) -> None:
 
         db_run.stats = _build_sync_run_stats(ctx)
         await session.commit()
-
-    collection_id_str = str(ctx.source.collection_id)
-    scenario_for_behavioral = str(ctx.twin_stats.get("twin_asis_scenario_id") or "")
-    if scenario_for_behavioral:
-        background = asyncio.create_task(
-            _materialize_behavioral_layers_impl(
-                source_id=str(ctx.source.id),
-                collection_id=collection_id_str,
-                scenario_id=scenario_for_behavioral,
-                source_version_id=(str(ctx.source_version_id) if ctx.source_version_id else None),
-                deleted_file_paths=ctx.deleted_file_paths,
-            )
-        )
-        background.add_done_callback(_log_background_task_failure)
 
     await update_progress_artifact(ctx.progress_id, progress=100, description="Sync complete!")  # type: ignore[misc]
 
@@ -4185,6 +4217,22 @@ async def sync_web_source(
             f"TWIN_BUILD_TIMEOUT: source={source.id} timeout={twin_timeout_seconds}s"
         ) from exc
 
+    behavioral_stats: dict[str, object] = {}
+    scenario_for_behavioral = str(twin_stats.get("twin_asis_scenario_id") or "")
+    if scenario_for_behavioral:
+        await update_progress_artifact(  # type: ignore[misc]
+            progress_id,
+            progress=97,
+            description="Materializing behavioral layers...",
+        )
+        behavioral_stats = await _run_behavioral_materialization(
+            source_id=str(source.id),
+            collection_id=collection_id_str,
+            scenario_id=scenario_for_behavioral,
+            source_version_id=None,
+            deleted_file_paths=None,
+        )
+
     await update_progress_artifact(progress_id, progress=98, description="Saving results...")  # type: ignore[misc]
 
     async with get_session() as session:
@@ -4228,22 +4276,10 @@ async def sync_web_source(
             "surface_proto_nodes": surface_stats.get("proto_nodes", 0),
             "surface_job_nodes": surface_stats.get("job_nodes", 0),
             "surface_edges_created": surface_stats.get("edges_created", 0),
+            **_behavioral_stats_subset(behavioral_stats),
         }
 
         await session.commit()
-
-    scenario_for_behavioral = str(twin_stats.get("twin_asis_scenario_id") or "")
-    if scenario_for_behavioral:
-        background = asyncio.create_task(
-            _materialize_behavioral_layers_impl(
-                source_id=str(source.id),
-                collection_id=collection_id_str,
-                scenario_id=scenario_for_behavioral,
-                source_version_id=None,
-                deleted_file_paths=None,
-            )
-        )
-        background.add_done_callback(_log_background_task_failure)
 
     await update_progress_artifact(progress_id, progress=100, description="Sync complete!")  # type: ignore[misc]
 

--- a/apps/worker/tests/test_final_coverage.py
+++ b/apps/worker/tests/test_final_coverage.py
@@ -5,11 +5,9 @@ Each section targets specific uncovered lines from --cov-report=term-missing.
 
 from __future__ import annotations
 
-import asyncio
 import json
 from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import MagicMock
 
 from contextmine_worker.flows import (
     IGNORED_REPO_PATH_PARTS,
@@ -17,7 +15,6 @@ from contextmine_worker.flows import (
     _is_ignored_repo_path,
     _joern_parse_timeout_seconds,
     _knowledge_graph_build_timeout_seconds,
-    _log_background_task_failure,
     _sync_blocking_step_timeout_seconds,
     _sync_document_step_timeout_seconds,
     _sync_documents_per_run_limit,
@@ -284,25 +281,6 @@ class TestIgnoredRepoParts:
         assert "vendor" in IGNORED_REPO_PATH_PARTS
         assert "__pycache__" in IGNORED_REPO_PATH_PARTS
         assert ".git" in IGNORED_REPO_PATH_PARTS
-
-
-class TestLogBackgroundTaskFailure:
-    def test_cancelled_task(self) -> None:
-        task = MagicMock(spec=asyncio.Task)
-        task.cancelled.return_value = True
-        _log_background_task_failure(task)  # Should not raise
-
-    def test_task_with_exception(self) -> None:
-        task = MagicMock(spec=asyncio.Task)
-        task.cancelled.return_value = False
-        task.exception.return_value = RuntimeError("test")
-        _log_background_task_failure(task)  # Should not raise
-
-    def test_task_no_exception(self) -> None:
-        task = MagicMock(spec=asyncio.Task)
-        task.cancelled.return_value = False
-        task.exception.return_value = None
-        _log_background_task_failure(task)  # Should not raise
 
 
 # ============================================================================

--- a/apps/worker/tests/test_flows_async.py
+++ b/apps/worker/tests/test_flows_async.py
@@ -1384,6 +1384,53 @@ class TestMaterializeBehavioralLayersTask:
         record_mock.assert_awaited()
 
 
+class TestRunBehavioralMaterialization:
+    async def test_awaits_materialization_to_completion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        expected = {
+            "behavioral_layers_status": "ready",
+            "last_behavioral_materialized_at": "2026-01-01T00:00:00+00:00",
+        }
+        materialize = AsyncMock(return_value=expected)
+        monkeypatch.setattr(
+            flows,
+            "materialize_behavioral_layers",
+            SimpleNamespace(fn=materialize),
+        )
+
+        result = await flows._run_behavioral_materialization(
+            source_id=str(uuid.uuid4()),
+            collection_id=str(uuid.uuid4()),
+            scenario_id=str(uuid.uuid4()),
+            source_version_id=str(uuid.uuid4()),
+            deleted_file_paths=["deleted.py"],
+        )
+
+        assert result == expected
+        materialize.assert_awaited_once()
+
+    async def test_returns_advisory_failure_status(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        materialize = AsyncMock(side_effect=RuntimeError("behavioral failed"))
+        monkeypatch.setattr(
+            flows,
+            "materialize_behavioral_layers",
+            SimpleNamespace(fn=materialize),
+        )
+
+        result = await flows._run_behavioral_materialization(
+            source_id=str(uuid.uuid4()),
+            collection_id=str(uuid.uuid4()),
+            scenario_id=str(uuid.uuid4()),
+            source_version_id=None,
+            deleted_file_paths=None,
+        )
+
+        assert result["behavioral_layers_status"] == "failed"
+        assert result["deep_warnings"] == ["behavioral failed"]
+        materialize.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # ingest_coverage_metrics: deeper paths
 # ---------------------------------------------------------------------------

--- a/apps/worker/tests/test_flows_pipelines.py
+++ b/apps/worker/tests/test_flows_pipelines.py
@@ -792,16 +792,10 @@ class TestSyncGithubSourceHappyPath:
             ),
         )
 
-        # Mock behavioral layers
         monkeypatch.setattr(
             flows,
             "_materialize_behavioral_layers_impl",
             AsyncMock(return_value={}),
-        )
-        monkeypatch.setattr(
-            flows,
-            "_log_background_task_failure",
-            lambda task: None,
         )
 
         result = await flows.sync_github_source.fn(source, sync_run, run_started_at)
@@ -1029,12 +1023,12 @@ class TestSyncGithubSourceHappyPath:
                 }
             ),
         )
+        behavioral_impl = AsyncMock(return_value={})
         monkeypatch.setattr(
             flows,
             "_materialize_behavioral_layers_impl",
-            AsyncMock(return_value={}),
+            behavioral_impl,
         )
-        monkeypatch.setattr(flows, "_log_background_task_failure", lambda task: None)
 
         result = await flows.sync_github_source.fn(source, sync_run, run_started_at)
 
@@ -1042,3 +1036,4 @@ class TestSyncGithubSourceHappyPath:
         assert result.files_scanned == 1
         assert result.files_indexed == 1
         assert result.docs_deleted >= 0
+        behavioral_impl.assert_awaited_once()

--- a/apps/worker/tests/test_flows_unit.py
+++ b/apps/worker/tests/test_flows_unit.py
@@ -29,7 +29,6 @@ from contextmine_worker.flows import (
     _is_ignored_repo_path,
     _joern_parse_timeout_seconds,
     _knowledge_graph_build_timeout_seconds,
-    _log_background_task_failure,
     _run_blocking_with_timeout,
     _sync_blocking_step_timeout_seconds,
     _sync_document_step_timeout_seconds,
@@ -449,33 +448,6 @@ class TestRunBlockingWithTimeout:
             assert result == 100
 
         asyncio.run(_inner())
-
-
-# ---------------------------------------------------------------------------
-# _log_background_task_failure
-# ---------------------------------------------------------------------------
-
-
-class TestLogBackgroundTaskFailure:
-    def test_cancelled_task_logs_warning(self) -> None:
-        mock_task = MagicMock()
-        mock_task.cancelled.return_value = True
-        # Should not raise
-        _log_background_task_failure(mock_task)
-        mock_task.cancelled.assert_called_once()
-
-    def test_task_with_exception_logs_warning(self) -> None:
-        mock_task = MagicMock()
-        mock_task.cancelled.return_value = False
-        mock_task.exception.return_value = RuntimeError("boom")
-        _log_background_task_failure(mock_task)
-        mock_task.exception.assert_called_once()
-
-    def test_successful_task_no_error(self) -> None:
-        mock_task = MagicMock()
-        mock_task.cancelled.return_value = False
-        mock_task.exception.return_value = None
-        _log_background_task_failure(mock_task)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- await behavioral layer materialization before GitHub and web sync tasks reach terminal completion
- run extraction through the existing failure-recording wrapper
- keep behavioral failures advisory while persisting an explicit `failed` status and warnings
- include behavioral status in sync-run and source-version statistics
- remove detached `asyncio.create_task` callbacks that could be cancelled when a one-shot worker exits

## Verification

- 372 affected worker tests passed
- added a pipeline regression proving that a GitHub sync waits for behavioral extraction
- Ruff lint and format checks for all changed files
- `git diff --check`
- the cancellation mode was observed after a full Apache Superset repository sync in a one-shot worker

The test run still reports six pre-existing unawaited-coroutine warnings in timeout-path tests.