### PR TITLE
Add a dependency upgrade baseline and model-free system gate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.venv
+**/.git
+**/.venv
+**/node_modules
+**/dist
+**/coverage
+**/playwright-report
+**/target
+**/test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,10 +112,41 @@ jobs:
       - name: Build web application
         run: npm run build
 
+  rust:
+    name: Rust Format, Clippy & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust/spider_md
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Rust 1.88 toolchain
+        run: rustup toolchain install 1.88.0 --profile minimal --component clippy,rustfmt
+
+      - name: Check formatting
+        run: cargo +1.88.0 fmt --check
+
+      - name: Run Clippy
+        run: cargo +1.88.0 clippy --locked --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo +1.88.0 test --locked --all-targets --all-features
+
+  model-free-system-smoke:
+    name: Model-free System & Live Web Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Run pinned repository sync gate
+        run: ./scripts/smoke/model-free-system.sh
+
   build:
     name: Build & Push Containers
     runs-on: ubuntu-latest
-    needs: [lint, test, web]
+    needs: [lint, test, web, rust, model-free-system-smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
@@ -169,7 +200,7 @@ jobs:
   helm:
     name: Publish Helm Chart
     runs-on: ubuntu-latest
-    needs: [lint, test, web]
+    needs: [build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   PYTHON_VERSION: "3.12"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     # Run weekly on Sundays at midnight
     - cron: '0 0 * * 0'

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ htmlcov/
 
 # Build artifacts
 *.log
+target/
 
 # Local tooling caches
 .playwright-cli/

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -34,8 +34,9 @@ COPY packages/ packages/
 COPY apps/api/ apps/api/
 COPY apps/worker/pyproject.toml apps/worker/
 
-# Sync dependencies (includes multilspy + jedi-language-server for LSP support)
-RUN uv sync --frozen --no-dev
+# Sync the API package and its workspace dependencies during the image build.
+# The container must not resolve or install packages when it starts.
+RUN uv sync --frozen --no-dev --package contextmine-api
 
 # Copy built frontend from stage 1
 COPY --from=frontend-builder /app/dist /app/static

--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -4,9 +4,9 @@ set -e
 # Run database migrations
 echo "Running database migrations..."
 cd /app/packages/core
-uv run alembic upgrade head
+/app/.venv/bin/alembic upgrade head
 
 # Start the API server
 echo "Starting API server..."
 cd /app/apps/api
-exec uv run uvicorn app.main:app --host 0.0.0.0 --port 8000
+exec /app/.venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 8000

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -8,7 +8,6 @@ dependencies = [
     "uvicorn[standard]>=0.49.0",
     "fastmcp>=3.4.2",
     "contextmine-core",
-    "contextmine-worker",
     "itsdangerous>=2.2.0",
     "httpx>=0.28.1",
     "slowapi>=0.1.10",

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+coverage
+playwright-report
+test-results
+.npm-cache

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,19 +2,21 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+# Create the runtime user before dependency installation so the image does not
+# need to recursively chown node_modules after every source change.
+RUN adduser --disabled-password --gecos "" appuser && \
+    chown appuser:appuser /app
+
 # Copy package files
-COPY package*.json ./
+COPY --chown=appuser:appuser package*.json ./
+
+USER appuser
 
 # Install dependencies
 RUN npm ci
 
 # Copy source files
-COPY . .
-
-# Create non-root user and fix ownership
-RUN adduser --disabled-password --gecos "" appuser && \
-    chown -R appuser:appuser /app
-USER appuser
+COPY --chown=appuser:appuser . .
 
 # Expose port
 EXPOSE 5173

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -92,8 +92,9 @@ COPY packages/ packages/
 COPY apps/worker/ apps/worker/
 COPY apps/api/pyproject.toml apps/api/
 
-# Sync dependencies, create non-root user and data/cache directories
-RUN uv sync --frozen --no-dev && \
+# Sync the worker package and its workspace dependencies during the image build.
+# The container must not resolve or install packages when it starts.
+RUN uv sync --frozen --no-dev --package contextmine-worker && \
     useradd --create-home --shell /bin/bash appuser && \
     mkdir -p /data/repos \
       /home/appuser/.npm \
@@ -115,5 +116,5 @@ USER appuser
 # Set working directory to worker
 WORKDIR /app/apps/worker
 
-# Run the worker
-CMD ["uv", "run", "python", "-m", "contextmine_worker.main"]
+# Run from the environment materialized during the image build.
+CMD ["/app/.venv/bin/python", "-m", "contextmine_worker.main"]

--- a/docs/development.md
+++ b/docs/development.md
@@ -121,6 +121,19 @@ uv run pytest packages/core/tests/test_metrics_pipeline.py -v
 DEBUG=true uv run pytest apps/api/tests/test_sources.py apps/api/tests/test_twin_views.py -v
 ```
 
+For dependency and container changes, run the larger model-free system gate:
+
+```bash
+./scripts/smoke/model-free-system.sh
+```
+
+It requires Docker and network access to fetch an exact, pinned public fixture
+commit. It starts no host-facing ports and does not require model API keys. A
+pinned Chromium/Playwright runner checks the live web container, its static
+assets, and the web-to-API proxy before the repository sync starts. See the
+[dependency and upgrade inventory](diataxis/reference/dependency_inventory.md)
+for the full gate contract and upgrade grouping rules.
+
 ## Code Quality
 
 ```bash

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -1,0 +1,171 @@
+# Dependency and Upgrade Inventory
+
+This document is the baseline for dependency maintenance. It records the
+dependency surfaces that must move together, the checks that protect them, and
+the commands used to refresh the snapshot. It is not a request to upgrade every
+package in one change.
+
+Snapshot date: **2026-08-31**  
+Repository baseline: **6832263b7911c536958facaf99e0d1e9ecbf560b**
+
+## Inventory Summary
+
+| Surface | Manifest and lock | Current size | Runtime role |
+| --- | --- | ---: | --- |
+| Python workspace | `pyproject.toml`, three workspace `pyproject.toml` files, `uv.lock` | 230 locked packages; 29 core, 8 API, 11 worker, and 9 development declarations | API, MCP, sync worker, analysis, search, graph, telemetry |
+| Web application | `apps/web/package.json`, `apps/web/package-lock.json` | 9 runtime and 19 development declarations; 481 lock entries | React cockpit, diagrams, observability |
+| Rust crawler | `rust/spider_md/Cargo.toml`, `rust/spider_md/Cargo.lock` | 8 direct declarations; 357 locked packages | Deterministic website crawling binary embedded in the worker image |
+| Runtime images | Dockerfiles, Compose files, Helm values | API, worker, web, PostgreSQL/pg4ai, Prefect, CodeCharta, OpenTelemetry | Build and deployment compatibility |
+| CI actions and tools | `.github/workflows/*.yml`, `.pre-commit-config.yaml` | SHA-pinned GitHub Actions plus scanner/tool versions | Verification and delivery |
+
+The Python requirements use lower bounds while `uv.lock` supplies the exact
+resolved environment. This makes the lockfile essential: a fresh unlocked
+resolution may cross major-version boundaries even when a manifest was not
+edited.
+
+## Component Ownership
+
+| Component | Main dependencies | Compatibility boundary |
+| --- | --- | --- |
+| Shared persistence and configuration | Pydantic, Pydantic Settings, SQLAlchemy, asyncpg, Alembic, pgvector, cryptography | API and worker must use the same core package and database schema. Database-driver and migration changes need a fresh-database migration plus real PostgreSQL tests. |
+| API and MCP | FastAPI, FastMCP, Uvicorn, SlowAPI, Prometheus instrumentation | Upgrade FastAPI/Starlette/Pydantic together only after checking route, lifespan, middleware, MCP discovery, and container startup. |
+| Sync orchestration | Prefect, GitPython, Tenacity | The Prefect Python client and Prefect server image are one upgrade unit. Test a real submitted flow, not imports alone. |
+| Model integrations | OpenAI, Anthropic, Google Gen AI, LangChain Core, LangChain provider packages, LangGraph | Provider SDK majors and the LangChain/LangGraph family are high-risk. Model-free indexing must remain green before any provider-specific tests are considered. |
+| Code intelligence | protobuf, tree-sitter-language-pack, Lizard, SCIP CLIs installed by the worker image | Validate Python and TypeScript/JavaScript project detection, index creation, relation coverage, parsing, and persisted symbols. |
+| Knowledge graph and Twin | igraph, leidenalg, SQLAlchemy, pg4ai with Apache AGE and pgvector | Exercise deterministic knowledge-graph and Twin materialization against the production database image. |
+| Web cockpit | React, React Flow, Cytoscape, ELK, Mermaid, Grafana Faro | Run lint, component tests, TypeScript build, and API image build because the API image embeds the web bundle. |
+| Crawler | Rust `spider`, Tokio, serde, URL and hashing crates | Build the worker image and run Rust formatting, Clippy, and tests when the crawler lock or toolchain changes. |
+| Telemetry | OpenTelemetry API/SDK/exporter/instrumentation family and Grafana Faro | Upgrade each telemetry family as a synchronized set; verify disabled and enabled startup modes. |
+| Deployment | Python/Node/Rust base images, uv image, pg4ai, Prefect, CodeCharta, OTel collector, Helm | Floating tags are not reproducible. Move them to reviewed version or digest pins in dedicated changes, with container and Helm checks. |
+
+### DeepAgents
+
+`deepagents` is neither declared nor imported. ContextMine currently implements
+its research agent with its own LangChain/LangGraph-based code. Adding
+DeepAgents would therefore be an architecture and behavior change, not a
+dependency update, and should be evaluated separately.
+
+## Upgrade Snapshot
+
+A read-only refresh on the snapshot date found a broad pending set:
+
+- A full Python resolution would change roughly one hundred transitive entries
+  and increase the lock from 230 to 232 packages. Direct major boundaries
+  include Anthropic `0.112.0 -> 1.2.0`, OpenAI `2.44.0 -> 3.6.0`,
+  cryptography `49.0.0 -> 50.0.1`, protobuf `6.33.6 -> 7.36.0`, and pgvector
+  `0.4.2 -> 0.5.0`. LangChain provider packages, LangChain Core, LangGraph,
+  Prefect, FastAPI, FastMCP, Uvicorn, tree-sitter-language-pack, and the
+  OpenTelemetry family also have newer compatible resolutions.
+- The web runtime has compatible updates for the Grafana Faro family,
+  Cytoscape, Mermaid, React, and React DOM. ELK moves from `0.11.1` to `0.12.0`;
+  because it is pre-1.0, treat that as a potentially breaking change. Separate
+  tooling majors are available for ESLint 10, TypeScript 7, jsdom 30, and
+  Testing Library jest-dom 7.
+- `npm audit` reports seven fixable findings in the current lock: two moderate
+  and five high. Mermaid is the only direct affected package; its current
+  `11.15.0` declaration resolves below the fixed `11.16.1` boundary. The other
+  findings are transitive `brace-expansion`, `dompurify`, `js-yaml`, `nanoid`,
+  `postcss`, and `undici` versions. A non-major web lock refresh, including
+  Mermaid, is therefore the first security-priority upgrade slice.
+- `cargo update --dry-run` proposes 121 compatible lock changes, including
+  `spider 2.52.4 -> 2.53.6`. This is a lock refresh, not evidence that a future
+  direct major is safe.
+- Compose and the default Helm values still contain floating `latest` tags for
+  operational images. Docker base images and the copied uv binary are also tag
+  based. The worker additionally fetches the Coursier launcher from `master`,
+  the Composer installer dynamically, and scip-php from `dev-main`; the other
+  SCIP versions are build arguments with defaults. These are part of the
+  dependency inventory even though language package bots do not cover them
+  reliably.
+
+Do not combine these sets into one upgrade. The counts are a triage signal, not
+a target change list.
+
+## Required Upgrade Gate
+
+The normal CI checks remain required:
+
+1. Ruff lint and formatting plus `ty` type checking.
+2. The complete PostgreSQL-backed Python test suite.
+3. Web ESLint, Vitest, and production build.
+4. Rust 1.88 formatting, strict Clippy, and all crawler tests.
+5. Security workflows and the relevant container/Helm build checks. Helm
+   publication waits for the complete image-build dependency chain.
+
+Dependency changes additionally run:
+
+```bash
+./scripts/smoke/model-free-system.sh
+```
+
+The system gate deliberately takes longer than a unit smoke test. It:
+
+- creates a fresh pg4ai database and applies every Alembic migration;
+- starts a real Prefect server and builds the shipped API, web, and worker
+  images;
+- uses pinned Chromium/Playwright to verify the live login surface, static
+  assets, and the web-to-API health proxy;
+- fetches `fastapi/full-stack-fastapi-template` at the immutable commit
+  `486f054cc8d1aead59ec96cc0a16933d06c10e0d`;
+- refuses to install the fixture's dependencies;
+- runs the real GitHub-source sync flow with `MODEL_CALLS_ENABLED=false` and
+  fails if an embedding or LLM provider is initialized;
+- requires strict Python and TypeScript/JavaScript SCIP project and relation
+  coverage plus strict structural metrics;
+- verifies persisted documents, chunks, symbols, knowledge nodes, Twin nodes,
+  known fixture paths, and full-text-only retrieval;
+- compares deterministic extraction and persistence counts to an explicit
+  baseline (210 documents, 691 chunks, 553 symbols, 4 SCIP projects, 5,998
+  SCIP relations, 4,665 knowledge nodes, and 4,621 active Twin nodes); a
+  deliberate parser behavior change must update these expectations visibly;
+- performs a second sync and requires it to be a no-op with unchanged persisted
+  counts; and
+- uses no host ports and removes its temporary repository, containers, network,
+  and volumes after the run.
+
+Joern is advisory in this gate, so this test does not qualify Joern/CPG changes.
+Authenticated browser workflows, web crawling, and model-provider behavior also
+need their own targeted checks when those surfaces change.
+
+## Refresh Commands
+
+These commands inspect available updates without modifying a lockfile:
+
+```bash
+uv lock --upgrade --dry-run
+
+cd apps/web
+npm outdated --long
+cd ../..
+
+cd rust/spider_md
+cargo update --dry-run
+cd ../..
+```
+
+Also review image tags and action references:
+
+```bash
+rg -n 'uses:|image:|FROM ' .github apps scripts docker-compose.yml deploy/helm
+```
+
+Record the date and baseline commit whenever the snapshot is refreshed.
+
+## Upgrade Slicing
+
+Use small, independently revertible changes in this order:
+
+1. Establish and keep this baseline gate green.
+2. Apply patch/minor lock refreshes within one ecosystem, starting with
+   low-coupling tooling and libraries.
+3. Upgrade synchronized families in separate changes: OpenTelemetry;
+   LangChain/LangGraph provider stack; Prefect client/server; database stack;
+   FastAPI/FastMCP; and web runtime/tooling.
+4. Handle each major version in its own change with release-note review and a
+   targeted regression test for the affected boundary.
+5. Pin and update runtime images deliberately, including database capability
+   checks and Helm/container startup checks.
+
+Dependabot or Renovate can create the routine proposals after these groups and
+required checks are defined. Automation is an input to this process; it does
+not replace compatibility grouping, release-note review, or the system gate.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
           - Extracted Views QA Checklist: extracted_views_qa_checklist.md
       - Reference:
           - Cockpit Contracts: diataxis/reference/cockpit_contracts.md
+          - Dependency and Upgrade Inventory: diataxis/reference/dependency_inventory.md
       - Explanation:
           - Strict Metrics Pipeline: diataxis/explanation/strict_metrics_pipeline.md
   - MCP Interface: mcp.md

--- a/packages/core/contextmine_core/analyzer/extractors/alembic.py
+++ b/packages/core/contextmine_core/analyzer/extractors/alembic.py
@@ -27,6 +27,7 @@ class ColumnDef:
     nullable: bool = True
     primary_key: bool = False
     foreign_key: str | None = None  # "table.column" format
+    description: str | None = None
 
 
 @dataclass
@@ -36,6 +37,7 @@ class TableDef:
     name: str
     columns: list[ColumnDef] = field(default_factory=list)
     primary_keys: list[str] = field(default_factory=list)
+    description: str | None = None
 
 
 @dataclass

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "lizard>=1.23.0",
     # Tree-sitter for AST-based analysis (rule extraction, outline)
     "tree-sitter-language-pack>=1.10.9",
+    # Deterministic community detection for the knowledge graph
+    "igraph>=1.0.0",
+    "leidenalg>=0.12.0",
     # OpenTelemetry (optional - only imports when OTEL_ENABLED=true)
     "opentelemetry-sdk>=1.43.0",
     "opentelemetry-api>=1.43.0",

--- a/packages/core/tests/test_erm_extractor.py
+++ b/packages/core/tests/test_erm_extractor.py
@@ -160,10 +160,12 @@ def upgrade():
         extractor.add_alembic_extraction(extract_from_alembic("002.py", migration2))
 
         assert "users" in extractor.schema.tables
+        assert extractor.schema.tables["users"].description is None
         cols = {c.name: c for c in extractor.schema.tables["users"].columns}
         assert "id" in cols
         assert "name" in cols
         assert "email" in cols
+        assert cols["id"].description is None
 
     def test_collect_sources(self) -> None:
         """Test that source files are tracked."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 description = "Open-source local Context7 alternative with MCP retrieval"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "igraph>=1.0.0",
-    "leidenalg>=0.12.0",
-]
+dependencies = []
 
 [dependency-groups]
 dev = [

--- a/rust/spider_md/src/main.rs
+++ b/rust/spider_md/src/main.rs
@@ -5,15 +5,14 @@
 //! processing by Python (trafilatura) for content extraction.
 
 use clap::Parser;
-use hex;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use spider::configuration::Configuration;
 use spider::reqwest::header::HeaderName;
 use spider::website::Website;
 use std::io::{self, Write};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use tokio::sync::Mutex;
 use url::Url;
 
@@ -34,7 +33,10 @@ struct Args {
     max_pages: usize,
 
     /// User agent string
-    #[arg(long, default_value = "Mozilla/5.0 (compatible; ContextMine/1.0; +https://github.com/mayflower/contextmine)")]
+    #[arg(
+        long,
+        default_value = "Mozilla/5.0 (compatible; ContextMine/1.0; +https://github.com/mayflower/contextmine)"
+    )]
     user_agent: String,
 
     /// Request delay in milliseconds
@@ -129,7 +131,7 @@ async fn main() {
     let base_url = match Url::parse(&args.base_url) {
         Ok(u) => u,
         Err(e) => {
-            eprintln!("Invalid base URL: {}", e);
+            eprintln!("Invalid base URL: {e}");
             std::process::exit(1);
         }
     };
@@ -141,7 +143,7 @@ async fn main() {
     let start_url = match Url::parse(start_url_str) {
         Ok(u) => u,
         Err(e) => {
-            eprintln!("Invalid start URL: {}", e);
+            eprintln!("Invalid start URL: {e}");
             std::process::exit(1);
         }
     };
@@ -154,10 +156,7 @@ async fn main() {
 
     // Start URL must be within base URL scope
     if !is_url_in_scope(start_url.as_str(), &base_url) {
-        eprintln!(
-            "Start URL {} is not within base URL scope {}",
-            start_url, base_url
-        );
+        eprintln!("Start URL {start_url} is not within base URL scope {base_url}");
         std::process::exit(1);
     }
 
@@ -254,7 +253,7 @@ async fn main() {
     });
 
     // Start the crawl (pages are sent to the subscriber as they are discovered)
-    eprintln!("[spider_md] Starting crawl of {}", start_url);
+    eprintln!("[spider_md] Starting crawl of {start_url}");
     website.crawl().await;
     website.unsubscribe();
     eprintln!("[spider_md] Crawl completed");
@@ -267,13 +266,11 @@ async fn main() {
     let mut handle = stdout.lock();
     let outputs = collected_outputs.lock().await;
     for json in outputs.iter() {
-        let _ = writeln!(handle, "{}", json);
+        let _ = writeln!(handle, "{json}");
     }
 
-    eprintln!(
-        "[spider_md] Done: {} pages collected",
-        page_count.load(Ordering::Relaxed)
-    );
+    let collected_page_count = page_count.load(Ordering::Relaxed);
+    eprintln!("[spider_md] Done: {collected_page_count} pages collected");
 }
 
 #[cfg(test)]
@@ -284,7 +281,10 @@ mod tests {
     fn test_url_in_scope_same_host() {
         let base = Url::parse("https://example.com/docs/").unwrap();
         assert!(is_url_in_scope("https://example.com/docs/intro", &base));
-        assert!(is_url_in_scope("https://example.com/docs/guide/start", &base));
+        assert!(is_url_in_scope(
+            "https://example.com/docs/guide/start",
+            &base
+        ));
         assert!(!is_url_in_scope("https://example.com/blog/", &base));
         assert!(!is_url_in_scope("https://other.com/docs/", &base));
     }

--- a/scripts/smoke/docker-compose.yml
+++ b/scripts/smoke/docker-compose.yml
@@ -116,7 +116,6 @@ services:
       TWIN_GRAPH_BUILD_TIMEOUT_SECONDS: "1800"
       CONTEXTMINE_SMOKE_FIXTURE_DIR: /fixtures/repository
       CONTEXTMINE_SMOKE_FIXTURE_REVISION: ${CONTEXTMINE_SMOKE_FIXTURE_REVISION:?fixture revision is required}
-      CONTEXTMINE_SMOKE_API_HEALTH_URL: http://api:8000/api/health
     volumes:
       - ./:/smoke:ro
       - ${CONTEXTMINE_SMOKE_FIXTURE_DIR:?fixture directory is required}:/fixtures/repository:ro

--- a/scripts/smoke/docker-compose.yml
+++ b/scripts/smoke/docker-compose.yml
@@ -1,0 +1,130 @@
+services:
+  postgres:
+    image: ghcr.io/mayflower/pg4ai:latest@sha256:6489ff6174117b54fa25bebd5bce5c647258f833c1c68ff015e4f7c46f2f7802
+    platform: linux/amd64
+    environment:
+      POSTGRES_USER: contextmine
+      POSTGRES_PASSWORD: contextmine
+      POSTGRES_DB: contextmine
+    tmpfs:
+      - /var/lib/postgresql/data
+    volumes:
+      - ../../scripts/docker/init-db.sql:/docker-entrypoint-initdb.d/10-init-db.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U contextmine -d contextmine"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+  prefect-server:
+    image: prefecthq/prefect:3-python3.12@sha256:6c0dc14195cae814eddeb66104a8333810a0a9886a5d7f0c45443136f167b3e0
+    command: prefect server start --host 0.0.0.0
+    environment:
+      PREFECT_SERVER_API_HOST: 0.0.0.0
+      PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://contextmine:contextmine@postgres:5432/prefect
+      PREFECT_SERVER_ANALYTICS_ENABLED: "false"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://localhost:4200/api/health')
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
+
+  api:
+    build:
+      context: ../..
+      dockerfile: apps/api/Dockerfile
+    environment:
+      DATABASE_URL: postgresql+asyncpg://contextmine:contextmine@postgres:5432/contextmine
+      PREFECT_API_URL: http://prefect-server:4200/api
+      MODEL_CALLS_ENABLED: "false"
+      OTEL_ENABLED: "false"
+      GITHUB_CLIENT_ID: contextmine-smoke
+      GITHUB_CLIENT_SECRET: contextmine-smoke-not-a-real-secret
+      PUBLIC_BASE_URL: https://contextmine-smoke.invalid
+      MCP_OAUTH_BASE_URL: https://contextmine-smoke.invalid
+    depends_on:
+      postgres:
+        condition: service_healthy
+      prefect-server:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
+
+  web:
+    build:
+      context: ../../apps/web
+      dockerfile: Dockerfile
+    environment:
+      VITE_API_URL: http://api:8000
+      __VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS: web
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - fetch('http://localhost:5173/').then((response) => { if (!response.ok) process.exit(1) }).catch(() => process.exit(1))
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 15s
+
+  browser:
+    image: chromedp/headless-shell:stable@sha256:2d349b544a1ea6b5b5fd7c0fe99215ff662339c57407ee2e8c0a11af93516b04
+    shm_size: 1gb
+
+  smoke:
+    build:
+      context: ../..
+      dockerfile: apps/worker/Dockerfile
+    environment:
+      DATABASE_URL: postgresql+asyncpg://contextmine:contextmine@postgres:5432/contextmine
+      PREFECT_API_URL: http://prefect-server:4200/api
+      PREFECT_LOGGING_LEVEL: INFO
+      MODEL_CALLS_ENABLED: "false"
+      OTEL_ENABLED: "false"
+      SCIP_LANGUAGES: python,typescript,javascript
+      SCIP_INSTALL_DEPS_MODE: never
+      SCIP_BEST_EFFORT: "false"
+      SCIP_REQUIRE_LANGUAGE_COVERAGE: "true"
+      SCIP_REQUIRE_RELATION_COVERAGE: "true"
+      METRICS_STRICT_MODE: "true"
+      METRICS_LANGUAGES: python,typescript,javascript
+      JOERN_REQUIRED_FOR_SYNC: "false"
+      SYNC_DOCUMENTS_PER_RUN_LIMIT: "0"
+      SYNC_SOURCE_TIMEOUT_SECONDS: "3600"
+      SYNC_BLOCKING_STEP_TIMEOUT_SECONDS: "1200"
+      KNOWLEDGE_GRAPH_BUILD_TIMEOUT_SECONDS: "1800"
+      TWIN_GRAPH_BUILD_TIMEOUT_SECONDS: "1800"
+      CONTEXTMINE_SMOKE_FIXTURE_DIR: /fixtures/repository
+      CONTEXTMINE_SMOKE_FIXTURE_REVISION: ${CONTEXTMINE_SMOKE_FIXTURE_REVISION:?fixture revision is required}
+      CONTEXTMINE_SMOKE_API_HEALTH_URL: http://api:8000/api/health
+    volumes:
+      - ./:/smoke:ro
+      - ${CONTEXTMINE_SMOKE_FIXTURE_DIR:?fixture directory is required}:/fixtures/repository:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+      prefect-server:
+        condition: service_healthy
+      api:
+        condition: service_healthy
+    command: ["/bin/bash", "/smoke/run-model-free-system.sh"]

--- a/scripts/smoke/live_web.mjs
+++ b/scripts/smoke/live_web.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict'
+import { lookup } from 'node:dns/promises'
+
+import { chromium } from 'playwright'
+
+const webUrl = process.env.CONTEXTMINE_SMOKE_WEB_URL
+assert.ok(webUrl, 'CONTEXTMINE_SMOKE_WEB_URL is required')
+
+const browserUrl = process.env.CONTEXTMINE_SMOKE_BROWSER_URL
+assert.ok(browserUrl, 'CONTEXTMINE_SMOKE_BROWSER_URL is required')
+
+const resolvedBrowserUrl = new URL(browserUrl)
+const browserAddress = await lookup(resolvedBrowserUrl.hostname)
+resolvedBrowserUrl.hostname = browserAddress.address
+
+async function connectToBrowser() {
+  let lastError
+
+  for (let attempt = 1; attempt <= 60; attempt += 1) {
+    try {
+      return await chromium.connectOverCDP(resolvedBrowserUrl.href)
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+  }
+
+  throw new Error(`browser did not become ready: ${lastError}`)
+}
+
+const browser = await connectToBrowser()
+
+try {
+  const context = browser.contexts()[0] ?? await browser.newContext()
+  const page = await context.newPage()
+  const pageErrors = []
+  const failedRequests = []
+
+  page.on('pageerror', (error) => pageErrors.push(error.message))
+  page.on('requestfailed', (request) => {
+    failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText}`)
+  })
+
+  const response = await page.goto(webUrl, { waitUntil: 'networkidle' })
+  assert.equal(response?.status(), 200, 'web root must return HTTP 200')
+
+  await page.getByRole('heading', { name: 'ContextMine', exact: true }).waitFor()
+  await page.getByRole('button', { name: 'Sign in with GitHub' }).waitFor()
+
+  const logo = page.getByRole('img', { name: 'ContextMine' })
+  await logo.waitFor()
+  assert.equal(
+    await logo.evaluate((element) => element.complete && element.naturalWidth > 0),
+    true,
+    'ContextMine logo must load successfully',
+  )
+
+  const healthResponse = await page.request.get(`${webUrl}/api/health`)
+  assert.equal(healthResponse.status(), 200, 'web API proxy must return HTTP 200')
+  assert.deepEqual(await healthResponse.json(), { status: 'ok' })
+
+  assert.deepEqual(pageErrors, [], `browser page errors: ${pageErrors.join('; ')}`)
+  assert.deepEqual(
+    failedRequests,
+    [],
+    `browser request failures: ${failedRequests.join('; ')}`,
+  )
+
+  console.log(
+    JSON.stringify({
+      api_proxy: 'pass',
+      browser: 'chromium',
+      login_surface: 'pass',
+      static_assets: 'pass',
+      web_url: webUrl,
+    }),
+  )
+} finally {
+  await browser.close()
+}

--- a/scripts/smoke/model-free-system.sh
+++ b/scripts/smoke/model-free-system.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly FIXTURE_REPOSITORY="https://github.com/fastapi/full-stack-fastapi-template.git"
+readonly FIXTURE_REVISION="486f054cc8d1aead59ec96cc0a16933d06c10e0d"
+readonly FIXTURE_BRANCH="contextmine-smoke"
+
+repository_root="$(git rev-parse --show-toplevel)"
+fixture_root="$(mktemp -d -t contextmine-model-free-smoke.XXXXXX)"
+fixture_repository="${fixture_root}/repository"
+compose_file="${repository_root}/scripts/smoke/docker-compose.yml"
+compose_project="contextmine-model-free-smoke-${BASHPID}"
+
+cleanup() {
+  docker compose \
+    --project-name "${compose_project}" \
+    --file "${compose_file}" \
+    down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "${fixture_root}"
+}
+trap cleanup EXIT
+
+git init --quiet "${fixture_repository}"
+git -C "${fixture_repository}" remote add origin "${FIXTURE_REPOSITORY}"
+git -C "${fixture_repository}" fetch --quiet --depth 1 origin "${FIXTURE_REVISION}"
+git -C "${fixture_repository}" switch --quiet --create "${FIXTURE_BRANCH}" FETCH_HEAD
+
+resolved_revision="$(git -C "${fixture_repository}" rev-parse HEAD)"
+if [[ "${resolved_revision}" != "${FIXTURE_REVISION}" ]]; then
+  echo "Fixture revision mismatch: expected ${FIXTURE_REVISION}, got ${resolved_revision}" >&2
+  exit 1
+fi
+
+export CONTEXTMINE_SMOKE_FIXTURE_DIR="${fixture_repository}"
+export CONTEXTMINE_SMOKE_FIXTURE_REVISION="${FIXTURE_REVISION}"
+
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  up --build --detach --wait --wait-timeout 300 \
+  postgres prefect-server api web browser
+
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  run --rm --no-deps \
+  --env CONTEXTMINE_SMOKE_WEB_URL=http://web:5173 \
+  --env CONTEXTMINE_SMOKE_BROWSER_URL=http://browser:9222 \
+  --volume "${repository_root}/scripts/smoke/live_web.mjs:/app/live_web.mjs:ro" \
+  web node /app/live_web.mjs
+
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  run --build --rm --no-deps smoke

--- a/scripts/smoke/model_free_system.py
+++ b/scripts/smoke/model_free_system.py
@@ -11,10 +11,10 @@ import asyncio
 import json
 import os
 import uuid
+from http.client import HTTPConnection
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
-from urllib.request import urlopen
 
 from contextmine_core import (
     Chunk,
@@ -59,7 +59,6 @@ def _require_environment(name: str) -> str:
 
 FIXTURE_PATH = Path(_require_environment("CONTEXTMINE_SMOKE_FIXTURE_DIR")).resolve()
 FIXTURE_REVISION = _require_environment("CONTEXTMINE_SMOKE_FIXTURE_REVISION")
-API_HEALTH_URL = _require_environment("CONTEXTMINE_SMOKE_API_HEALTH_URL")
 
 
 def _assert_fixture() -> None:
@@ -74,8 +73,15 @@ def _assert_fixture() -> None:
 
 
 def _assert_api_health() -> None:
-    with urlopen(API_HEALTH_URL, timeout=10) as response:
-        payload = json.load(response)
+    connection = HTTPConnection("api", 8000, timeout=10)
+    try:
+        connection.request("GET", "/api/health")
+        response = connection.getresponse()
+        if response.status != 200:
+            raise AssertionError(f"API health returned HTTP {response.status}")
+        payload = json.loads(response.read())
+    finally:
+        connection.close()
     if payload != {"status": "ok"}:
         raise AssertionError(f"Unexpected API health response: {payload}")
 

--- a/scripts/smoke/model_free_system.py
+++ b/scripts/smoke/model_free_system.py
@@ -1,0 +1,374 @@
+"""End-to-end model-free repository sync gate.
+
+This runs inside the production worker image against a fresh pg4ai database and
+a real Prefect server. Only the remote GitHub URL is redirected to a read-only,
+pinned local clone so that upstream branch movement cannot change the fixture.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+from urllib.request import urlopen
+
+from contextmine_core import (
+    Chunk,
+    Collection,
+    CollectionVisibility,
+    Document,
+    Source,
+    SourceType,
+    Symbol,
+    TwinNode,
+    TwinScenario,
+    User,
+    get_session,
+    get_settings,
+    hybrid_search,
+)
+from contextmine_core.models import KnowledgeNode
+from contextmine_worker import flows
+from git import Repo
+from sqlalchemy import func, select
+
+FIXTURE_OWNER = "fastapi"
+FIXTURE_REPOSITORY = "full-stack-fastapi-template"
+FIXTURE_BRANCH = "contextmine-smoke"
+FIXTURE_URL = f"https://github.com/{FIXTURE_OWNER}/{FIXTURE_REPOSITORY}"
+EXPECTED_DOCUMENT_SUFFIXES = {
+    "README.md",
+    "backend/app/main.py",
+    "backend/app/api/routes/items.py",
+    "frontend/src/main.tsx",
+    "frontend/src/components/Items/AddItem.tsx",
+    "compose.yml",
+}
+
+
+def _require_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"{name} must be set")
+    return value
+
+
+FIXTURE_PATH = Path(_require_environment("CONTEXTMINE_SMOKE_FIXTURE_DIR")).resolve()
+FIXTURE_REVISION = _require_environment("CONTEXTMINE_SMOKE_FIXTURE_REVISION")
+API_HEALTH_URL = _require_environment("CONTEXTMINE_SMOKE_API_HEALTH_URL")
+
+
+def _assert_fixture() -> None:
+    repository = Repo(FIXTURE_PATH)
+    actual_revision = repository.head.commit.hexsha
+    if actual_revision != FIXTURE_REVISION:
+        raise AssertionError(
+            f"Fixture revision mismatch: expected {FIXTURE_REVISION}, got {actual_revision}"
+        )
+    if repository.is_dirty(untracked_files=True):
+        raise AssertionError("Pinned fixture must be clean")
+
+
+def _assert_api_health() -> None:
+    with urlopen(API_HEALTH_URL, timeout=10) as response:
+        payload = json.load(response)
+    if payload != {"status": "ok"}:
+        raise AssertionError(f"Unexpected API health response: {payload}")
+
+
+def _forbid_model_provider(*_args: object, **_kwargs: object) -> None:
+    raise AssertionError("A model provider was initialized while MODEL_CALLS_ENABLED=false")
+
+
+def _clone_pinned_fixture(
+    repo_path: Path,
+    clone_url: str,
+    branch: str | None = None,
+    token: str | None = None,
+    ssh_private_key: str | None = None,
+) -> Repo:
+    expected_url = f"{FIXTURE_URL}.git"
+    if clone_url != expected_url:
+        raise AssertionError(f"Unexpected clone URL: {clone_url}")
+    if token or ssh_private_key:
+        raise AssertionError("The public smoke fixture must not require credentials")
+
+    repository = _ORIGINAL_CLONE_OR_PULL(
+        repo_path,
+        str(FIXTURE_PATH),
+        FIXTURE_BRANCH,
+    )
+    actual_revision = repository.head.commit.hexsha
+    if actual_revision != FIXTURE_REVISION:
+        raise AssertionError(
+            f"Indexed revision mismatch: expected {FIXTURE_REVISION}, got {actual_revision}"
+        )
+    return repository
+
+
+_ORIGINAL_CLONE_OR_PULL = flows.clone_or_pull_repo
+
+
+async def _seed_source() -> tuple[uuid.UUID, uuid.UUID]:
+    user_id = uuid.uuid4()
+    collection_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+
+    async with get_session() as session:
+        session.add(
+            User(
+                id=user_id,
+                github_user_id=9_000_000_001,
+                github_login="contextmine-smoke",
+                name="ContextMine Smoke",
+            )
+        )
+        session.add(
+            Collection(
+                id=collection_id,
+                slug="model-free-system-smoke",
+                name="Model-free system smoke",
+                visibility=CollectionVisibility.GLOBAL,
+                owner_user_id=user_id,
+                config={},
+            )
+        )
+        session.add(
+            Source(
+                id=source_id,
+                collection_id=collection_id,
+                type=SourceType.GITHUB,
+                url=FIXTURE_URL,
+                config={
+                    "owner": FIXTURE_OWNER,
+                    "repo": FIXTURE_REPOSITORY,
+                    "branch": FIXTURE_BRANCH,
+                },
+                enabled=True,
+                schedule_interval_minutes=1440,
+            )
+        )
+
+    return collection_id, source_id
+
+
+async def _database_snapshot(collection_id: uuid.UUID, source_id: uuid.UUID) -> dict[str, Any]:
+    async with get_session() as session:
+        document_count = await session.scalar(
+            select(func.count(Document.id)).where(Document.source_id == source_id)
+        )
+        chunk_count = await session.scalar(
+            select(func.count(Chunk.id))
+            .join(Document, Chunk.document_id == Document.id)
+            .where(Document.source_id == source_id)
+        )
+        symbol_count = await session.scalar(
+            select(func.count(Symbol.id))
+            .join(Document, Symbol.document_id == Document.id)
+            .where(Document.source_id == source_id)
+        )
+        knowledge_node_count = await session.scalar(
+            select(func.count(KnowledgeNode.id)).where(KnowledgeNode.collection_id == collection_id)
+        )
+        twin_node_count = await session.scalar(
+            select(func.count(TwinNode.id)).where(
+                TwinNode.scenario_id.in_(
+                    select(TwinScenario.id).where(TwinScenario.collection_id == collection_id)
+                ),
+                TwinNode.is_active.is_(True),
+            )
+        )
+        source = await session.scalar(select(Source).where(Source.id == source_id))
+        uris = set(
+            (await session.execute(select(Document.uri).where(Document.source_id == source_id)))
+            .scalars()
+            .all()
+        )
+
+    return {
+        "documents": int(document_count or 0),
+        "chunks": int(chunk_count or 0),
+        "symbols": int(symbol_count or 0),
+        "knowledge_nodes": int(knowledge_node_count or 0),
+        "twin_nodes": int(twin_node_count or 0),
+        "cursor": source.cursor if source else None,
+        "uris": uris,
+    }
+
+
+def _assert_first_sync(result: dict[str, Any]) -> dict[str, Any]:
+    if result.get("status") != "success":
+        raise AssertionError(f"Initial sync did not succeed: {result}")
+
+    stats = dict(result.get("stats") or {})
+    expected_equal = {
+        "commit_sha": FIXTURE_REVISION,
+        "docs_processing_failures": 0,
+        "docs_processing_timeouts": 0,
+        "docs_chunk_deferred": 0,
+        "embedding_tokens_used": 0,
+        "chunks_embedded": 0,
+        "metrics_gate": "pass",
+        "scip_degraded": False,
+    }
+    for key, expected in expected_equal.items():
+        actual = stats.get(key)
+        if actual != expected:
+            raise AssertionError(f"Unexpected {key}: expected {expected!r}, got {actual!r}")
+
+    expected_counts = {
+        "files_indexed": 210,
+        "docs_created": 210,
+        "chunks_created": 691,
+        "symbols_created": 553,
+        "scip_projects_detected": 4,
+        "scip_projects_indexed": 4,
+        "scip_symbols": 2652,
+        "scip_relations": 5998,
+        "structural_metric_files": 124,
+        "metrics_requested_files": 124,
+        "kg_file_nodes": 210,
+        "kg_symbol_nodes": 553,
+        "twin_nodes_upserted": 6391,
+    }
+    for key, expected in expected_counts.items():
+        actual = int(stats.get(key, 0) or 0)
+        if actual != expected:
+            raise AssertionError(f"Unexpected {key}: expected {expected}, got {actual}")
+
+    detected_languages = set(stats.get("scip_languages_detected") or [])
+    if not {"python", "typescript"}.issubset(detected_languages):
+        raise AssertionError(f"Expected Python and TypeScript, got {sorted(detected_languages)}")
+    if stats.get("kg_errors"):
+        raise AssertionError(f"Knowledge graph errors: {stats['kg_errors']}")
+
+    return stats
+
+
+def _assert_database_snapshot(snapshot: dict[str, Any]) -> None:
+    expected_counts = {
+        "documents": 210,
+        "chunks": 691,
+        "symbols": 553,
+        "knowledge_nodes": 4665,
+        "twin_nodes": 4621,
+    }
+    for key, expected in expected_counts.items():
+        actual = int(snapshot[key])
+        if actual != expected:
+            raise AssertionError(f"Unexpected persisted {key}: expected {expected}, got {actual}")
+    if snapshot["cursor"] != FIXTURE_REVISION:
+        raise AssertionError(f"Expected source cursor {FIXTURE_REVISION}, got {snapshot['cursor']}")
+
+    uris = set(snapshot["uris"])
+    missing = {
+        suffix
+        for suffix in EXPECTED_DOCUMENT_SUFFIXES
+        if not any(uri.split("?", 1)[0].endswith(f"/{suffix}") for uri in uris)
+    }
+    if missing:
+        raise AssertionError(f"Expected fixture documents are missing: {sorted(missing)}")
+
+
+def _assert_noop_sync(result: dict[str, Any]) -> None:
+    if result.get("status") != "success":
+        raise AssertionError(f"No-op sync did not succeed: {result}")
+    stats = dict(result.get("stats") or {})
+    expected_zero = (
+        "docs_created",
+        "docs_updated",
+        "docs_deleted",
+        "chunks_created",
+        "chunks_deleted",
+        "symbols_created",
+        "symbols_deleted",
+        "embedding_tokens_used",
+    )
+    for key in expected_zero:
+        if int(stats.get(key, 0) or 0) != 0:
+            raise AssertionError(f"No-op sync changed {key}: {stats.get(key)}")
+    if stats.get("commit_sha") != FIXTURE_REVISION:
+        raise AssertionError(f"No-op sync moved revision: {stats.get('commit_sha')}")
+
+
+async def _run() -> None:
+    _assert_fixture()
+    _assert_api_health()
+    settings = get_settings()
+    if settings.model_calls_enabled:
+        raise AssertionError("MODEL_CALLS_ENABLED must be false for this gate")
+
+    collection_id, source_id = await _seed_source()
+    provider_patches = (
+        patch.object(flows, "clone_or_pull_repo", side_effect=_clone_pinned_fixture),
+        patch.object(flows, "get_embedder", side_effect=_forbid_model_provider),
+        patch(
+            "contextmine_core.research.llm.get_llm_provider",
+            side_effect=_forbid_model_provider,
+        ),
+        patch(
+            "contextmine_core.research.llm.get_research_llm_provider",
+            side_effect=_forbid_model_provider,
+        ),
+    )
+
+    with provider_patches[0], provider_patches[1], provider_patches[2], provider_patches[3]:
+        first_result = await flows.sync_single_source(str(source_id), FIXTURE_URL)
+        first_stats = _assert_first_sync(first_result)
+        first_snapshot = await _database_snapshot(collection_id, source_id)
+        _assert_database_snapshot(first_snapshot)
+
+        search_response = await hybrid_search(
+            query="FastAPI",
+            query_embedding=None,
+            user_id=None,
+            collection_id=collection_id,
+            top_k=10,
+        )
+        if not search_response.results:
+            raise AssertionError("Model-free full-text search returned no results")
+        if search_response.total_vector_matches != 0:
+            raise AssertionError("Model-free search unexpectedly returned vector matches")
+
+        second_result = await flows.sync_single_source(str(source_id), FIXTURE_URL)
+        _assert_noop_sync(second_result)
+        second_snapshot = await _database_snapshot(collection_id, source_id)
+
+    if {key: value for key, value in first_snapshot.items() if key != "uris"} != {
+        key: value for key, value in second_snapshot.items() if key != "uris"
+    }:
+        raise AssertionError("No-op sync changed persisted object counts")
+
+    summary = {
+        "fixture": f"{FIXTURE_OWNER}/{FIXTURE_REPOSITORY}@{FIXTURE_REVISION}",
+        "model_calls_enabled": False,
+        "first_sync": {
+            key: first_stats.get(key)
+            for key in (
+                "files_indexed",
+                "docs_created",
+                "chunks_created",
+                "symbols_created",
+                "scip_projects_indexed",
+                "scip_symbols",
+                "scip_relations",
+                "structural_metric_files",
+                "metrics_gate",
+                "kg_file_nodes",
+                "kg_symbol_nodes",
+                "twin_nodes_upserted",
+            )
+        },
+        "persisted": {key: value for key, value in first_snapshot.items() if key != "uris"},
+        "search_results": len(search_response.results),
+        "noop_sync": "pass",
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(_run())

--- a/scripts/smoke/run-model-free-system.sh
+++ b/scripts/smoke/run-model-free-system.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd /app/packages/core
+/app/.venv/bin/alembic upgrade head
+
+cd /app
+/app/.venv/bin/python /smoke/model_free_system.py

--- a/scripts/smoke/run-model-free-system.sh
+++ b/scripts/smoke/run-model-free-system.sh
@@ -2,8 +2,9 @@
 
 set -euo pipefail
 
-# The fixture is a read-only bind mount whose host UID differs on CI runners.
+# The fixture and its Git directory are read-only mounts whose host UID differs on CI.
 git config --global --add safe.directory /fixtures/repository
+git config --global --add safe.directory /fixtures/repository/.git
 
 cd /app/packages/core
 /app/.venv/bin/alembic upgrade head

--- a/scripts/smoke/run-model-free-system.sh
+++ b/scripts/smoke/run-model-free-system.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# The fixture is a read-only bind mount whose host UID differs on CI runners.
+git config --global --add safe.directory /fixtures/repository
+
 cd /app/packages/core
 /app/.venv/bin/alembic upgrade head
 

--- a/uv.lock
+++ b/uv.lock
@@ -474,10 +474,6 @@ wheels = [
 name = "contextmine"
 version = "0.1.0"
 source = { virtual = "." }
-dependencies = [
-    { name = "igraph" },
-    { name = "leidenalg" },
-]
 
 [package.dev-dependencies]
 dev = [
@@ -493,10 +489,6 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "igraph", specifier = ">=1.0.0" },
-    { name = "leidenalg", specifier = ">=0.12.0" },
-]
 
 [package.metadata.requires-dev]
 dev = [
@@ -517,7 +509,6 @@ version = "0.1.0"
 source = { editable = "apps/api" }
 dependencies = [
     { name = "contextmine-core" },
-    { name = "contextmine-worker" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
@@ -530,7 +521,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "contextmine-core", editable = "packages/core" },
-    { name = "contextmine-worker", editable = "apps/worker" },
     { name = "fastapi", specifier = ">=0.138.0" },
     { name = "fastmcp", specifier = ">=3.4.2" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -552,10 +542,12 @@ dependencies = [
     { name = "defusedxml" },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "igraph" },
     { name = "langchain-anthropic" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "leidenalg" },
     { name = "lizard" },
     { name = "openai" },
     { name = "opentelemetry-api" },
@@ -583,10 +575,12 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "google-genai", specifier = ">=2.10.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "igraph", specifier = ">=1.0.0" },
     { name = "langchain-anthropic", specifier = ">=1.4.7" },
     { name = "langchain-core", specifier = ">=1.4.8" },
     { name = "langchain-openai", specifier = ">=1.3.3" },
     { name = "langgraph", specifier = ">=1.2.6" },
+    { name = "leidenalg", specifier = ">=0.12.0" },
     { name = "lizard", specifier = ">=1.23.0" },
     { name = "openai", specifier = ">=2.44.0" },
     { name = "opentelemetry-api", specifier = ">=1.43.0" },


### PR DESCRIPTION
## Summary

- document the current Python, web, Rust, container, and CI dependency surfaces and group future upgrades by compatibility risk
- add a reproducible model-free system gate against fastapi/full-stack-fastapi-template at commit 486f054cc8d1aead59ec96cc0a16933d06c10e0d
- exercise the shipped web container in pinned headless Chromium, including the login surface, static assets, and the live API proxy
- run two real source synchronizations and require exact extraction, SCIP, metrics, graph, persistence, search, and no-op baselines
- make package ownership and production image installation deterministic, and fix the Alembic ERM description edge case exposed by the gate
- add Rust formatting, Clippy, and test coverage to CI and require the complete validation chain before image publication

This PR intentionally does not upgrade dependency versions. It establishes the inventory and executable safety net used by follow-up upgrade PRs.

## Verification

- model-free system and live web gate: passed
- Python: 4,969 passed, 12 skipped
- web: ESLint passed; 473 tests passed; production build passed
- Rust 1.88: rustfmt passed; Clippy with warnings denied passed; 7 tests passed
- Ruff, ty, strict MkDocs build, and staged diff checks passed

## Gate boundaries

Model providers are disabled and fail if initialized. Joern remains advisory, while SCIP and structural metrics are strict. Authenticated browser workflows, web crawling, model-provider behavior, and Joern qualification retain their targeted test lanes.