### PR TITLE
feat: add model-free indexing and retrieval mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,7 +44,11 @@ MCP_ALLOWED_ORIGINS=
 # Must match where your server is accessible
 MCP_OAUTH_BASE_URL=http://localhost:8000
 
-# LLM Providers (at least one required for context assembly)
+# Set to false for deterministic indexing and FTS-only retrieval without
+# external embedding or LLM calls.
+MODEL_CALLS_ENABLED=true
+
+# Model providers (at least one is required when model calls are enabled)
 # OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
 # GEMINI_API_KEY=...

--- a/README.md
+++ b/README.md
@@ -286,12 +286,13 @@ Copy `.env.example` to `.env` and configure these variables:
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth app secret |
 | `SESSION_SECRET` | Secret for session cookies |
 | `TOKEN_ENCRYPTION_KEY` | Key for encrypting stored tokens |
-| `OPENAI_API_KEY` | OpenAI API key for embeddings |
 
 ### Optional
 
 | Variable | Description |
 |----------|-------------|
+| `MODEL_CALLS_ENABLED` | Enable external embedding and LLM calls (default: `true`) |
+| `OPENAI_API_KEY` | OpenAI API key for embeddings and LLM features |
 | `GEMINI_API_KEY` | Alternative to OpenAI for embeddings |
 | `ANTHROPIC_API_KEY` | For deep_research agent (uses Claude) |
 | `MCP_ALLOWED_ORIGINS` | CORS origins for MCP in production |
@@ -300,6 +301,12 @@ Copy `.env.example` to `.env` and configure these variables:
 | `METRICS_LANGUAGES` | Metrics language scope (default: `python,typescript,javascript,java,php`) |
 | `COVERAGE_INGEST_MAX_PAYLOAD_MB` | Max multipart payload size for CI coverage uploads (default: `25`) |
 | `COVERAGE_INGEST_PREFECT_FLOW_NAME` | Prefect flow name for async coverage ingest (default: `ingest_coverage_metrics`) |
+
+Set `MODEL_CALLS_ENABLED=false` to operate without external model calls. Syncs
+still extract documents, symbols, deterministic schemas, API surfaces, and
+graph communities. Search, context assembly, and MCP retrieval use full-text
+evidence without embeddings or LLM synthesis. Model-dependent enrichment,
+research agents, and generated architecture narratives remain unavailable.
 
 ### Setting Up GitHub OAuth
 

--- a/apps/api/app/mcp_server.py
+++ b/apps/api/app/mcp_server.py
@@ -23,6 +23,7 @@ from contextmine_core.architecture import (
 )
 from contextmine_core.context import assemble_context
 from contextmine_core.embeddings import FakeEmbedder, get_embedder, parse_embedding_model_spec
+from contextmine_core.model_policy import ModelCallsDisabledError
 from contextmine_core.search import hybrid_search
 from fastmcp import FastMCP
 from sqlalchemy import func, or_, select
@@ -466,8 +467,9 @@ async def get_context_markdown(
     offset: Annotated[int, "Pagination offset"] = 0,
     raw: Annotated[bool, "Return raw chunks without LLM synthesis (faster)"] = False,
 ) -> str:
-    """Semantic search across all indexed documentation and code. Returns synthesized context."""
+    """Search indexed documentation and code, with synthesis when model calls are enabled."""
     user_id = get_current_user_id()
+    settings = get_settings()
 
     # Parse collection_id if provided
     collection_uuid: uuid.UUID | None = None
@@ -478,8 +480,8 @@ async def get_context_markdown(
             return f"# Error\n\nInvalid collection_id: {collection_id}"
 
     try:
-        # If raw mode or topic filter, we need to do the search ourselves
-        if raw or topic:
+        # Model-free operation is evidence-only and must never synthesize an answer.
+        if raw or topic or not settings.model_calls_enabled:
             return await _get_raw_chunks(
                 query=query,
                 user_id=user_id,
@@ -513,15 +515,16 @@ async def _get_raw_chunks(
     """Get raw search results without LLM assembly."""
     settings = get_settings()
 
-    # Get query embedding
-    try:
-        emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
-        embedder = get_embedder(emb_provider, emb_model)
-    except Exception:
-        embedder = FakeEmbedder()
+    query_embedding: list[float] | None = None
+    if settings.model_calls_enabled:
+        try:
+            emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
+            embedder = get_embedder(emb_provider, emb_model)
+        except Exception:
+            embedder = FakeEmbedder()
 
-    embed_result = await embedder.embed_batch([query])
-    query_embedding = embed_result.embeddings[0]
+        embed_result = await embedder.embed_batch([query])
+        query_embedding = embed_result.embeddings[0]
 
     # Search with extra results to handle topic filtering and offset
     search_limit = max_chunks + offset + 50 if topic else max_chunks + offset
@@ -553,6 +556,8 @@ async def _get_raw_chunks(
 
     # Build markdown output
     lines = [f"# Search Results for: {query}\n"]
+    if not settings.model_calls_enabled:
+        lines.append("*Retrieval mode: deterministic full-text search; model calls disabled.*\n")
     if topic:
         lines.append(f"*Filtered by topic: {topic}*\n")
 
@@ -2510,7 +2515,7 @@ async def _arc42_regenerate(db, collection, scenario, existing, section_key, set
             max_turns=int(settings.arch_docs_agent_sdk_max_turns),
             permission_mode=settings.arch_docs_agent_sdk_permission_mode,
         )
-    except ClaudeAgentSdkUnavailableError as exc:
+    except (ClaudeAgentSdkUnavailableError, ModelCallsDisabledError) as exc:
         return f"# Error\n\n{exc}"
 
     if section_key:

--- a/apps/api/app/routes/search.py
+++ b/apps/api/app/routes/search.py
@@ -58,7 +58,7 @@ def get_current_user_id(request: Request) -> uuid.UUID | None:
     return uuid.UUID(user_id)
 
 
-async def get_query_embedding(query: str, collection_id: str | None = None) -> list[float]:
+async def get_query_embedding(query: str, collection_id: str | None = None) -> list[float] | None:
     """Get embedding for query text.
 
     Uses FakeEmbedder for now; will be replaced with real embedder.
@@ -67,6 +67,8 @@ async def get_query_embedding(query: str, collection_id: str | None = None) -> l
     from contextmine_core import FakeEmbedder, get_embedder, parse_embedding_model_spec
 
     settings = get_settings()
+    if not settings.model_calls_enabled:
+        return None
 
     # If collection_id provided, could look up collection's embedding config
     # For now, use global default

--- a/apps/api/app/routes/twin.py
+++ b/apps/api/app/routes/twin.py
@@ -38,6 +38,7 @@ from contextmine_core.exports import (
 )
 from contextmine_core.graph.age import run_read_only_cypher, sync_scenario_to_age
 from contextmine_core.graphrag import trace_path as graphrag_trace_path
+from contextmine_core.model_policy import ModelCallsDisabledError
 from contextmine_core.models import (
     CommunityMember,
     CoverageIngestJob,
@@ -3172,7 +3173,7 @@ async def arc42_view(
                 max_turns=int(settings.arch_docs_agent_sdk_max_turns),
                 permission_mode=settings.arch_docs_agent_sdk_permission_mode,
             )
-        except ClaudeAgentSdkUnavailableError as exc:
+        except (ClaudeAgentSdkUnavailableError, ModelCallsDisabledError) as exc:
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         except FileNotFoundError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/apps/api/tests/test_mcp_async_coverage.py
+++ b/apps/api/tests/test_mcp_async_coverage.py
@@ -39,6 +39,7 @@ def _make_settings(**overrides):
         "arch_docs_llm_max_hypotheses": 12,
         "repos_root": "/tmp/repos",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
     }
     defaults.update(overrides)
     return SimpleNamespace(**defaults)

--- a/apps/api/tests/test_mcp_coverage_extra.py
+++ b/apps/api/tests/test_mcp_coverage_extra.py
@@ -43,6 +43,7 @@ def _make_settings(**overrides):
         "arch_docs_agent_sdk_max_turns": 10,
         "arch_docs_agent_sdk_permission_mode": "never",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
         "repos_root": "/tmp/repos",
         "twin_analysis_cache_ttl_seconds": 300,
     }

--- a/apps/api/tests/test_mcp_final.py
+++ b/apps/api/tests/test_mcp_final.py
@@ -91,6 +91,7 @@ def _make_settings(**overrides):
         "arch_docs_agent_sdk_max_turns": 10,
         "arch_docs_agent_sdk_permission_mode": "never",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
         "repos_root": "/tmp/repos",
         "twin_analysis_cache_ttl_seconds": 300,
     }

--- a/apps/api/tests/test_mcp_tools.py
+++ b/apps/api/tests/test_mcp_tools.py
@@ -627,6 +627,21 @@ class TestGetMarkdown:
         assert "Search Results" in result
 
     @pytest.mark.anyio
+    async def test_model_free_mode_forces_raw_retrieval(self, _patch_user_id) -> None:
+        settings = MagicMock(model_calls_enabled=False)
+        with (
+            patch("app.mcp_server.get_settings", return_value=settings),
+            patch("app.mcp_server._get_raw_chunks", new_callable=AsyncMock) as mock_raw,
+            patch("app.mcp_server.assemble_context", new_callable=AsyncMock) as mock_assemble,
+        ):
+            mock_raw.return_value = "# Search Results\n\nEvidence"
+            result = await _get_context_markdown(query="test")
+
+        assert "Evidence" in result
+        mock_raw.assert_awaited_once()
+        mock_assemble.assert_not_awaited()
+
+    @pytest.mark.anyio
     async def test_error_returns_error_message(self, _patch_user_id) -> None:
         with patch("app.mcp_server.assemble_context", new_callable=AsyncMock) as mock_ac:
             mock_ac.side_effect = RuntimeError("LLM provider not configured")

--- a/apps/api/tests/test_mcp_tools_extended.py
+++ b/apps/api/tests/test_mcp_tools_extended.py
@@ -218,6 +218,34 @@ class TestGetContextMarkdownRaw:
         assert "Payment" not in result
 
     @pytest.mark.anyio
+    async def test_model_free_raw_search_never_initializes_embedder(self, _patch_user_id) -> None:
+        mock_search_response = MagicMock()
+        mock_search_response.results = [
+            MagicMock(uri="doc://a", title="Evidence", content="deterministic content")
+        ]
+        settings = MagicMock(
+            model_calls_enabled=False,
+            default_embedding_model="openai:text-embedding-3-small",
+        )
+
+        with (
+            patch("app.mcp_server.get_settings", return_value=settings),
+            patch(
+                "app.mcp_server.get_embedder",
+                side_effect=AssertionError("embedder must not be initialized"),
+            ),
+            patch(
+                "app.mcp_server.hybrid_search",
+                new_callable=AsyncMock,
+                return_value=mock_search_response,
+            ) as mock_search,
+        ):
+            result = await _get_context_markdown(query="test query", raw=True)
+
+        assert "model calls disabled" in result
+        assert mock_search.await_args.kwargs["query_embedding"] is None
+
+    @pytest.mark.anyio
     async def test_assembled_mode_calls_assemble_context(self, _patch_user_id) -> None:
         """Test the LLM-assembled path."""
         mock_response = MagicMock()

--- a/apps/api/tests/test_search.py
+++ b/apps/api/tests/test_search.py
@@ -189,6 +189,81 @@ class TestAccessControl:
             assert result.query == "test query"
 
 
+class TestModelFreeSearch:
+    @pytest.mark.anyio
+    async def test_hybrid_search_skips_vector_query_without_embedding(self) -> None:
+        import uuid
+        from contextlib import asynccontextmanager
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from contextmine_core.search import hybrid_search
+
+        collection_id = uuid.uuid4()
+        chunk_id = uuid.uuid4()
+
+        @asynccontextmanager
+        async def mock_get_session():
+            yield MagicMock()
+
+        vector_search = AsyncMock()
+        with (
+            patch("contextmine_core.search.get_session", mock_get_session),
+            patch(
+                "contextmine_core.search.get_accessible_collection_ids",
+                AsyncMock(return_value=[collection_id]),
+            ),
+            patch(
+                "contextmine_core.search.search_fts",
+                AsyncMock(return_value=[(chunk_id, 0.9, 1)]),
+            ),
+            patch("contextmine_core.search.search_vector", vector_search),
+            patch(
+                "contextmine_core.search.get_chunk_details",
+                AsyncMock(
+                    return_value={
+                        chunk_id: {
+                            "document_id": uuid.uuid4(),
+                            "content": "evidence",
+                            "uri": "doc://evidence",
+                            "title": "Evidence",
+                            "source_id": uuid.uuid4(),
+                            "collection_id": collection_id,
+                        }
+                    }
+                ),
+            ),
+        ):
+            result = await hybrid_search(
+                query="evidence",
+                query_embedding=None,
+                user_id=None,
+                top_k=10,
+            )
+
+        assert len(result.results) == 1
+        assert result.total_vector_matches == 0
+        vector_search.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_api_query_embedding_is_none_when_models_are_disabled(self) -> None:
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        from app.routes.search import get_query_embedding
+
+        with (
+            patch(
+                "app.routes.search.get_settings",
+                return_value=SimpleNamespace(model_calls_enabled=False),
+            ),
+            patch(
+                "contextmine_core.get_embedder",
+                side_effect=AssertionError("embedder must not be initialized"),
+            ),
+        ):
+            assert await get_query_embedding("evidence") is None
+
+
 class TestSearchIntegration:
     """Integration tests for the search endpoint.
 

--- a/apps/worker/contextmine_worker/agents/deployment.py
+++ b/apps/worker/contextmine_worker/agents/deployment.py
@@ -72,7 +72,7 @@ def build_agent():
 
     # Initialize LLM
     api_key = os.environ.get("ANTHROPIC_API_KEY", os.environ.get("ANTHROPIC_API_TOKEN"))
-    llm = ChatAnthropic(model="claude-3-5-sonnet-latest", api_key=api_key)
+    llm = ChatAnthropic(model_name="claude-3-5-sonnet-latest", api_key=api_key)
     llm_with_tools = llm.bind_tools(tools)
 
     def agent_node(state: AgentState):

--- a/apps/worker/contextmine_worker/agents/deployment.py
+++ b/apps/worker/contextmine_worker/agents/deployment.py
@@ -3,6 +3,7 @@ import os
 import re
 from typing import Annotated
 
+from contextmine_core.model_policy import ensure_model_calls_enabled
 from langchain_anthropic import ChatAnthropic
 from langchain_core.tools import tool
 from langgraph.graph import START, StateGraph
@@ -66,6 +67,7 @@ def glob_tool(pattern: str, repo_path: str) -> str:
 
 
 def build_agent():
+    ensure_model_calls_enabled()
     tools = [bash_tool, read_tool, glob_tool]
 
     # Initialize LLM

--- a/apps/worker/contextmine_worker/agents/deployment.py
+++ b/apps/worker/contextmine_worker/agents/deployment.py
@@ -72,7 +72,7 @@ def build_agent():
 
     # Initialize LLM
     api_key = os.environ.get("ANTHROPIC_API_KEY", os.environ.get("ANTHROPIC_API_TOKEN"))
-    llm = ChatAnthropic(model="claude-3-5-sonnet-latest", api_key=api_key)  # ty: ignore[missing-argument,unknown-argument]
+    llm = ChatAnthropic(model="claude-3-5-sonnet-latest", api_key=api_key)
     llm_with_tools = llm.bind_tools(tools)
 
     def agent_node(state: AgentState):

--- a/apps/worker/contextmine_worker/flows.py
+++ b/apps/worker/contextmine_worker/flows.py
@@ -300,6 +300,7 @@ class _DocProcessingAccumulator:
     chunks_deleted: int = 0
     chunks_embedded: int = 0
     chunks_deduplicated: int = 0
+    embedding_documents_skipped: int = 0
     tokens_used: int = 0
     symbols_created: int = 0
     symbols_deleted: int = 0
@@ -375,6 +376,8 @@ async def _process_single_document(
     acc.chunks_embedded += embed_stats["chunks_embedded"]
     acc.chunks_deduplicated += embed_stats.get("chunks_deduplicated", 0)
     acc.tokens_used += embed_stats["tokens_used"]
+    if embed_stats.get("skipped"):
+        acc.embedding_documents_skipped += 1
 
 
 async def _process_document_batch(
@@ -829,11 +832,20 @@ async def embed_document(document_id: str, collection_id: str | None = None) -> 
     Returns:
         Stats dict with chunks_embedded, chunks_deduplicated, and tokens_used
     """
+    settings = get_settings()
+    if not settings.model_calls_enabled:
+        return {
+            "chunks_embedded": 0,
+            "chunks_deduplicated": 0,
+            "tokens_used": 0,
+            "skipped": True,
+            "skip_reason": "model_calls_disabled",
+        }
+
     # Get embedding model spec from collection config or global default
     if collection_id:
         model_spec = await get_embedding_model_for_collection(collection_id)
     else:
-        settings = get_settings()
         model_spec = settings.default_embedding_model
 
     provider, model_name = parse_embedding_model_spec(model_spec)
@@ -908,7 +920,7 @@ async def _kg_has_db_tables(collection_uuid: object) -> bool:
 async def _kg_extract_erm(
     source_uuid: object,
     collection_uuid: object,
-    research_llm: object,
+    research_llm: object | None,
     changed_doc_ids: list[str] | None = None,
     deleted_file_paths: list[str] | None = None,
 ) -> dict[str, int]:
@@ -985,6 +997,15 @@ async def _kg_extract_erm(
             }
 
         if not schema_candidates:
+            if cleanup_stats.get("nodes_deleted", 0) or cleanup_stats.get("evidence_deleted", 0):
+                await session.commit()
+            return {
+                "tables_found": 0,
+                "nodes_deleted": cleanup_stats.get("nodes_deleted", 0),
+                "evidence_deleted": cleanup_stats.get("evidence_deleted", 0),
+            }
+
+        if research_llm is None:
             if cleanup_stats.get("nodes_deleted", 0) or cleanup_stats.get("evidence_deleted", 0):
                 await session.commit()
             return {
@@ -1427,8 +1448,9 @@ async def build_knowledge_graph(
     - Hierarchical Leiden communities
     - Community summaries and embeddings
 
-    REQUIRES: LLM provider and embedder must be configured.
-    GraphRAG features require both for proper entity resolution and community summaries.
+    With model calls disabled, deterministic file, symbol, schema, surface, and
+    community extraction remains available. Semantic enrichment requires an LLM
+    provider and embedder.
 
     Returns:
         Stats dict with KG extraction metrics
@@ -1449,50 +1471,59 @@ async def build_knowledge_graph(
         "kg_endpoints": 0,
         "kg_jobs": 0,
         "kg_errors": [],
+        "kg_mode": "full",
+        "kg_model_steps_skipped": [],
     }
 
     source_uuid = uuid_module.UUID(source_id)
     collection_uuid = uuid_module.UUID(collection_id)
 
-    # REQUIRED: Get LLM provider and embedder upfront
-    # GraphRAG is the core feature - no point running without these
     settings = get_settings()
-
-    # Get LLM provider (required for entity extraction and community summaries)
     llm_provider = None
-    if settings.default_llm_provider:
+    research_llm = None
+    embedder = None
+    if settings.model_calls_enabled:
+        if settings.default_llm_provider:
+            try:
+                llm_provider = get_llm_provider(settings.default_llm_provider)
+            except Exception as e:
+                raise ValueError(f"LLM provider configured but failed to initialize: {e}") from e
+        else:
+            raise ValueError(
+                "LLM provider required for Knowledge Graph. "
+                "Set DEFAULT_LLM_PROVIDER (e.g., 'openai', 'anthropic', 'gemini')."
+            )
+
+        research_llm = get_research_llm_provider()
+        if not research_llm:
+            raise ValueError(
+                "Research LLM provider required for business rule extraction. "
+                "Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GEMINI_API_KEY."
+            )
+
         try:
-            llm_provider = get_llm_provider(settings.default_llm_provider)
+            provider_name, model_name = parse_embedding_model_spec(settings.default_embedding_model)
+            embedder = get_embedder(provider_name, model_name)
         except Exception as e:
-            raise ValueError(f"LLM provider configured but failed to initialize: {e}") from e
+            raise ValueError(
+                f"Embedder required for Knowledge Graph but failed to initialize: {e}. "
+                f"Set DEFAULT_EMBEDDING_MODEL (e.g., 'openai:text-embedding-3-small')."
+            ) from e
+
+        logger.info(
+            "Knowledge Graph build starting with LLM=%s, embedder=%s",
+            settings.default_llm_provider,
+            settings.default_embedding_model,
+        )
     else:
-        raise ValueError(
-            "LLM provider required for Knowledge Graph. "
-            "Set DEFAULT_LLM_PROVIDER (e.g., 'openai', 'anthropic', 'gemini')."
-        )
-
-    research_llm = get_research_llm_provider()
-    if not research_llm:
-        raise ValueError(
-            "Research LLM provider required for business rule extraction. "
-            "Set OPENAI_API_KEY, ANTHROPIC_API_KEY, or GEMINI_API_KEY."
-        )
-
-    # Get embedder (required for entity resolution and community retrieval)
-    try:
-        provider_name, model_name = parse_embedding_model_spec(settings.default_embedding_model)
-        embedder = get_embedder(provider_name, model_name)
-    except Exception as e:
-        raise ValueError(
-            f"Embedder required for Knowledge Graph but failed to initialize: {e}. "
-            f"Set DEFAULT_EMBEDDING_MODEL (e.g., 'openai:text-embedding-3-small')."
-        ) from e
-
-    logger.info(
-        "Knowledge Graph build starting with LLM=%s, embedder=%s",
-        settings.default_llm_provider,
-        settings.default_embedding_model,
-    )
+        stats["kg_mode"] = "deterministic"
+        stats["kg_model_steps_skipped"] = [
+            "business_rules",
+            "generic_schema_extraction",
+            "semantic_entities",
+            "community_summaries",
+        ]
+        logger.info("Knowledge Graph build starting in deterministic model-free mode")
 
     # Step 1: Build FILE and SYMBOL nodes from indexed documents
     try:
@@ -1519,19 +1550,20 @@ async def build_knowledge_graph(
         stats["kg_errors"].append(f"file_symbol: {e}")
 
     # Step 2: Extract business rules from code files using LLM (INCREMENTAL)
-    try:
-        rules_count = await _kg_extract_business_rules(
-            source_uuid,
-            collection_uuid,
-            changed_doc_ids,
-            research_llm,
-            deleted_file_paths,
-        )
-        stats["kg_business_rules"] = rules_count.get("rules_created", 0)
-        stats["kg_nodes_deleted"] += rules_count.get("nodes_deleted", 0)
-    except Exception as e:
-        logger.warning("Failed to extract business rules: %s", e)
-        stats["kg_errors"].append(f"rules: {e}")
+    if settings.model_calls_enabled:
+        try:
+            rules_count = await _kg_extract_business_rules(
+                source_uuid,
+                collection_uuid,
+                changed_doc_ids,
+                research_llm,
+                deleted_file_paths,
+            )
+            stats["kg_business_rules"] = rules_count.get("rules_created", 0)
+            stats["kg_nodes_deleted"] += rules_count.get("nodes_deleted", 0)
+        except Exception as e:
+            logger.warning("Failed to extract business rules: %s", e)
+            stats["kg_errors"].append(f"rules: {e}")
 
     # Step 3: Extract ERM from Alembic migrations
     try:
@@ -1561,17 +1593,19 @@ async def build_knowledge_graph(
         stats["kg_errors"].append(f"surface: {e}")
 
     # Step 5: Extract semantic entities using LLM (for proper GraphRAG)
-    await _kg_step_semantic_entities(
-        stats, collection_uuid, llm_provider, embedder, changed_doc_ids, deleted_file_paths
-    )
+    if settings.model_calls_enabled:
+        await _kg_step_semantic_entities(
+            stats, collection_uuid, llm_provider, embedder, changed_doc_ids, deleted_file_paths
+        )
 
     # Step 6: Detect communities using Leiden algorithm (GraphRAG)
     await _kg_step_communities(stats, collection_uuid)
 
     # Step 7: Generate community summaries and embeddings
-    await _kg_step_summaries(
-        stats, collection_uuid, research_llm, embedder, changed_doc_ids, deleted_file_paths
-    )
+    if settings.model_calls_enabled:
+        await _kg_step_summaries(
+            stats, collection_uuid, research_llm, embedder, changed_doc_ids, deleted_file_paths
+        )
 
     return stats
 
@@ -3691,6 +3725,7 @@ def _build_source_version_stats(
         "docs_processing_failures": int(doc_acc.processing_failures),  # type: ignore[union-attr]
         "docs_processing_timeouts": int(doc_acc.processing_timeouts),  # type: ignore[union-attr]
         "docs_processing_error_samples": list(doc_acc.error_samples)[:25],  # type: ignore[union-attr]
+        "embedding_documents_skipped": int(doc_acc.embedding_documents_skipped),  # type: ignore[union-attr]
         "joern_status": "ready" if ctx.joern_ok else "failed",
         "joern_error": ctx.joern_error if not ctx.joern_ok else "",
         **scip_sub,
@@ -3740,6 +3775,7 @@ def _build_sync_run_stats(ctx: _SyncGitHubCtx) -> dict[str, Any]:
         "chunks_embedded": doc_acc.chunks_embedded,  # type: ignore[union-attr]
         "chunks_deduplicated": doc_acc.chunks_deduplicated,  # type: ignore[union-attr]
         "embedding_tokens_used": doc_acc.tokens_used,  # type: ignore[union-attr]
+        "embedding_documents_skipped": doc_acc.embedding_documents_skipped,  # type: ignore[union-attr]
         "symbols_created": doc_acc.symbols_created,  # type: ignore[union-attr]
         "symbols_deleted": doc_acc.symbols_deleted,  # type: ignore[union-attr]
         "commit_sha": ctx.new_sha,
@@ -4210,6 +4246,7 @@ async def sync_web_source(
             "chunks_embedded": total_chunks_embedded,
             "chunks_deduplicated": total_chunks_deduplicated,
             "embedding_tokens_used": total_tokens_used,
+            "embedding_documents_skipped": doc_acc.embedding_documents_skipped,
             "symbols_created": total_symbols_created,
             "symbols_deleted": total_symbols_deleted,
             # Twin stats

--- a/apps/worker/tests/test_flows_async.py
+++ b/apps/worker/tests/test_flows_async.py
@@ -38,6 +38,7 @@ def _make_settings(**overrides: Any) -> SimpleNamespace:
         "joern_parse_timeout_seconds": 120,
         "default_embedding_model": "openai:text-embedding-3-small",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
         "scip_languages": "python,typescript",
         "scip_install_deps_mode": "auto",
         "scip_timeout_python": 300,

--- a/apps/worker/tests/test_flows_coverage.py
+++ b/apps/worker/tests/test_flows_coverage.py
@@ -39,6 +39,7 @@ def _make_settings(**overrides: Any) -> SimpleNamespace:
         "joern_parse_timeout_seconds": 120,
         "default_embedding_model": "openai:text-embedding-3-small",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
         "scip_languages": "python,typescript",
         "scip_install_deps_mode": "auto",
         "scip_timeout_python": 300,

--- a/apps/worker/tests/test_flows_final.py
+++ b/apps/worker/tests/test_flows_final.py
@@ -39,6 +39,7 @@ def _make_settings(**overrides: Any) -> SimpleNamespace:
         "joern_parse_timeout_seconds": 120,
         "default_embedding_model": "openai:text-embedding-3-small",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
         "scip_languages": "python,typescript",
         "scip_install_deps_mode": "auto",
         "scip_timeout_python": 300,

--- a/apps/worker/tests/test_flows_pipelines.py
+++ b/apps/worker/tests/test_flows_pipelines.py
@@ -45,6 +45,7 @@ def _make_settings(**overrides: Any) -> SimpleNamespace:
         "joern_parse_timeout_seconds": 120,
         "default_embedding_model": "openai:text-embedding-3-small",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
         "scip_languages": "python,typescript",
         "scip_install_deps_mode": "auto",
         "scip_timeout_python": 300,

--- a/apps/worker/tests/test_flows_unit.py
+++ b/apps/worker/tests/test_flows_unit.py
@@ -63,6 +63,7 @@ def _make_settings(**overrides: Any) -> SimpleNamespace:
         "joern_parse_timeout_seconds": 120,
         "default_embedding_model": "openai:text-embedding-3-small",
         "default_llm_provider": "openai",
+        "model_calls_enabled": True,
         "scip_languages": "python,typescript",
         "scip_install_deps_mode": "auto",
         "scip_timeout_python": 300,
@@ -688,6 +689,32 @@ class TestGetEmbeddingModelForCollection:
 
 
 class TestEmbedDocument:
+    async def test_skips_when_model_calls_are_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        get_collection_model = AsyncMock()
+        monkeypatch.setattr(
+            flows,
+            "get_settings",
+            lambda: _make_settings(model_calls_enabled=False),
+        )
+        monkeypatch.setattr(
+            flows,
+            "get_embedding_model_for_collection",
+            get_collection_model,
+        )
+
+        result = await flows.embed_document(str(uuid.uuid4()), str(uuid.uuid4()))
+
+        assert result == {
+            "chunks_embedded": 0,
+            "chunks_deduplicated": 0,
+            "tokens_used": 0,
+            "skipped": True,
+            "skip_reason": "model_calls_disabled",
+        }
+        get_collection_model.assert_not_awaited()
+
     async def test_uses_collection_model_when_provided(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1604,7 +1631,114 @@ class TestTaskIndexScipProject:
 # ---------------------------------------------------------------------------
 
 
+async def test_model_free_erm_skips_generic_schema_model_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_result = MagicMock()
+    mock_result.all.return_value = [
+        (
+            "git://github.com/example/repo/db/schema.sql",
+            "CREATE TABLE users (id INTEGER PRIMARY KEY);",
+        )
+    ]
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(flows, "get_session", lambda: mock_cm)
+
+    cleanup = AsyncMock(return_value={"nodes_deleted": 0, "evidence_deleted": 0})
+    monkeypatch.setattr(
+        "contextmine_core.knowledge.builder.cleanup_scoped_knowledge_nodes",
+        cleanup,
+    )
+    generic_fallback = AsyncMock(side_effect=AssertionError("model fallback must not run"))
+    monkeypatch.setattr(flows, "_extract_schema_fallback", generic_fallback)
+
+    result = await flows._kg_extract_erm(
+        uuid.uuid4(),
+        uuid.uuid4(),
+        research_llm=None,
+    )
+
+    assert result == {"tables_found": 0, "nodes_deleted": 0, "evidence_deleted": 0}
+    generic_fallback.assert_not_awaited()
+
+
 class TestBuildKnowledgeGraph:
+    async def test_model_free_mode_runs_deterministic_steps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            flows,
+            "get_settings",
+            lambda: _make_settings(model_calls_enabled=False),
+        )
+
+        def unexpected_provider(*args: Any, **kwargs: Any) -> None:
+            raise AssertionError("model provider must not be initialized")
+
+        monkeypatch.setattr(
+            "contextmine_core.research.llm.get_llm_provider",
+            unexpected_provider,
+        )
+        monkeypatch.setattr(
+            "contextmine_core.research.llm.get_research_llm_provider",
+            unexpected_provider,
+        )
+        monkeypatch.setattr(flows, "get_embedder", unexpected_provider)
+
+        mock_session = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(flows, "get_session", lambda: mock_cm)
+
+        build_stats = SimpleNamespace(file_nodes_created=7, symbol_nodes_created=13)
+        build_files = AsyncMock(return_value=build_stats)
+        cleanup = AsyncMock(return_value={"nodes_deleted": 2})
+        monkeypatch.setattr(
+            "contextmine_core.knowledge.builder.build_knowledge_graph_for_source",
+            build_files,
+        )
+        monkeypatch.setattr(
+            "contextmine_core.knowledge.builder.cleanup_orphan_nodes",
+            cleanup,
+        )
+
+        extract_erm = AsyncMock(
+            return_value={"tables_found": 3, "nodes_deleted": 1, "evidence_deleted": 0}
+        )
+        extract_surfaces = AsyncMock(
+            return_value={"kg_endpoints": 5, "kg_jobs": 2, "nodes_deleted": 0}
+        )
+        communities = AsyncMock()
+        monkeypatch.setattr(flows, "_kg_extract_erm", extract_erm)
+        monkeypatch.setattr(flows, "_kg_extract_surfaces", extract_surfaces)
+        monkeypatch.setattr(flows, "_kg_step_communities", communities)
+
+        result = await flows.build_knowledge_graph.fn(
+            source_id=str(uuid.uuid4()),
+            collection_id=str(uuid.uuid4()),
+        )
+
+        assert result["kg_mode"] == "deterministic"
+        assert result["kg_model_steps_skipped"] == [
+            "business_rules",
+            "generic_schema_extraction",
+            "semantic_entities",
+            "community_summaries",
+        ]
+        assert result["kg_file_nodes"] == 7
+        assert result["kg_symbol_nodes"] == 13
+        assert result["kg_tables"] == 3
+        assert result["kg_endpoints"] == 5
+        assert result["kg_jobs"] == 2
+        assert result["kg_nodes_deleted"] == 3
+        assert extract_erm.await_args.args[2] is None
+        communities.assert_awaited_once()
+
     async def test_raises_when_no_llm_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             flows,

--- a/apps/worker/tests/test_worker_misc.py
+++ b/apps/worker/tests/test_worker_misc.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import contextmine_core.settings as settings_module
 import pytest
+from contextmine_core.model_policy import ModelCallsDisabledError
+from contextmine_core.settings import Settings
 from contextmine_worker.chunking import (
     ChunkResult,
     chunk_document,
@@ -25,6 +28,27 @@ from contextmine_worker.telemetry import (
 )
 
 pytestmark = pytest.mark.anyio
+
+
+def test_deployment_agent_respects_model_call_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from contextmine_worker.agents import deployment
+
+    monkeypatch.setattr(
+        settings_module,
+        "_settings",
+        Settings(model_calls_enabled=False),
+    )
+
+    with (
+        patch.object(deployment, "ChatAnthropic") as chat_anthropic,
+        pytest.raises(ModelCallsDisabledError),
+    ):
+        deployment.build_agent()
+
+    chat_anthropic.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Worker telemetry decorators

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,17 +108,23 @@ helm install contextmine oci://ghcr.io/mayflower/contextmine -f my-values.yaml
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth app secret |
 | `SESSION_SECRET` | Secret for session cookies |
 | `TOKEN_ENCRYPTION_KEY` | Key for encrypting stored tokens |
-| `OPENAI_API_KEY` | OpenAI API key for embeddings |
 
 ### Optional Environment Variables
 
 | Variable | Description |
 |----------|-------------|
+| `MODEL_CALLS_ENABLED` | Enable external embedding and LLM calls (default: `true`) |
+| `OPENAI_API_KEY` | OpenAI API key for embeddings and LLM features |
 | `GEMINI_API_KEY` | Alternative to OpenAI for embeddings |
 | `ANTHROPIC_API_KEY` | For deep_research agent (uses Claude) |
 | `DEFAULT_LLM_PROVIDER` | LLM provider: `openai`, `anthropic`, or `gemini` |
 | `DEFAULT_LLM_MODEL` | Model name (e.g., `claude-haiku-4-5-20251001`) |
 | `MCP_ALLOWED_ORIGINS` | CORS origins for MCP in production |
+
+With `MODEL_CALLS_ENABLED=false`, indexing retains deterministic document,
+symbol, schema, surface, and graph-community extraction. Search and context
+retrieval fall back to full-text evidence, while model-dependent enrichment,
+research agents, and generated architecture narratives are disabled.
 
 ### Setting Up GitHub OAuth
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -33,6 +33,8 @@ MCP authentication uses GitHub OAuth. When you first connect, your MCP client wi
 #### `get_markdown`
 
 Semantic search across all indexed documentation and code. Returns synthesized context.
+When `MODEL_CALLS_ENABLED=false`, this tool automatically returns raw full-text
+evidence without embeddings or LLM synthesis, regardless of the `raw` argument.
 
 ```
 get_markdown(
@@ -52,7 +54,7 @@ get_markdown(query="how does authentication work?")
 
 #### `deep_research`
 
-Multi-step research agent for complex codebase questions. Uses an iterative approach with multiple tools to search, read code, and build answers with citations.
+Multi-step research agent for complex codebase questions. Uses an iterative approach with multiple tools to search, read code, and build answers with citations. This tool is unavailable when `MODEL_CALLS_ENABLED=false`.
 
 ```
 deep_research(
@@ -70,7 +72,7 @@ deep_research(question="explain the payment flow", budget=15)
 
 #### `graph_rag`
 
-Graph-augmented retrieval implementing Microsoft GraphRAG approach with global (community) and local (entity) context.
+Graph-augmented retrieval implementing Microsoft GraphRAG approach with global (community) and local (entity) context. In model-free mode, context retrieval uses full-text seeds and deterministic graph expansion; `answer=true` remains unavailable.
 
 ```
 graph_rag(

--- a/packages/core/contextmine_core/__init__.py
+++ b/packages/core/contextmine_core/__init__.py
@@ -30,6 +30,7 @@ from contextmine_core.embeddings import (
     parse_embedding_model_spec,
 )
 from contextmine_core.joern import JoernClient, JoernResponse, parse_joern_output
+from contextmine_core.model_policy import ModelCallsDisabledError, ensure_model_calls_enabled
 from contextmine_core.models import (
     AppKV,
     ArchitectureIntent,
@@ -136,12 +137,14 @@ __all__ = [
     "ValidationSnapshot",
     "ValidationSourceKind",
     "MetricSnapshot",
+    "ModelCallsDisabledError",
     "assemble_context",
     "assemble_context_stream",
     "close_engine",
     "compute_ssh_key_fingerprint",
     "decrypt_token",
     "encrypt_token",
+    "ensure_model_calls_enabled",
     "exchange_code_for_token",
     "generate_state",
     "get_embedder",

--- a/packages/core/contextmine_core/architecture/agent_sdk.py
+++ b/packages/core/contextmine_core/architecture/agent_sdk.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
+from contextmine_core.model_policy import ensure_model_calls_enabled
+
 from .arc42 import SECTION_TITLES
 from .claim_model import ArchitectureClaim
 from .recovery_model import RecoveredArchitectureModel
@@ -320,6 +322,7 @@ async def generate_arc42_with_claude_sdk(
     permission_mode: str = "bypassPermissions",
 ) -> tuple[Arc42Document, dict[str, Any]]:
     """Generate an arc42 document via shared ClaudeSDKClient session."""
+    ensure_model_calls_enabled()
 
     if not repo_path.exists() or not repo_path.is_dir():
         raise FileNotFoundError(f"Repository path does not exist: {repo_path}")

--- a/packages/core/contextmine_core/context.py
+++ b/packages/core/contextmine_core/context.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from enum import Enum
 
+from contextmine_core.model_policy import ensure_model_calls_enabled
 from contextmine_core.search import SearchResult, hybrid_search
 from contextmine_core.settings import get_settings
 
@@ -109,6 +110,30 @@ def extract_sources(chunks: list[SearchResult]) -> list[dict]:
             sources.append(source)
 
     return sources
+
+
+def build_retrieval_markdown(query: str, chunks: list[SearchResult]) -> str:
+    """Render retrieved evidence without synthesizing a model-generated answer."""
+    lines = [
+        f"# Retrieved Context for: {query}",
+        "",
+        "*Retrieval mode: deterministic full-text search; model calls disabled.*",
+        "",
+    ]
+    for index, chunk in enumerate(chunks, 1):
+        lines.extend(
+            [
+                f"## Result {index}: {chunk.title}",
+                f"*Source: {chunk.uri}*",
+                "",
+                chunk.content,
+                "",
+            ]
+        )
+
+    lines.append("## Sources")
+    lines.extend(f"- {source['uri']}" for source in extract_sources(chunks))
+    return "\n".join(lines)
 
 
 class LLM(ABC):
@@ -232,6 +257,7 @@ class OpenAILLM(LLM):
 
     async def generate(self, system_prompt: str, user_prompt: str, max_tokens: int) -> str:
         """Generate using OpenAI API."""
+        ensure_model_calls_enabled()
         from openai import AsyncOpenAI
 
         client = AsyncOpenAI(api_key=self.api_key)
@@ -249,6 +275,7 @@ class OpenAILLM(LLM):
         self, system_prompt: str, user_prompt: str, max_tokens: int
     ) -> AsyncIterator[str]:
         """Generate streaming response using OpenAI API."""
+        ensure_model_calls_enabled()
         from openai import AsyncOpenAI
 
         client = AsyncOpenAI(api_key=self.api_key)
@@ -277,6 +304,7 @@ class AnthropicLLM(LLM):
 
     async def generate(self, system_prompt: str, user_prompt: str, max_tokens: int) -> str:
         """Generate using Anthropic API."""
+        ensure_model_calls_enabled()
         import anthropic
 
         client = anthropic.AsyncAnthropic(api_key=self.api_key)
@@ -297,6 +325,7 @@ class AnthropicLLM(LLM):
         self, system_prompt: str, user_prompt: str, max_tokens: int
     ) -> AsyncIterator[str]:
         """Generate streaming response using Anthropic API."""
+        ensure_model_calls_enabled()
         import anthropic
 
         client = anthropic.AsyncAnthropic(api_key=self.api_key)
@@ -321,6 +350,7 @@ class GeminiLLM(LLM):
 
     async def generate(self, system_prompt: str, user_prompt: str, max_tokens: int) -> str:
         """Generate using Gemini API."""
+        ensure_model_calls_enabled()
         from google import genai
         from google.genai import types
 
@@ -339,6 +369,7 @@ class GeminiLLM(LLM):
         self, system_prompt: str, user_prompt: str, max_tokens: int
     ) -> AsyncIterator[str]:
         """Generate streaming response using Gemini API."""
+        ensure_model_calls_enabled()
         from google import genai
         from google.genai import types
 
@@ -371,6 +402,8 @@ def get_llm(
     Returns:
         LLM instance
     """
+    ensure_model_calls_enabled()
+
     if isinstance(provider, str):
         provider = LLMProvider(provider)
 
@@ -425,15 +458,16 @@ async def assemble_context(
 
     settings = get_settings()
 
-    # Get query embedding
-    try:
-        emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
-        embedder = get_embedder(emb_provider, emb_model)
-    except Exception:
-        embedder = FakeEmbedder()
+    query_embedding: list[float] | None = None
+    if settings.model_calls_enabled:
+        try:
+            emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
+            embedder = get_embedder(emb_provider, emb_model)
+        except Exception:
+            embedder = FakeEmbedder()
 
-    embed_result = await embedder.embed_batch([query])
-    query_embedding = embed_result.embeddings[0]
+        embed_result = await embedder.embed_batch([query])
+        query_embedding = embed_result.embeddings[0]
 
     # Retrieve chunks
     search_response = await hybrid_search(
@@ -452,6 +486,14 @@ async def assemble_context(
             query=query,
             chunks_used=0,
             sources=[],
+        )
+
+    if not settings.model_calls_enabled:
+        return ContextResponse(
+            markdown=build_retrieval_markdown(query, chunks),
+            query=query,
+            chunks_used=len(chunks),
+            sources=extract_sources(chunks),
         )
 
     # Build prompt
@@ -516,15 +558,16 @@ async def assemble_context_stream(
 
     settings = get_settings()
 
-    # Get query embedding
-    try:
-        emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
-        embedder = get_embedder(emb_provider, emb_model)
-    except Exception:
-        embedder = FakeEmbedder()
+    query_embedding: list[float] | None = None
+    if settings.model_calls_enabled:
+        try:
+            emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
+            embedder = get_embedder(emb_provider, emb_model)
+        except Exception:
+            embedder = FakeEmbedder()
 
-    embed_result = await embedder.embed_batch([query])
-    query_embedding = embed_result.embeddings[0]
+        embed_result = await embedder.embed_batch([query])
+        query_embedding = embed_result.embeddings[0]
 
     # Retrieve chunks
     search_response = await hybrid_search(
@@ -545,6 +588,10 @@ async def assemble_context_stream(
     # Extract sources and yield metadata first
     sources = extract_sources(chunks)
     yield StreamingContextMetadata(query=query, chunks_used=len(chunks), sources=sources)
+
+    if not settings.model_calls_enabled:
+        yield build_retrieval_markdown(query, chunks)
+        return
 
     # Build prompt and stream response
     user_prompt = build_context_prompt(query, chunks)

--- a/packages/core/contextmine_core/embeddings.py
+++ b/packages/core/contextmine_core/embeddings.py
@@ -5,9 +5,10 @@ import struct
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
+from contextmine_core.model_policy import ModelCallsDisabledError, ensure_model_calls_enabled
 from contextmine_core.models import EmbeddingProvider
 from contextmine_core.settings import get_settings
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import retry, retry_if_not_exception_type, stop_after_attempt, wait_exponential
 
 
 @dataclass
@@ -172,11 +173,13 @@ class OpenAIEmbedder(Embedder):
         return self._dimensions[self._model_name]
 
     @retry(
+        retry=retry_if_not_exception_type(ModelCallsDisabledError),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
     )
     async def embed_batch(self, texts: list[str]) -> EmbeddingResult:
         """Embed a batch of texts using OpenAI API."""
+        ensure_model_calls_enabled()
         from contextmine_core.telemetry.spans import trace_embedding_call
         from openai import AsyncOpenAI
 
@@ -238,11 +241,13 @@ class GeminiEmbedder(Embedder):
         return self._dimensions[self._model_name]
 
     @retry(
+        retry=retry_if_not_exception_type(ModelCallsDisabledError),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=1, max=10),
     )
     async def embed_batch(self, texts: list[str]) -> EmbeddingResult:
         """Embed a batch of texts using Gemini API."""
+        ensure_model_calls_enabled()
         from contextmine_core.telemetry.spans import trace_embedding_call
         from google import genai
         from google.genai import types
@@ -283,6 +288,8 @@ def get_embedder(
     Returns:
         Embedder instance
     """
+    ensure_model_calls_enabled()
+
     if isinstance(provider, str):
         provider = EmbeddingProvider(provider)
 

--- a/packages/core/contextmine_core/graphrag.py
+++ b/packages/core/contextmine_core/graphrag.py
@@ -298,13 +298,13 @@ async def graph_rag_context(
     Returns:
         ContextPack with global + local context
     """
-    from contextmine_core import get_settings
     from contextmine_core.embeddings import get_embedder, parse_embedding_model_spec
     from contextmine_core.search import (
         SearchResponse,
         get_accessible_collection_ids,
         hybrid_search,
     )
+    from contextmine_core.settings import get_settings
 
     pack = ContextPack(query=query)
 
@@ -317,18 +317,19 @@ async def graph_rag_context(
     if not collection_ids:
         return pack
 
-    # Get query embedding - REQUIRED for GraphRAG (no fake embedder fallback)
+    # Community similarity requires an embedding. In model-free mode, retain
+    # deterministic local graph expansion by seeding it from FTS results.
     settings = get_settings()
-    emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
-    embedder = get_embedder(emb_provider, emb_model)
-
-    embed_result = await embedder.embed_batch([query])
-    query_embedding = embed_result.embeddings[0]
-
-    # Step 1: Global context - Community similarity
-    communities = await _find_relevant_communities(
-        session, query_embedding, collection_ids, max_communities
-    )
+    query_embedding: list[float] | None = None
+    communities: list[CommunityContext] = []
+    if settings.model_calls_enabled:
+        emb_provider, emb_model = parse_embedding_model_spec(settings.default_embedding_model)
+        embedder = get_embedder(emb_provider, emb_model)
+        embed_result = await embedder.embed_batch([query])
+        query_embedding = embed_result.embeddings[0]
+        communities = await _find_relevant_communities(
+            session, query_embedding, collection_ids, max_communities
+        )
     pack.communities = communities
 
     # Step 2: Hybrid search for local context seeds
@@ -344,8 +345,10 @@ async def graph_rag_context(
     seed_node_ids = await _map_search_to_nodes(session, search_response, collection_ids)
 
     # Step 4: Add community member nodes as additional seeds
-    community_member_ids = await _get_community_member_nodes(
-        session, [c.community_id for c in communities], limit=10
+    community_member_ids = (
+        await _get_community_member_nodes(session, [c.community_id for c in communities], limit=10)
+        if communities
+        else []
     )
     all_seed_ids = list(set(seed_node_ids + community_member_ids))
 

--- a/packages/core/contextmine_core/model_policy.py
+++ b/packages/core/contextmine_core/model_policy.py
@@ -1,0 +1,17 @@
+"""Central policy gate for external embedding and generative-model calls."""
+
+from __future__ import annotations
+
+
+class ModelCallsDisabledError(RuntimeError):
+    """Raised when an external model call is blocked by configuration."""
+
+
+def ensure_model_calls_enabled() -> None:
+    """Fail closed before initializing or invoking an external model client."""
+    from contextmine_core.settings import get_settings
+
+    if not get_settings().model_calls_enabled:
+        raise ModelCallsDisabledError(
+            "External model calls are disabled by MODEL_CALLS_ENABLED=false"
+        )

--- a/packages/core/contextmine_core/research/llm/provider.py
+++ b/packages/core/contextmine_core/research/llm/provider.py
@@ -11,6 +11,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from contextmine_core.model_policy import ensure_model_calls_enabled
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.output_parsers import PydanticOutputParser
@@ -163,6 +164,7 @@ class LangChainProvider(LLMProvider):
         temperature: float = 0.0,
     ) -> str:
         """Generate text response with retry logic."""
+        ensure_model_calls_enabled()
         from opentelemetry import trace
         from opentelemetry.trace import Status, StatusCode
 
@@ -222,6 +224,7 @@ class LangChainProvider(LLMProvider):
         temperature: float = 0.0,
     ) -> T:
         """Generate structured output with validation and retry."""
+        ensure_model_calls_enabled()
         lc_messages = self._build_messages(system, messages)
 
         # Try using LangChain's built-in structured output first
@@ -314,6 +317,8 @@ def get_llm_provider(
     Raises:
         ValueError: If provider is not supported
     """
+    ensure_model_calls_enabled()
+
     if provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
 

--- a/packages/core/contextmine_core/search.py
+++ b/packages/core/contextmine_core/search.py
@@ -249,7 +249,7 @@ async def get_chunk_details(
 
 async def hybrid_search(
     query: str,
-    query_embedding: list[float],
+    query_embedding: list[float] | None,
     user_id: uuid.UUID | None = None,
     collection_id: uuid.UUID | None = None,
     top_k: int = 20,
@@ -260,7 +260,7 @@ async def hybrid_search(
 
     Args:
         query: The search query text
-        query_embedding: The query embedding vector
+        query_embedding: The query embedding vector, or None for full-text-only search
         user_id: Optional user ID for access control
         collection_id: Optional collection ID to filter by
         top_k: Number of results to return
@@ -295,9 +295,13 @@ async def hybrid_search(
                 total_vector_matches=0,
             )
 
-        # Perform both searches
+        # Full-text search remains available when external embeddings are disabled.
         fts_results = await search_fts(session, query, collection_ids, fts_limit)
-        vector_results = await search_vector(session, query_embedding, collection_ids, vector_limit)
+        vector_results = (
+            await search_vector(session, query_embedding, collection_ids, vector_limit)
+            if query_embedding is not None
+            else []
+        )
 
         # Compute RRF scores
         rrf_scores = compute_rrf_scores(fts_results, vector_results)

--- a/packages/core/contextmine_core/settings.py
+++ b/packages/core/contextmine_core/settings.py
@@ -64,6 +64,15 @@ class Settings(BaseSettings):
         description="Base URL for MCP OAuth callbacks. Must match where the server is accessible.",
     )
 
+    # External model policy
+    model_calls_enabled: bool = Field(
+        default=True,
+        description=(
+            "Allow external embedding and generative-model calls. When disabled, "
+            "sync uses deterministic extraction and retrieval uses full-text search only."
+        ),
+    )
+
     # Embedding providers
     openai_api_key: str | None = Field(
         default=None,

--- a/packages/core/tests/test_context.py
+++ b/packages/core/tests/test_context.py
@@ -7,7 +7,7 @@ assemble_context with mocked DB, and LLM provider selection.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from contextmine_core.context import (
@@ -17,10 +17,14 @@ from contextmine_core.context import (
     FakeLLM,
     LLMProvider,
     StreamingContextMetadata,
+    assemble_context,
+    assemble_context_stream,
     build_context_prompt,
+    build_retrieval_markdown,
     extract_sources,
     get_llm,
 )
+from contextmine_core.search import SearchResponse, SearchResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -110,6 +114,88 @@ class TestExtractSources:
     def test_empty_chunks(self) -> None:
         sources = extract_sources([])
         assert sources == []
+
+
+def _search_result() -> SearchResult:
+    return SearchResult(
+        chunk_id="chunk-1",
+        document_id="document-1",
+        source_id="source-1",
+        collection_id="collection-1",
+        content="Deterministic evidence",
+        uri="git://github.com/org/repo/src/main.py?ref=main",
+        title="main.py",
+        score=1.0,
+        fts_rank=1,
+        vector_rank=None,
+        fts_score=0.9,
+        vector_score=None,
+    )
+
+
+class TestModelFreeContext:
+    @pytest.mark.anyio
+    async def test_assemble_context_returns_fts_evidence_without_models(self) -> None:
+        settings = MagicMock(
+            model_calls_enabled=False,
+            default_embedding_model="openai:text-embedding-3-small",
+        )
+        llm = AsyncMock()
+        search = AsyncMock(
+            return_value=SearchResponse(
+                results=[_search_result()],
+                query="auth",
+                total_fts_matches=1,
+                total_vector_matches=0,
+            )
+        )
+
+        with (
+            patch("contextmine_core.context.get_settings", return_value=settings),
+            patch("contextmine_core.context.hybrid_search", search),
+            patch(
+                "contextmine_core.embeddings.get_embedder",
+                side_effect=AssertionError("embedder must not be initialized"),
+            ),
+        ):
+            response = await assemble_context(query="auth", llm=llm)
+
+        assert "Deterministic evidence" in response.markdown
+        assert "model calls disabled" in response.markdown
+        assert response.chunks_used == 1
+        assert search.await_args.kwargs["query_embedding"] is None
+        llm.generate.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_streaming_context_returns_one_deterministic_document(self) -> None:
+        settings = MagicMock(
+            model_calls_enabled=False,
+            default_embedding_model="openai:text-embedding-3-small",
+        )
+        search = AsyncMock(
+            return_value=SearchResponse(
+                results=[_search_result()],
+                query="auth",
+                total_fts_matches=1,
+                total_vector_matches=0,
+            )
+        )
+
+        with (
+            patch("contextmine_core.context.get_settings", return_value=settings),
+            patch("contextmine_core.context.hybrid_search", search),
+        ):
+            items = [item async for item in assemble_context_stream(query="auth")]
+
+        assert isinstance(items[0], StreamingContextMetadata)
+        assert len(items) == 2
+        assert "Deterministic evidence" in items[1]
+        assert search.await_args.kwargs["query_embedding"] is None
+
+    def test_retrieval_markdown_lists_unique_sources(self) -> None:
+        markdown = build_retrieval_markdown("auth", [_search_result(), _search_result()])
+
+        assert markdown.count("- git://github.com/org/repo/src/main.py?ref=main") == 1
 
 
 # ---------------------------------------------------------------------------

--- a/packages/core/tests/test_graphrag_async.py
+++ b/packages/core/tests/test_graphrag_async.py
@@ -1052,7 +1052,8 @@ class TestGraphRagContext:
             ) as mock_acl,
         ):
             mock_settings.return_value = MagicMock(
-                default_embedding_model="openai:text-embedding-3-small"
+                default_embedding_model="openai:text-embedding-3-small",
+                model_calls_enabled=True,
             )
             mock_parse.return_value = ("openai", "text-embedding-3-small")
             mock_embedder = AsyncMock()
@@ -1096,7 +1097,8 @@ class TestGraphRagContext:
             ) as mock_cit_by,
         ):
             mock_settings.return_value = MagicMock(
-                default_embedding_model="openai:text-embedding-3-small"
+                default_embedding_model="openai:text-embedding-3-small",
+                model_calls_enabled=True,
             )
             mock_parse.return_value = ("openai", "text-embedding-3-small")
             mock_embedder = AsyncMock()
@@ -1121,3 +1123,52 @@ class TestGraphRagContext:
             pack = await graph_rag_context(session, "query", collection_id=coll_id)
             assert isinstance(pack, ContextPack)
             assert len(pack.entities) == 1
+
+    @pytest.mark.anyio
+    async def test_model_free_mode_uses_fts_without_embedding(self) -> None:
+        session = _mock_session()
+        coll_id = uuid4()
+
+        with (
+            patch("contextmine_core.settings.get_settings") as mock_settings,
+            patch("contextmine_core.embeddings.parse_embedding_model_spec") as mock_parse,
+            patch("contextmine_core.embeddings.get_embedder") as mock_get_emb,
+            patch("contextmine_core.search.hybrid_search", new_callable=AsyncMock) as mock_search,
+            patch(
+                "contextmine_core.graphrag._find_relevant_communities", new_callable=AsyncMock
+            ) as mock_comms,
+            patch(
+                "contextmine_core.graphrag._map_search_to_nodes", new_callable=AsyncMock
+            ) as mock_map,
+            patch(
+                "contextmine_core.graphrag._get_community_member_nodes", new_callable=AsyncMock
+            ) as mock_members,
+            patch(
+                "contextmine_core.graphrag._expand_from_seeds", new_callable=AsyncMock
+            ) as mock_expand,
+            patch(
+                "contextmine_core.graphrag._gather_citations", new_callable=AsyncMock
+            ) as mock_cit,
+            patch(
+                "contextmine_core.graphrag._citations_by_node", new_callable=AsyncMock
+            ) as mock_cit_by,
+        ):
+            mock_settings.return_value = MagicMock(
+                default_embedding_model="openai:text-embedding-3-small",
+                model_calls_enabled=False,
+            )
+            mock_search.return_value = MagicMock(results=[])
+            mock_map.return_value = []
+            mock_expand.return_value = ([], [])
+            mock_cit.return_value = []
+            mock_cit_by.return_value = {}
+
+            pack = await graph_rag_context(session, "query", collection_id=coll_id)
+
+        assert isinstance(pack, ContextPack)
+        assert pack.communities == []
+        mock_parse.assert_not_called()
+        mock_get_emb.assert_not_called()
+        mock_comms.assert_not_awaited()
+        mock_members.assert_not_awaited()
+        assert mock_search.await_args.kwargs["query_embedding"] is None

--- a/packages/core/tests/test_model_policy.py
+++ b/packages/core/tests/test_model_policy.py
@@ -26,7 +26,7 @@ def model_calls_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_model_calls_are_enabled_by_default() -> None:
-    assert Settings(_env_file=None).model_calls_enabled is True
+    assert Settings.model_fields["model_calls_enabled"].default is True
 
 
 def test_model_factories_fail_closed(model_calls_disabled: None) -> None:

--- a/packages/core/tests/test_model_policy.py
+++ b/packages/core/tests/test_model_policy.py
@@ -1,0 +1,69 @@
+"""Tests for the fail-closed external model-call policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import contextmine_core.settings as settings_module
+import pytest
+from contextmine_core.architecture.agent_sdk import generate_arc42_with_claude_sdk
+from contextmine_core.context import LLMProvider, OpenAILLM, get_llm
+from contextmine_core.embeddings import OpenAIEmbedder, get_embedder
+from contextmine_core.model_policy import ModelCallsDisabledError
+from contextmine_core.research.llm.provider import LangChainProvider, get_llm_provider
+from contextmine_core.settings import Settings
+
+
+@pytest.fixture
+def model_calls_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        settings_module,
+        "_settings",
+        Settings(model_calls_enabled=False),
+    )
+
+
+def test_model_calls_are_enabled_by_default() -> None:
+    assert Settings(_env_file=None).model_calls_enabled is True
+
+
+def test_model_factories_fail_closed(model_calls_disabled: None) -> None:
+    with pytest.raises(ModelCallsDisabledError):
+        get_embedder("openai", api_key="test-key")
+    with pytest.raises(ModelCallsDisabledError):
+        get_llm(LLMProvider.OPENAI, api_key="test-key")
+    with pytest.raises(ModelCallsDisabledError):
+        get_llm_provider("openai", api_key="test-key")
+
+
+@pytest.mark.anyio
+async def test_direct_clients_cannot_bypass_policy(model_calls_disabled: None) -> None:
+    embedder = OpenAIEmbedder(api_key="test-key")
+    llm = OpenAILLM(api_key="test-key")
+    research_provider = LangChainProvider(
+        model=MagicMock(),
+        model_name="test-model",
+    )
+
+    with pytest.raises(ModelCallsDisabledError):
+        await embedder.embed_batch(["content"])
+    with pytest.raises(ModelCallsDisabledError):
+        await llm.generate("system", "user", 10)
+    with pytest.raises(ModelCallsDisabledError):
+        await research_provider.generate_text(system="system", messages=[])
+
+
+@pytest.mark.anyio
+async def test_agent_sdk_generation_cannot_bypass_policy(
+    model_calls_disabled: None,
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ModelCallsDisabledError):
+        await generate_arc42_with_claude_sdk(
+            collection_id=uuid4(),
+            scenario_id=uuid4(),
+            scenario_name="AS-IS",
+            repo_path=tmp_path,
+        )


### PR DESCRIPTION
## Summary

- add a global `MODEL_CALLS_ENABLED` policy that fails closed at provider factories and direct SDK invocation boundaries
- keep source sync useful without external models by skipping embeddings and generative graph enrichment while retaining deterministic document, symbol, schema, surface, and community extraction
- use full-text-only retrieval for API context, MCP `get_markdown`, and local GraphRAG context when model calls are disabled
- expose skipped embedding/model steps in sync statistics and document the operating mode

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .` — 342 files formatted
- `uvx ty check`
- targeted Core/API/Worker tests — 596 passed, 5 skipped
- focused model-free Worker tests — 4 passed
- local full Python suite — 4,956 passed, 13 skipped; the remaining 9 failures reproduce unchanged on clean `main` at `b749391`
- GitHub CI — Lint & Type Check and Bandit pass; the database-backed test job passes 4,965 tests and retains one existing `validate_github_url` baseline failure; Semgrep reports only 21 existing mutable-action-tag findings in unchanged workflow files

The mode was also exercised during a full Apache Superset sync: 9,429 documents and 57,401 chunks were indexed with zero embedding/model tokens, followed by deterministic full-text retrieval.