### PR TITLE
Harden Node and TypeScript language server runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Run frontend tests with coverage
         working-directory: apps/web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
-  NODE_VERSION: "22"
+  NODE_VERSION: "24"
   UV_CACHE_DIR: /tmp/.uv-cache
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ Strict metrics gate behavior for GitHub sources:
 ### Prerequisites
 
 - Python 3.12+
-- Node.js 20+
+- Node.js 24+
 - [uv](https://github.com/astral-sh/uv) for Python dependency management
 - Docker (for pg4ai: PostgreSQL + pgvector + Apache AGE)
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build frontend
-FROM node:20-alpine AS frontend-builder
+FROM node:24-alpine AS frontend-builder
 
 WORKDIR /app
 
@@ -15,17 +15,28 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+ARG NODE_VERSION=24
+ARG TYPESCRIPT_VERSION=6.0.3
+ARG TYPESCRIPT_LANGUAGE_SERVER_VERSION=6.0.0
+
 # Install system dependencies for LSP servers and TypeScript language server
 # - Node.js: Required for TypeScript/JavaScript language server
 # - git: Required by some language servers for project detection
-# - curl: For downloading language server binaries
+# - curl and gnupg: Required to install a supported Node.js release
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nodejs \
-    npm \
-    git \
+    ca-certificates \
     curl \
+    git \
+    gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
-    && npm install -g typescript typescript-language-server
+    && npm install -g \
+       typescript@${TYPESCRIPT_VERSION} \
+       typescript-language-server@${TYPESCRIPT_LANGUAGE_SERVER_VERSION} \
+    && node --version | grep -Eq "^v${NODE_VERSION}\\." \
+    && test "$(tsc --version)" = "Version ${TYPESCRIPT_VERSION}" \
+    && test "$(typescript-language-server --version)" = "${TYPESCRIPT_LANGUAGE_SERVER_VERSION}"
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # Copy workspace files

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 

--- a/apps/web/e2e/cockpit.spec.ts
+++ b/apps/web/e2e/cockpit.spec.ts
@@ -11,8 +11,7 @@ interface MockOptions {
   collections?: Array<{ id: string; name: string }>
   scenariosByCollection?: Record<string, Scenario[]>
   cityDelayMs?: number
-  failCityOnce?: boolean
-  cityFailCount?: number
+  failCity?: boolean
 }
 
 const DEFAULT_COLLECTIONS = [{ id: 'col-1', name: 'Alpha Project' }]
@@ -30,7 +29,7 @@ function json(route: Route, payload: unknown, status = 200) {
 }
 
 async function mockApi(page: Page, options: MockOptions = {}) {
-  let cityFailuresRemaining = options.cityFailCount ?? (options.failCityOnce ? 1 : 0)
+  let failCity = options.failCity ?? false
   const collections = options.collections ?? DEFAULT_COLLECTIONS
   const scenariosByCollection = options.scenariosByCollection ?? { 'col-1': DEFAULT_SCENARIOS }
 
@@ -333,8 +332,7 @@ async function mockApi(page: Page, options: MockOptions = {}) {
         await new Promise((resolve) => setTimeout(resolve, options.cityDelayMs))
       }
 
-      if (cityFailuresRemaining > 0) {
-        cityFailuresRemaining -= 1
+      if (failCity) {
         return json(route, { detail: 'city endpoint failed' }, 500)
       }
 
@@ -827,6 +825,12 @@ async function mockApi(page: Page, options: MockOptions = {}) {
 
     return json(route, {})
   })
+
+  return {
+    allowCitySuccess: () => {
+      failCity = false
+    },
+  }
 }
 
 test('discoverability: sidebar and dashboard CTA open Architecture Cockpit', async ({ page }) => {
@@ -1067,10 +1071,11 @@ test('exports view can generate output and supports copy/download actions', asyn
 })
 
 test('overview error handling shows inline error and supports retry', async ({ page }) => {
-  await mockApi(page, { cityFailCount: 2 })
+  const cityMock = await mockApi(page, { failCity: true })
   await page.goto('/?page=cockpit&collection=col-1&scenario=scn-asis&view=overview')
 
   await expect(page.getByText('Overview request failed')).toBeVisible()
+  cityMock.allowCitySuccess()
   await page.getByRole('button', { name: 'Retry' }).first().click()
   await expect(page.getByText('System health summary')).toBeVisible()
 })

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -21,7 +21,7 @@ ARG SCIP_PYTHON_VERSION=0.6.6
 ARG SCIP_JAVA_VERSION=0.10.3
 ARG SCIP_PHP_VERSION=dev-main
 ARG SCIP_PHP_REPO_URL=https://github.com/mayflower/scip-php.git
-ARG NODE_VERSION=20
+ARG NODE_VERSION=24
 
 # Install system dependencies
 # - git: for cloning repos
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get install -y \
     && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/* \
+    && node --version | grep -Eq "^v${NODE_VERSION}\\." \
     && corepack enable \
     && npm install -g \
        @sourcegraph/scip-typescript@${SCIP_TYPESCRIPT_VERSION} \

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@ This guide covers setting up a development environment and contributing to Conte
 ## Prerequisites
 
 - Python 3.12+
-- Node.js 20+
+- Node.js 24+
 - [uv](https://github.com/astral-sh/uv) for Python dependency management
 - Docker (for pg4ai: PostgreSQL + pgvector + Apache AGE)
 

--- a/docs/scip_polyglot_indexing.md
+++ b/docs/scip_polyglot_indexing.md
@@ -216,8 +216,8 @@ When `cfg.best_effort=True` (default), individual project failures don't abort t
 The worker image must include:
 
 ```dockerfile
-# Node.js 20 (for scip-python, scip-typescript)
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+# Node.js 24 (for scip-python, scip-typescript)
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
     apt-get install -y nodejs
 
 # SCIP indexers (npm)

--- a/scripts/smoke/model-free-system.sh
+++ b/scripts/smoke/model-free-system.sh
@@ -53,4 +53,10 @@ docker compose \
 docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
+  exec --no-TTY api /app/.venv/bin/python - \
+  < "${repository_root}/scripts/smoke/typescript_lsp.py"
+
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
   run --build --rm --no-deps smoke

--- a/scripts/smoke/typescript_lsp.py
+++ b/scripts/smoke/typescript_lsp.py
@@ -1,0 +1,280 @@
+"""Exercise the shipped TypeScript language server over JSON-RPC stdio."""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+class LspProcess:
+    """Small synchronous LSP client used only by the system smoke gate."""
+
+    def __init__(self, workspace: Path) -> None:
+        self._workspace = workspace
+        self._buffer = bytearray()
+        self._process = subprocess.Popen(  # noqa: S603
+            ["typescript-language-server", "--stdio", "--log-level", "1"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+
+    def send(self, message: dict[str, Any]) -> None:
+        """Send one JSON-RPC message using LSP content-length framing."""
+        if self._process.stdin is None:
+            raise RuntimeError("language-server stdin is unavailable")
+
+        body = json.dumps(message, separators=(",", ":")).encode()
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode()
+        self._process.stdin.write(header + body)
+        self._process.stdin.flush()
+
+    def request(
+        self,
+        request_id: int,
+        method: str,
+        params: dict[str, Any] | None,
+        *,
+        timeout_seconds: float = 30,
+    ) -> Any:
+        """Send a request and wait for its response."""
+        self.send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": params,
+            }
+        )
+        deadline = time.monotonic() + timeout_seconds
+
+        while True:
+            message = self._read_message(deadline)
+            if "method" in message and "id" in message:
+                self._answer_server_request(message)
+                continue
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                raise RuntimeError(f"LSP {method} failed: {message['error']}")
+            return message.get("result")
+
+    def notify(self, method: str, params: dict[str, Any] | None) -> None:
+        """Send a JSON-RPC notification."""
+        self.send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def close(self) -> None:
+        """Stop the process even when a protocol assertion failed."""
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=5)
+
+    def stderr(self) -> str:
+        """Return bounded server diagnostics after the process stopped."""
+        if self._process.stderr is None or self._process.poll() is None:
+            return ""
+        return self._process.stderr.read().decode(errors="replace")[-4000:]
+
+    def _read_message(self, deadline: float) -> dict[str, Any]:
+        if self._process.stdout is None:
+            raise RuntimeError("language-server stdout is unavailable")
+
+        while True:
+            separator = self._buffer.find(b"\r\n\r\n")
+            if separator >= 0:
+                header = self._buffer[:separator].decode("ascii")
+                content_length = self._content_length(header)
+                body_start = separator + 4
+                body_end = body_start + content_length
+                if len(self._buffer) >= body_end:
+                    body = bytes(self._buffer[body_start:body_end])
+                    del self._buffer[:body_end]
+                    parsed = json.loads(body)
+                    if not isinstance(parsed, dict):
+                        raise RuntimeError("LSP message is not a JSON object")
+                    return parsed
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out waiting for an LSP response")
+
+            ready, _, _ = select.select([self._process.stdout.fileno()], [], [], remaining)
+            if not ready:
+                raise TimeoutError("timed out waiting for LSP output")
+
+            chunk = os.read(self._process.stdout.fileno(), 65536)
+            if not chunk:
+                raise RuntimeError(
+                    "language server stopped before responding"
+                    f" (exit={self._process.poll()}, stderr={self.stderr()!r})"
+                )
+            self._buffer.extend(chunk)
+
+    @staticmethod
+    def _content_length(header: str) -> int:
+        for line in header.split("\r\n"):
+            name, separator, value = line.partition(":")
+            if separator and name.lower() == "content-length":
+                return int(value.strip())
+        raise RuntimeError("LSP message is missing Content-Length")
+
+    def _answer_server_request(self, message: dict[str, Any]) -> None:
+        method = message["method"]
+        params = message.get("params") or {}
+
+        if method == "workspace/configuration":
+            result: Any = [None for _ in params.get("items", [])]
+        elif method == "workspace/workspaceFolders":
+            result = [{"uri": self._workspace.as_uri(), "name": self._workspace.name}]
+        else:
+            result = None
+
+        self.send({"jsonrpc": "2.0", "id": message["id"], "result": result})
+
+
+def command_output(*command: str) -> str:
+    """Run a bounded version probe."""
+    return subprocess.run(  # noqa: S603
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    ).stdout.strip()
+
+
+def main() -> None:
+    """Initialize TypeScript LSP and prove semantic requests against a fixture."""
+    source = """export function greet(name: string): string {
+  return `Hello ${name}`
+}
+
+const message = greet("ContextMine")
+console.log(message)
+"""
+
+    with tempfile.TemporaryDirectory(prefix="contextmine-typescript-lsp-") as directory:
+        workspace = Path(directory)
+        source_path = workspace / "index.ts"
+        tsserver_path = (
+            Path(command_output("npm", "root", "--global")) / "typescript" / "lib" / "tsserver.js"
+        )
+        if not tsserver_path.is_file():
+            raise RuntimeError(f"global TypeScript server not found at {tsserver_path}")
+
+        source_path.write_text(source)
+        (workspace / "tsconfig.json").write_text(
+            json.dumps(
+                {
+                    "compilerOptions": {
+                        "strict": True,
+                        "target": "ES2022",
+                        "module": "ESNext",
+                        "noEmit": True,
+                    },
+                    "files": ["index.ts"],
+                }
+            )
+        )
+
+        client = LspProcess(workspace)
+        try:
+            capabilities = client.request(
+                1,
+                "initialize",
+                {
+                    "processId": os.getpid(),
+                    "clientInfo": {"name": "contextmine-smoke", "version": "1"},
+                    "rootUri": workspace.as_uri(),
+                    "workspaceFolders": [{"uri": workspace.as_uri(), "name": workspace.name}],
+                    "capabilities": {
+                        "workspace": {"configuration": True, "workspaceFolders": True},
+                        "textDocument": {
+                            "definition": {"linkSupport": True},
+                            "hover": {"contentFormat": ["plaintext"]},
+                        },
+                    },
+                    "initializationOptions": {
+                        "tsserver": {"path": str(tsserver_path)},
+                    },
+                    "trace": "off",
+                },
+            )
+            if not isinstance(capabilities, dict) or "capabilities" not in capabilities:
+                raise RuntimeError("LSP initialize response did not contain capabilities")
+
+            client.notify("initialized", {})
+            client.notify(
+                "textDocument/didOpen",
+                {
+                    "textDocument": {
+                        "uri": source_path.as_uri(),
+                        "languageId": "typescript",
+                        "version": 1,
+                        "text": source,
+                    }
+                },
+            )
+
+            position = {"line": 4, "character": 18}
+            text_document = {"uri": source_path.as_uri()}
+            hover = client.request(
+                2,
+                "textDocument/hover",
+                {"textDocument": text_document, "position": position},
+            )
+            if not hover:
+                raise RuntimeError("TypeScript LSP returned no hover information")
+
+            definition = client.request(
+                3,
+                "textDocument/definition",
+                {"textDocument": text_document, "position": position},
+            )
+            definitions = definition if isinstance(definition, list) else [definition]
+            if not any(
+                isinstance(item, dict)
+                and (item.get("uri") or item.get("targetUri")) == source_path.as_uri()
+                for item in definitions
+            ):
+                raise RuntimeError("TypeScript LSP did not resolve the local definition")
+
+            client.request(4, "shutdown", None)
+            client.notify("exit", None)
+            if client._process.wait(timeout=5) != 0:
+                raise RuntimeError(
+                    f"TypeScript LSP exited unsuccessfully (stderr={client.stderr()!r})"
+                )
+        finally:
+            client.close()
+
+    print(
+        json.dumps(
+            {
+                "definition": "pass",
+                "hover": "pass",
+                "initialize": "pass",
+                "node": command_output("node", "--version"),
+                "typescript": command_output("tsc", "--version"),
+                "typescript_language_server": command_output(
+                    "typescript-language-server", "--version"
+                ),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- align CI and the API, worker, and web images on Node.js 24 LTS
- pin TypeScript 6.0.3 and typescript-language-server 6.0.0 in the API image, with build-time version assertions
- add a real JSON-RPC TypeScript LSP smoke covering initialize, hover, and go-to-definition to the model-free system gate
- make the overview retry E2E mock deterministic across Node.js scheduling differences
- update the documented Node.js baseline

## Why

The API image previously installed the latest global TypeScript packages without a lock. That allowed TypeScript 7 to be paired with typescript-language-server 6, which could start but could not initialize a usable TypeScript server. The exact TypeScript 6 / language-server 6 pair is compatible, and the protocol smoke now detects future runtime drift.

Moving CI to Node.js 24 also exposed an E2E test that assumed exactly two initial city requests before retry. The mock now fails until the test explicitly permits success, so it verifies retry behavior without relying on request scheduling.

## Validation

- uv run ruff check .
- uv run ruff format --check .
- uv run ty check
- Python: 4,969 passed, 12 skipped
- npm run lint
- npm run test: 473 passed
- npm run build
- npm run test:e2e: 17 passed
- overview retry E2E: 10 repeated runs passed
- ./scripts/smoke/model-free-system.sh
  - live web smoke passed
  - TypeScript LSP initialize, hover, and definition passed on Node 24.20.0
  - pinned fastapi/full-stack-fastapi-template@486f054cc8d1aead59ec96cc0a16933d06c10e0d fixture matched the established baseline
  - second sync was a no-op and model calls remained disabled
  - Joern stayed advisory and was skipped because joern-parse is not installed in this model-free gate

This validates the shipped TypeScript server process. Activating the optional Python multilspy integration remains separate work.