### PR TITLE
Fix stale Cockpit end-to-end expectations

### DIFF
--- a/apps/web/e2e/cockpit.spec.ts
+++ b/apps/web/e2e/cockpit.spec.ts
@@ -1000,7 +1000,7 @@ test('graphrag empty state is guided when no knowledge graph exists', async ({ p
 
   await page.goto('/?page=cockpit&collection=col-1&scenario=scn-asis&view=graphrag')
   await expect(page.getByText('No knowledge graph available yet')).toBeVisible()
-  await expect(page.getByText('Run sync/build pipeline')).toBeVisible()
+  await expect(page.getByText(/Run the sync\/build pipeline to populate GraphRAG nodes and evidence\./)).toBeVisible()
 })
 
 test('c4 diff shows AS-IS and TO-BE compare panes', async ({ page }) => {
@@ -1035,12 +1035,18 @@ test('architecture view renders arc42, ports/adapters, erm/erd, and drift sectio
   await expect(page.getByRole('tab', { name: 'Architecture' })).toHaveAttribute('aria-selected', 'true')
   await expect(page.getByText('Architecture intelligence')).toBeVisible()
   await expect(page.getByText('arc42 sections')).toBeVisible()
+
+  await page.getByRole('tab', { name: 'Ports/Adapters' }).click()
   await expect(page.getByText('Ports & adapters map')).toBeVisible()
-  await expect(page.getByText('ERM data model')).toBeVisible()
-  await expect(page.getByText('Advisory drift report')).toBeVisible()
   await expect(page.getByText('CreateInvoice', { exact: true })).toBeVisible()
+
+  await page.getByRole('tab', { name: 'ERD' }).click()
+  await expect(page.getByText('ERM data model')).toBeVisible()
   await expect(page.locator('.cockpit2-erd-pane')).toBeVisible()
   await expect(page.getByText('users')).toBeVisible()
+
+  await page.getByRole('tab', { name: 'Drift' }).click()
+  await expect(page.getByText('Advisory drift report')).toBeVisible()
   await expect(page.getByText('new_port')).toBeVisible()
 })
 


### PR DESCRIPTION
## Summary

- assert the current guided GraphRAG empty-state instruction
- navigate through the Architecture view's nested tabs before asserting tab-specific content
- retain coverage for arc42, Ports/Adapters, ERD, and Drift content instead of weakening the assertions

## Context

The two tests failed identically on the unchanged base commit:

- the GraphRAG assertion omitted the word "the" from the rendered instruction
- the Architecture assertion expected content from four mutually exclusive tabs to be visible at the same time

The updated test follows the same interaction model as a user and verifies representative content after each tab transition.

## Validation

- targeted Playwright run: 2 passed
- full Playwright suite: 17 passed
- npm run lint: passed
- npm run test: 33 files and 473 tests passed
- npm run build: passed
