### PR TITLE
ci: restore deterministic validation baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: uv run ruff format --check .
 
       - name: Run ty check
-        run: uvx ty check
+        run: uv run ty check
 
   test:
     name: Test

--- a/apps/api/tests/test_final_coverage.py
+++ b/apps/api/tests/test_final_coverage.py
@@ -162,7 +162,7 @@ class TestValidateGithubUrl:
         result = validate_github_url("https://github.com/owner/repo")
         assert result["owner"] == "owner"
         assert result["repo"] == "repo"
-        assert result["branch"] == "main"
+        assert result["branch"] is None
 
     def test_valid_url_with_git(self) -> None:
         result = validate_github_url("https://github.com/owner/repo.git")


### PR DESCRIPTION
## Summary

- run `ty` from the repository lockfile instead of downloading an unpinned latest release with `uvx`
- align the duplicate GitHub URL validation test with the established `branch=None` contract, which lets the worker resolve the repository actual default branch

## Why

The current `main` baseline makes otherwise unrelated pull requests fail for two reasons: the floating type-checker version changed its diagnostics, and one duplicate test still assumes a hard-coded `main` branch despite the implementation and canonical route test intentionally using default-branch discovery.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .` — 340 files formatted
- `uv run ty check`
- focused GitHub URL validation tests — 6 passed
- both failures were reproduced independently of the feature pull requests on `main` at `b749391`