### PR TITLE
ci(web): enforce frontend validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
+  NODE_VERSION: "22"
   UV_CACHE_DIR: /tmp/.uv-cache
 
 jobs:
@@ -83,10 +84,38 @@ jobs:
           DEBUG: "true"
         run: uv run pytest -v
 
+  web:
+    name: Web Lint, Test & Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Build web application
+        run: npm run build
+
   build:
     name: Build & Push Containers
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, web]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
@@ -140,7 +169,7 @@ jobs:
   helm:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, web]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -9,7 +9,7 @@
  *
  * Since these are not exported, we replicate the logic to test it thoroughly.
  */
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 
 // --- Replicated from App.tsx ---
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -635,7 +635,7 @@ function App() {
   }, [])
 
   // Fetch dashboard stats
-  const fetchStats = async () => {
+  const fetchStats = useCallback(async () => {
     try {
       const response = await fetch('/api/stats')
       if (response.ok) {
@@ -647,14 +647,17 @@ function App() {
     } catch {
       // Silently fail - stats are optional
     }
-  }
+  }, [])
 
   // Load stats when switching to Dashboard page
   useEffect(() => {
     if (currentPage === 'dashboard' && user) {
-      fetchStats()
+      const timeoutId = globalThis.setTimeout(() => {
+        void fetchStats()
+      }, 0)
+      return () => globalThis.clearTimeout(timeoutId)
     }
-  }, [currentPage, user])
+  }, [currentPage, fetchStats, user])
 
   const handleLogin = () => {
     globalThis.location.href = '/api/auth/login'
@@ -666,7 +669,7 @@ function App() {
   }
 
   // Fetch collections
-  const fetchCollections = async () => {
+  const fetchCollections = useCallback(async () => {
     setCollectionsLoading(true)
     try {
       const response = await fetch('/api/collections', { credentials: 'include' })
@@ -679,14 +682,17 @@ function App() {
     } finally {
       setCollectionsLoading(false)
     }
-  }
+  }, [])
 
   // Load collections when switching to Collections page
   useEffect(() => {
     if (currentPage === 'collections' && user) {
-      fetchCollections()
+      const timeoutId = globalThis.setTimeout(() => {
+        void fetchCollections()
+      }, 0)
+      return () => globalThis.clearTimeout(timeoutId)
     }
-  }, [currentPage, user])
+  }, [currentPage, fetchCollections, user])
 
   // Fetch collection members, invites, and sources
   const fetchCollectionDetails = async (collection: Collection) => {
@@ -1154,7 +1160,7 @@ function App() {
   }
 
   // Fetch runs for a source
-  const fetchRuns = async (source: Source) => {
+  const fetchRuns = useCallback(async (source: Source) => {
     setRunsLoading(true)
     try {
       const response = await fetch(`/api/runs?source_id=${source.id}`, { credentials: 'include' })
@@ -1167,10 +1173,10 @@ function App() {
     } finally {
       setRunsLoading(false)
     }
-  }
+  }, [])
 
   // Fetch Prefect flow runs
-  const fetchPrefectFlowRuns = async () => {
+  const fetchPrefectFlowRuns = useCallback(async () => {
     try {
       const response = await fetch('/api/prefect/flow-runs', { credentials: 'include' })
       if (response.ok) {
@@ -1180,34 +1186,38 @@ function App() {
     } catch {
       // Error fetching Prefect flow runs
     }
-  }
+  }, [])
 
   // Load collections and Prefect runs when switching to runs page
   useEffect(() => {
     if (currentPage === 'runs' && user) {
-      fetchCollections()
-      fetchPrefectFlowRuns()
-      // Refresh selected source's runs if one is selected
-      if (selectedRunSource) {
-        fetchRuns(selectedRunSource)
-      }
-      // Poll for active runs and selected source runs every 5 seconds
-      const interval = setInterval(() => {
-        fetchPrefectFlowRuns()
+      const refreshRunsPage = () => {
+        void fetchCollections()
+        void fetchPrefectFlowRuns()
         if (selectedRunSource) {
-          fetchRuns(selectedRunSource)
+          void fetchRuns(selectedRunSource)
         }
-      }, 5000)
-      return () => clearInterval(interval)
+      }
+
+      const timeoutId = globalThis.setTimeout(refreshRunsPage, 0)
+      // Poll for active runs and selected source runs every 5 seconds
+      const interval = globalThis.setInterval(refreshRunsPage, 5000)
+      return () => {
+        globalThis.clearTimeout(timeoutId)
+        globalThis.clearInterval(interval)
+      }
     }
-  }, [currentPage, user, selectedRunSource])
+  }, [currentPage, fetchCollections, fetchPrefectFlowRuns, fetchRuns, selectedRunSource, user])
 
   // Load collections for dashboard (needed for query form)
   useEffect(() => {
     if ((currentPage === 'dashboard' || currentPage === 'cockpit') && user) {
-      fetchCollections()
+      const timeoutId = globalThis.setTimeout(() => {
+        void fetchCollections()
+      }, 0)
+      return () => globalThis.clearTimeout(timeoutId)
     }
-  }, [currentPage, user])
+  }, [currentPage, fetchCollections, user])
 
   // Handle query submission with SSE streaming
   const handleQuery = async (e: React.FormEvent) => {

--- a/apps/web/src/cockpit/CockpitPage.tsx
+++ b/apps/web/src/cockpit/CockpitPage.tsx
@@ -218,9 +218,10 @@ export default function CockpitPage({
     setToast({ id: Date.now(), kind, message })
   }, [])
 
-  useEffect(() => {
-    setOverlayData((prev) => ({ ...prev, mode: overlayMode }))
-  }, [overlayMode])
+  const activeOverlayData = useMemo<OverlayState>(
+    () => ({ ...overlayData, mode: overlayMode }),
+    [overlayData, overlayMode],
+  )
 
   const graphFilters = useMemo(
     () => ({
@@ -371,6 +372,50 @@ export default function CockpitPage({
     onScenarioAutoSelect: setScenarioId,
     onViewError,
   })
+
+  const openCollections = useCallback(() => {
+    if (onOpenCollections) {
+      onOpenCollections()
+      return
+    }
+    globalThis.location.href = '/?page=collections'
+  }, [onOpenCollections])
+
+  const openRuns = useCallback(() => {
+    if (onOpenRuns) {
+      onOpenRuns()
+      return
+    }
+    globalThis.location.href = '/?page=runs'
+  }, [onOpenRuns])
+
+  const trackFilterChange = useCallback(() => {
+    getFaro()?.api.pushEvent('cockpit_filter_changed', {
+      query: graphQuery,
+      include: includeKinds.join(','),
+      exclude: excludeKinds.join(','),
+      edge_kinds: edgeKinds.join(','),
+    })
+  }, [edgeKinds, excludeKinds, graphQuery, includeKinds])
+
+  const handleLoadOverlayFile = useCallback(async (file: File) => {
+    try {
+      const parsed = await parseOverlayFile(file)
+      setOverlayData((prev) => ({
+        ...prev,
+        ...parsed,
+        mode: overlayMode,
+        loadedAt: new Date().toISOString(),
+      }))
+      pushToast('success', `Loaded overlay file: ${file.name}`)
+      getFaro()?.api.pushEvent('cockpit_overlay_enabled', {
+        mode: overlayMode,
+        file: file.name,
+      })
+    } catch (error) {
+      pushToast('error', error instanceof Error ? error.message : 'Could not parse overlay file.')
+    }
+  }, [overlayMode, pushToast])
 
   const selectedScenario = useMemo(
     () => scenarios.find((scenario) => scenario.id === selection.scenarioId) ?? null,
@@ -562,9 +607,9 @@ export default function CockpitPage({
     neighborhood,
     neighborhoodState,
     neighborhoodError,
-    overlay: overlayData,
+    overlay: activeOverlayData,
     onClearSelection: () => setSelectedNodeId(''),
-  }), [resolvedNodeId, graph, neighborhood, neighborhoodState, neighborhoodError, overlayData, setSelectedNodeId])
+  }), [resolvedNodeId, graph, neighborhood, neighborhoodState, neighborhoodError, activeOverlayData, setSelectedNodeId])
 
   useEffect(() => {
     const isGraphView =
@@ -585,8 +630,11 @@ export default function CockpitPage({
       return
     }
 
-    setLayer('code_controlflow')
-    pushToast('info', 'No nodes in this layer. Switched to Code / Controlflow.')
+    const timeoutId = globalThis.setTimeout(() => {
+      setLayer('code_controlflow')
+      pushToast('info', 'No nodes in this layer. Switched to Code / Controlflow.')
+    }, 0)
+    return () => globalThis.clearTimeout(timeoutId)
   }, [activeState, graph.nodes.length, graph.total_nodes, pushToast, selection.layer, selection.view, setLayer])
 
   useEffect(() => {
@@ -652,50 +700,6 @@ export default function CockpitPage({
     pushToast('info', 'Downloaded export artifact.')
   }
 
-  function openCollections() {
-    if (onOpenCollections) {
-      onOpenCollections()
-      return
-    }
-    globalThis.location.href = '/?page=collections'
-  }
-
-  function openRuns() {
-    if (onOpenRuns) {
-      onOpenRuns()
-      return
-    }
-    globalThis.location.href = '/?page=runs'
-  }
-
-  function trackFilterChange() {
-    getFaro()?.api.pushEvent('cockpit_filter_changed', {
-      query: graphQuery,
-      include: includeKinds.join(','),
-      exclude: excludeKinds.join(','),
-      edge_kinds: edgeKinds.join(','),
-    })
-  }
-
-  async function handleLoadOverlayFile(file: File) {
-    try {
-      const parsed = await parseOverlayFile(file)
-      setOverlayData((prev) => ({
-        ...prev,
-        ...parsed,
-        mode: overlayMode,
-        loadedAt: new Date().toISOString(),
-      }))
-      pushToast('success', `Loaded overlay file: ${file.name}`)
-      getFaro()?.api.pushEvent('cockpit_overlay_enabled', {
-        mode: overlayMode,
-        file: file.name,
-      })
-    } catch (error) {
-      pushToast('error', error instanceof Error ? error.message : 'Could not parse overlay file.')
-    }
-  }
-
   const handleSelectNodeId = (nodeId: string) => {
     setSelectedNodeId(nodeId)
     getFaro()?.api.pushEvent('cockpit_node_selected', {
@@ -730,7 +734,7 @@ export default function CockpitPage({
               density={topologyDensity}
               layoutEngine={topologyLayoutEngine}
               elkEnabled={cockpitFlags.elkLayout}
-              overlay={overlayData}
+              overlay={activeOverlayData}
               selectedNodeId={resolvedNodeId}
               onDensityChange={setTopologyDensity}
               onLayoutEngineChange={setTopologyLayoutEngine}
@@ -757,7 +761,7 @@ export default function CockpitPage({
               layer={selection.layer}
               density={deepDiveDensity}
               mode={deepDiveMode}
-              overlay={overlayData}
+              overlay={activeOverlayData}
               selectedNodeId={resolvedNodeId}
               onModeChange={setDeepDiveMode}
               onDensityChange={setDeepDiveDensity}
@@ -949,7 +953,7 @@ export default function CockpitPage({
                 density={topologyDensity}
                 layoutEngine={topologyLayoutEngine}
                 elkEnabled={cockpitFlags.elkLayout}
-                overlay={overlayData}
+                overlay={activeOverlayData}
                 selectedNodeId={resolvedNodeId}
                 onDensityChange={setTopologyDensity}
                 onLayoutEngineChange={setTopologyLayoutEngine}

--- a/apps/web/src/cockpit/hooks/useCockpitData.ts
+++ b/apps/web/src/cockpit/hooks/useCockpitData.ts
@@ -1109,7 +1109,8 @@ export function useCockpitData({
   }, [parseApiErrorMessage, refreshActiveView, selection.collectionId])
 
   const regenerateArc42 = useCallback(async () => {
-    const { collectionId, scenarioId } = selection
+    const collectionId = selection.collectionId
+    const scenarioId = selection.scenarioId
     if (!collectionId || !scenarioId) {
       setArchitectureActions((prev) => ({
         ...prev,

--- a/apps/web/src/cockpit/views/DeepDiveView.tsx
+++ b/apps/web/src/cockpit/views/DeepDiveView.tsx
@@ -48,14 +48,8 @@ export default function DeepDiveView({
 }: Readonly<DeepDiveViewProps>) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const graphRef = useRef<Core | null>(null)
-  const [showLabels, setShowLabels] = useState(true)
-  const [labelsPinned, setLabelsPinned] = useState(false)
-
-  useEffect(() => {
-    if (density > 5000 && !labelsPinned) {
-      setShowLabels(false)
-    }
-  }, [density, labelsPinned])
+  const [showLabelsOverride, setShowLabelsOverride] = useState<boolean | null>(null)
+  const showLabels = showLabelsOverride ?? density <= 5000
 
   useEffect(() => {
     if (!containerRef.current || state === 'loading' || graph.nodes.length === 0) {
@@ -237,8 +231,7 @@ export default function DeepDiveView({
           type="button"
           className="secondary"
           onClick={() => {
-            setLabelsPinned(true)
-            setShowLabels((prev) => !prev)
+            setShowLabelsOverride((prev) => !(prev ?? density <= 5000))
           }}
         >
           {showLabels ? 'Hide labels' : 'Show labels'}

--- a/apps/web/src/cockpit/views/ExportsView.test.tsx
+++ b/apps/web/src/cockpit/views/ExportsView.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import ExportsView from './ExportsView'

--- a/apps/web/src/cockpit/views/GraphRagView.tsx
+++ b/apps/web/src/cockpit/views/GraphRagView.tsx
@@ -364,12 +364,7 @@ export default function GraphRagView({
   const [focusedProcessId, setFocusedProcessId] = useState('')
   const [focusedProcessNodeIds, setFocusedProcessNodeIds] = useState<Set<string>>(new Set())
   const [modalOpen, setModalOpen] = useState(false)
-
-  useEffect(() => {
-    if (!pathFrom && selectedNodeId) {
-      setPathFrom(selectedNodeId)
-    }
-  }, [pathFrom, selectedNodeId])
+  const resolvedPathFrom = pathFrom || selectedNodeId
 
   const communityColorById = useMemo(() => {
     const map = new Map<string, string>()
@@ -758,7 +753,7 @@ export default function GraphRagView({
         <div className="cockpit2-graph-toolbar">
           <label>
             From{' '}
-            <input value={pathFrom} onChange={(event) => setPathFrom(event.target.value)} />
+            <input value={resolvedPathFrom} onChange={(event) => setPathFrom(event.target.value)} />
           </label>
           <label>
             To{' '}
@@ -774,7 +769,7 @@ export default function GraphRagView({
               onChange={(event) => setPathHops(Math.max(1, Math.min(20, Number(event.target.value) || 1)))}
             />
           </label>
-          <button type="button" onClick={() => onTracePath(pathFrom, pathTo, pathHops)}>
+          <button type="button" onClick={() => onTracePath(resolvedPathFrom, pathTo, pathHops)}>
             {pathState === 'loading' ? 'Tracing…' : 'Trace'}
           </button>
         </div>

--- a/apps/web/src/cockpit/views/SemanticMapView.tsx
+++ b/apps/web/src/cockpit/views/SemanticMapView.tsx
@@ -165,7 +165,7 @@ export default function SemanticMapView({
   onSelectNodeId,
   onRetry,
 }: Readonly<SemanticMapViewProps>) {
-  const points = payload?.points || []
+  const points = useMemo(() => payload?.points || [], [payload])
 
   const diffItems = useMemo(() => {
     if (!payload || !comparisonPayload) {

--- a/apps/web/src/cockpit/views/TopologyView.test.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { OverlayState, TwinGraphResponse } from '../types'
 

--- a/apps/web/src/cockpit/views/TopologyView.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.tsx
@@ -193,33 +193,36 @@ export default function TopologyView({
   }
 
   useEffect(() => {
-    if (graph.nodes.length === 0) {
-      setLayoutPositions({})
-      setLayoutStatus('idle')
-      return
-    }
-
-    const coarse = runGridLayout(graph.nodes.map((node) => ({ id: node.id })), columns)
-    setLayoutPositions(coarse)
-    setLayoutStatus(preferredEngine === 'grid' ? 'refined' : 'coarse')
-    if (preferredEngine === 'grid') {
-      return
-    }
-
     const cancelRef = { current: false }
-    applyElkLayout({
-      nodes: graph.nodes.map((node) => ({ id: node.id })),
-      edges: graph.edges.map((edge) => ({ source: edge.source_node_id, target: edge.target_node_id })),
-      engine: preferredEngine,
-      columns,
-      cancelled: cancelRef,
-      startedAt: performance.now(),
-      onPositions: setLayoutPositions,
-      onCompleted: onLayoutCompleted,
-      onFinish: () => setLayoutStatus('refined'),
-    })
+    const timeoutId = globalThis.setTimeout(() => {
+      if (graph.nodes.length === 0) {
+        setLayoutPositions({})
+        setLayoutStatus('idle')
+        return
+      }
+
+      const coarse = runGridLayout(graph.nodes.map((node) => ({ id: node.id })), columns)
+      setLayoutPositions(coarse)
+      setLayoutStatus(preferredEngine === 'grid' ? 'refined' : 'coarse')
+      if (preferredEngine === 'grid') {
+        return
+      }
+
+      void applyElkLayout({
+        nodes: graph.nodes.map((node) => ({ id: node.id })),
+        edges: graph.edges.map((edge) => ({ source: edge.source_node_id, target: edge.target_node_id })),
+        engine: preferredEngine,
+        columns,
+        cancelled: cancelRef,
+        startedAt: performance.now(),
+        onPositions: setLayoutPositions,
+        onCompleted: onLayoutCompleted,
+        onFinish: () => setLayoutStatus('refined'),
+      })
+    }, 0)
     return () => {
       cancelRef.current = true
+      globalThis.clearTimeout(timeoutId)
     }
   }, [graph.edges, graph.nodes, columns, preferredEngine, onLayoutCompleted])
 


### PR DESCRIPTION
## Summary

- clear the existing web ESLint baseline of 12 errors and 7 warnings without disabling rules
- replace synchronous effect-driven state updates with derived state, stable callbacks, and deferred effect work
- fail the standard web lint command on warnings to keep the baseline clean
- add a blocking Node.js 22 CI job that installs locked dependencies, runs ESLint, executes the full Vitest suite, and builds the production bundle
- require web validation before container and Helm publishing jobs can run on `main`

## Why

The existing `Lint & Type Check` job validates the Python codebase only. As a result, pull requests could remain green while the complete web ESLint command failed locally, and neither web tests nor the production build were blocking pull-request checks.

## Verification

- `npm run lint` — zero errors and zero warnings
- `npm run test` — 33 test files and 473 tests passed
- `npm run build` — TypeScript and Vite production build passed
- `git diff --check`

The production build retains its existing non-blocking large-chunk warnings.
