### PR TITLE
Run Cockpit Playwright tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,43 @@ jobs:
       - name: Build web application
         run: npm run build
 
+  web-e2e:
+    name: Web End-to-End
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: playwright-failure-${{ github.run_attempt }}
+          path: |
+            apps/web/playwright-report/
+            apps/web/test-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
   rust:
     name: Rust Format, Clippy & Test
     runs-on: ubuntu-latest
@@ -145,7 +182,7 @@ jobs:
   build:
     name: Build & Push Containers
     runs-on: ubuntu-latest
-    needs: [lint, test, web, rust, model-free-system-smoke]
+    needs: [lint, test, web, web-e2e, rust, model-free-system-smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   fullyParallel: true,
   use: {
     baseURL: 'http://127.0.0.1:4173',
-    trace: 'on-first-retry',
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
   },
   webServer: {
     command: 'npm run dev -- --host 127.0.0.1 --port 4173',

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -84,7 +84,7 @@ The normal CI checks remain required:
 
 1. Ruff lint and formatting plus `ty` type checking.
 2. The complete PostgreSQL-backed Python test suite.
-3. Web ESLint, Vitest, and production build.
+3. Web ESLint, Vitest, Playwright end-to-end tests, and production build.
 4. Rust 1.88 formatting, strict Clippy, and all crawler tests.
 5. Security workflows and the relevant container/Helm build checks. Helm
    publication waits for the complete image-build dependency chain.


### PR DESCRIPTION
## Summary

- add a dedicated Web End-to-End job that runs the full Playwright suite on pull requests and main
- install the Chromium build matched to the locked Playwright package
- retain Playwright traces in CI and upload failure artifacts for diagnosis
- require the E2E job before container publication can start
- document Playwright as part of the required dependency-upgrade gate

## Motivation

The Cockpit Playwright suite was not part of the existing Web Lint, Test & Build job. Two stale end-to-end expectations could therefore fail locally while all required CI checks remained green. This change gives the suite its own visible gate and keeps its failure signal separate from Vitest and the model-free system smoke.

## Validation

- workflow YAML parsed successfully
- npm ci: passed; 0 vulnerabilities
- CI=true npm run test:e2e: 17 passed
- npm run lint: passed
- npm run test: 33 files and 473 tests passed
- npm run build: passed

The existing model-free system smoke remains unchanged and continues to cover live containers, the web-to-API proxy, repository indexing, persistence baselines, and no-op resynchronization.
