### PR TITLE
Enable the optional multilspy runtime and gate the real LSP adapter

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from contextmine_core import close_engine
+from contextmine_core.lsp import shutdown_lsp_manager
 from contextmine_core.telemetry import init_telemetry, shutdown_telemetry
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -58,6 +59,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # Startup
         yield
     # Shutdown
+    await shutdown_lsp_manager()
     await close_engine()
     await shutdown_telemetry()
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -7,7 +7,7 @@ dependencies = [
     "fastapi>=0.138.0",
     "uvicorn[standard]>=0.49.0",
     "fastmcp>=3.4.2",
-    "contextmine-core",
+    "contextmine-core[lsp]",
     "itsdangerous>=2.2.0",
     "httpx>=0.28.1",
     "slowapi>=0.1.10",

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -22,6 +22,8 @@ ARG SCIP_JAVA_VERSION=0.10.3
 ARG SCIP_PHP_VERSION=dev-main
 ARG SCIP_PHP_REPO_URL=https://github.com/mayflower/scip-php.git
 ARG NODE_VERSION=24
+ARG TYPESCRIPT_VERSION=6.0.3
+ARG TYPESCRIPT_LANGUAGE_SERVER_VERSION=6.0.0
 
 # Install system dependencies
 # - git: for cloning repos
@@ -48,7 +50,11 @@ RUN apt-get update && apt-get install -y \
     && corepack enable \
     && npm install -g \
        @sourcegraph/scip-typescript@${SCIP_TYPESCRIPT_VERSION} \
-       @sourcegraph/scip-python@${SCIP_PYTHON_VERSION}
+       @sourcegraph/scip-python@${SCIP_PYTHON_VERSION} \
+       typescript@${TYPESCRIPT_VERSION} \
+       typescript-language-server@${TYPESCRIPT_LANGUAGE_SERVER_VERSION} \
+    && test "$(tsc --version)" = "Version ${TYPESCRIPT_VERSION}" \
+    && test "$(typescript-language-server --version)" = "${TYPESCRIPT_LANGUAGE_SERVER_VERSION}"
 
 # Install Coursier/scip-java, Composer/scip-php, and verify SCIP tools
 ENV COMPOSER_HOME=/opt/composer

--- a/apps/worker/contextmine_worker/main.py
+++ b/apps/worker/contextmine_worker/main.py
@@ -9,6 +9,7 @@ import logging
 import signal
 from datetime import timedelta
 
+from contextmine_core.lsp import shutdown_lsp_manager
 from contextmine_core.telemetry import init_telemetry
 
 from contextmine_worker.flows import sync_due_sources
@@ -69,6 +70,7 @@ async def run_worker() -> None:
         logger.info("Worker cancelled")
         raise
     finally:
+        await shutdown_lsp_manager()
         logger.info("Worker shutdown complete")
 
 

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "ContextMine Prefect worker for syncing sources"
 requires-python = ">=3.12"
 dependencies = [
-    "contextmine-core",
+    "contextmine-core[lsp]",
     "prefect>=3.7.5",
     "gitpython>=3.1.50",
     "langchain-text-splitters>=1.1.2",

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -5,14 +5,14 @@ dependency surfaces that must move together, the checks that protect them, and
 the commands used to refresh the snapshot. It is not a request to upgrade every
 package in one change.
 
-Snapshot date: **2026-08-31**  
-Repository baseline: **95caf9654eae39318a00d8c30eac0e6a3b2db242**
+Snapshot date: **2026-09-01**  
+Repository baseline: **5691da2e591781847cc2be81f9cd9c4abda9b8c4**
 
 ## Inventory Summary
 
 | Surface | Manifest and lock | Current size | Runtime role |
 | --- | --- | ---: | --- |
-| Python workspace | `pyproject.toml`, three workspace `pyproject.toml` files, `uv.lock` | 230 locked packages; 29 core, 8 API, 11 worker, and 9 development declarations | API, MCP, sync worker, analysis, search, graph, telemetry |
+| Python workspace | `pyproject.toml`, three workspace `pyproject.toml` files, `uv.lock` | 241 locked packages; 29 core plus 1 optional LSP, 8 API, 11 worker, and 9 development declarations | API, MCP, sync worker, analysis, search, graph, telemetry |
 | Web application | `apps/web/package.json`, `apps/web/package-lock.json` | 9 runtime and 19 development declarations; 456 lock entries | React cockpit, diagrams, observability |
 | Rust crawler | `rust/spider_md/Cargo.toml`, `rust/spider_md/Cargo.lock` | 8 direct declarations; 357 locked packages | Deterministic website crawling binary embedded in the worker image |
 | Runtime images | Dockerfiles, Compose files, Helm values | API, worker, web, PostgreSQL/pg4ai, Prefect, CodeCharta, OpenTelemetry | Build and deployment compatibility |
@@ -31,7 +31,7 @@ edited.
 | API and MCP | FastAPI, FastMCP, Uvicorn, SlowAPI, Prometheus instrumentation | Upgrade FastAPI/Starlette/Pydantic together only after checking route, lifespan, middleware, MCP discovery, and container startup. |
 | Sync orchestration | Prefect, GitPython, Tenacity | The Prefect Python client and Prefect server image are one upgrade unit. Test a real submitted flow, not imports alone. |
 | Model integrations | OpenAI, Anthropic, Google Gen AI, LangChain Core, LangChain provider packages, LangGraph | Provider SDK majors and the LangChain/LangGraph family are high-risk. Model-free indexing must remain green before any provider-specific tests are considered. |
-| Code intelligence | protobuf, tree-sitter-language-pack, Lizard, SCIP CLIs installed by the worker image | Validate Python and TypeScript/JavaScript project detection, index creation, relation coverage, parsing, and persisted symbols. |
+| Code intelligence | protobuf, tree-sitter-language-pack, Lizard, optional multilspy, and SCIP/LSP CLIs installed by the runtime images | Validate Python and TypeScript/JavaScript project detection, index creation, relation coverage, parsing, persisted symbols, and a semantic request through the ContextMine LSP adapter. |
 | Knowledge graph and Twin | igraph, leidenalg, SQLAlchemy, pg4ai with Apache AGE and pgvector | Exercise deterministic knowledge-graph and Twin materialization against the production database image. |
 | Web cockpit | React, React Flow, Cytoscape, ELK, Mermaid, Grafana Faro | Run lint, component tests, TypeScript build, and API image build because the API image embeds the web bundle. |
 | Crawler | Rust `spider`, Tokio, serde, URL and hashing crates | Build the worker image and run Rust formatting, Clippy, and tests when the crawler lock or toolchain changes. |
@@ -109,6 +109,9 @@ The system gate deliberately takes longer than a unit smoke test. It:
   fails if an embedding or LLM provider is initialized;
 - requires strict Python and TypeScript/JavaScript SCIP project and relation
   coverage plus strict structural metrics;
+- starts the pinned TypeScript language server through ContextMine's real
+  `LspManager` and requires hover, client caching, and cross-file definition
+  resolution without downloading a server at runtime;
 - verifies persisted documents, chunks, symbols, knowledge nodes, Twin nodes,
   known fixture paths, and full-text-only retrieval;
 - compares deterministic extraction and persistence counts to an explicit

--- a/packages/core/contextmine_core/lsp/__init__.py
+++ b/packages/core/contextmine_core/lsp/__init__.py
@@ -24,7 +24,7 @@ from contextmine_core.lsp.languages import (
     detect_language,
     find_project_root,
 )
-from contextmine_core.lsp.manager import LspManager, get_lsp_manager
+from contextmine_core.lsp.manager import LspManager, get_lsp_manager, shutdown_lsp_manager
 
 __all__ = [
     # Client
@@ -47,4 +47,5 @@ __all__ = [
     # Manager
     "LspManager",
     "get_lsp_manager",
+    "shutdown_lsp_manager",
 ]

--- a/packages/core/contextmine_core/lsp/manager.py
+++ b/packages/core/contextmine_core/lsp/manager.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import shutil
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from contextmine_core.lsp.client import LspClient, MockLspClient
 from contextmine_core.lsp.exceptions import LspNotAvailableError, LspTimeoutError
@@ -30,6 +31,27 @@ if TYPE_CHECKING:
     pass  # Reserved for future type-only imports
 
 logger = logging.getLogger(__name__)
+
+
+def _find_server_binary(language: SupportedLanguage) -> str | None:
+    """Find a pre-installed language server supported by the runtime image."""
+    if language in {SupportedLanguage.JAVASCRIPT, SupportedLanguage.TYPESCRIPT}:
+        return shutil.which("typescript-language-server")
+    return None
+
+
+def _register_client_request_handlers(server: Any, project_root: Path) -> None:
+    """Register client capabilities required by current TypeScript servers."""
+
+    async def workspace_configuration(params: dict[str, Any]) -> list[None]:
+        items = params.get("items", [])
+        return [None for _ in items] if isinstance(items, list) else []
+
+    async def workspace_folders(_params: dict[str, Any]) -> list[dict[str, str]]:
+        return [{"uri": project_root.as_uri(), "name": project_root.name}]
+
+    server.server.on_request("workspace/configuration", workspace_configuration)
+    server.server.on_request("workspace/workspaceFolders", workspace_folders)
 
 
 @dataclass
@@ -183,13 +205,20 @@ class LspManager:
             from multilspy.multilspy_config import MultilspyConfig
             from multilspy.multilspy_logger import MultilspyLogger
         except ImportError as e:
-            raise LspNotAvailableError("multilspy not installed. Run: pip install multilspy") from e
+            raise LspNotAvailableError(
+                "multilspy not installed. Install the ContextMine 'lsp' extra."
+            ) from e
 
         try:
-            config = MultilspyConfig.from_dict({"code_language": language.value})
+            config_values = {"code_language": language.value}
+            if server_binary := _find_server_binary(language):
+                config_values["server_binary"] = server_binary
+
+            config = MultilspyConfig.from_dict(config_values)
             lsp_logger = MultilspyLogger()
 
             server = LanguageServer.create(config, lsp_logger, str(project_root))
+            _register_client_request_handlers(server, project_root)
 
             client = LspClient(server, project_root)
             await asyncio.wait_for(
@@ -280,3 +309,17 @@ def get_lsp_manager() -> LspManager:
         The singleton LspManager
     """
     return LspManager.get_instance()
+
+
+async def shutdown_lsp_manager() -> None:
+    """Shutdown and clear the global manager without creating one."""
+    manager = LspManager._instance
+    if manager is None:
+        return
+
+    try:
+        await manager.shutdown()
+    finally:
+        with LspManager._lock:
+            if LspManager._instance is manager:
+                LspManager._instance = None

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -40,9 +40,17 @@ dependencies = [
     "defusedxml>=0.7.1",
 ]
 
+[project.optional-dependencies]
+lsp = [
+    "multilspy @ git+https://github.com/microsoft/multilspy@6f4c0b7c287f2ff6917fc4008ba0d98a26d6aa24",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["contextmine_core"]

--- a/packages/core/tests/test_lsp_manager.py
+++ b/packages/core/tests/test_lsp_manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,7 +19,10 @@ from contextmine_core.lsp.languages import SupportedLanguage
 from contextmine_core.lsp.manager import (
     CachedServer,
     LspManager,
+    _find_server_binary,
+    _register_client_request_handlers,
     get_lsp_manager,
+    shutdown_lsp_manager,
 )
 
 # ---------------------------------------------------------------------------
@@ -81,6 +85,16 @@ class TestLspManagerSingleton:
     def test_get_lsp_manager_helper(self) -> None:
         instance = get_lsp_manager()
         assert isinstance(instance, LspManager)
+
+    @pytest.mark.anyio
+    async def test_shutdown_helper_closes_and_clears_singleton(self) -> None:
+        instance = LspManager.get_instance()
+        instance.shutdown = AsyncMock()
+
+        await shutdown_lsp_manager()
+
+        instance.shutdown.assert_awaited_once()
+        assert LspManager._instance is None
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +215,38 @@ class TestGetClient:
 
 
 class TestStartServer:
+    def test_preinstalled_typescript_server_is_discovered(self) -> None:
+        with patch(
+            "contextmine_core.lsp.manager.shutil.which",
+            return_value="/usr/local/bin/typescript-language-server",
+        ) as which:
+            assert (
+                _find_server_binary(SupportedLanguage.TYPESCRIPT)
+                == "/usr/local/bin/typescript-language-server"
+            )
+
+        which.assert_called_once_with("typescript-language-server")
+
+    def test_unmanaged_language_does_not_probe_for_server(self) -> None:
+        with patch("contextmine_core.lsp.manager.shutil.which") as which:
+            assert _find_server_binary(SupportedLanguage.PYTHON) is None
+
+        which.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_required_typescript_client_requests_are_registered(self, tmp_path: Path) -> None:
+        protocol = MagicMock()
+        handlers: dict[str, Any] = {}
+        protocol.on_request.side_effect = handlers.__setitem__
+        server = MagicMock(server=protocol)
+
+        _register_client_request_handlers(server, tmp_path)
+
+        configuration = handlers["workspace/configuration"]
+        folders = handlers["workspace/workspaceFolders"]
+        assert await configuration({"items": [{"section": "typescript"}]}) == [None]
+        assert await folders({}) == [{"uri": tmp_path.as_uri(), "name": tmp_path.name}]
+
     @pytest.mark.anyio
     async def test_multilspy_not_installed(self) -> None:
         manager = LspManager()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,12 @@ members = ["apps/api", "apps/worker", "packages/*"]
 contextmine-core = { workspace = true }
 contextmine-worker = { workspace = true }
 
+[tool.uv]
+# multilspy's v0.1.0 release metadata still pins requests==2.32.3. Keep the
+# workspace on the current patched requests release while exercising the
+# compatibility in the real LSP smoke gate.
+override-dependencies = ["requests>=2.34.2"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,10 @@ members = ["apps/api", "apps/worker", "packages/*"]
 contextmine-core = { workspace = true }
 contextmine-worker = { workspace = true }
 
-[tool.uv]
+[tool.uv]  # nosemgrep: package_managers.uv.uv-missing-dependency-cooldown.uv-missing-dependency-cooldown
+# A global dependency cooldown would force an unrelated full-workspace re-lock.
+# Keep this narrowly scoped dependency pinned by immutable commit and lockfile;
+# introduce the cooldown with the next controlled workspace dependency refresh.
 # multilspy's v0.1.0 release metadata still pins requests==2.32.3. Keep the
 # workspace on the current patched requests release while exercising the
 # compatibility in the real LSP smoke gate.

--- a/scripts/smoke/contextmine_lsp.py
+++ b/scripts/smoke/contextmine_lsp.py
@@ -1,0 +1,85 @@
+"""Exercise a real language server through ContextMine's LSP adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+from contextmine_core.lsp.manager import LspManager
+
+
+async def exercise_lsp() -> dict[str, str]:
+    """Resolve a cross-file TypeScript definition through LspManager."""
+    server_binary = shutil.which("typescript-language-server")
+    if server_binary is None:
+        raise RuntimeError("typescript-language-server is not available on PATH")
+
+    with tempfile.TemporaryDirectory(prefix="contextmine-lsp-manager-") as directory:
+        workspace = Path(directory)
+        definition_path = workspace / "greeting.ts"
+        usage_path = workspace / "index.ts"
+
+        definition_path.write_text(
+            "export function greet(name: string): string {\n  return `Hello ${name}`\n}\n"
+        )
+        usage_path.write_text(
+            'import { greet } from "./greeting"\n\n'
+            'const message = greet("ContextMine")\n'
+            "console.log(message)\n"
+        )
+        (workspace / "tsconfig.json").write_text(
+            json.dumps(
+                {
+                    "compilerOptions": {
+                        "strict": True,
+                        "target": "ES2022",
+                        "module": "ESNext",
+                        "moduleResolution": "Bundler",
+                        "noEmit": True,
+                    },
+                    "files": ["greeting.ts", "index.ts"],
+                }
+            )
+        )
+
+        manager = LspManager(request_timeout_seconds=30)
+        try:
+            client = await manager.get_client(usage_path, project_root=workspace)
+            cached_client = await manager.get_client(usage_path, project_root=workspace)
+            if cached_client is not client:
+                raise RuntimeError("LspManager did not reuse its cached client")
+
+            hover = await client.get_hover(str(usage_path), line=3, column=18)
+            if hover is None or not hover.signature:
+                raise RuntimeError("ContextMine LSP adapter returned no hover information")
+
+            definitions = await client.get_definition(str(usage_path), line=3, column=18)
+            if not any(
+                Path(location.file_path).resolve() == definition_path for location in definitions
+            ):
+                raise RuntimeError(
+                    "ContextMine LSP adapter did not resolve the cross-file definition"
+                )
+        finally:
+            await manager.shutdown()
+
+    return {
+        "cache": "pass",
+        "cross_file_definition": "pass",
+        "hover": "pass",
+        "multilspy": importlib.metadata.version("multilspy"),
+        "server_binary": server_binary,
+    }
+
+
+def main() -> None:
+    """Run the async adapter smoke and emit a compact machine-readable result."""
+    print(json.dumps(asyncio.run(exercise_lsp()), sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke/model_free_system.py
+++ b/scripts/smoke/model_free_system.py
@@ -31,6 +31,7 @@ from contextmine_core import (
     get_settings,
     hybrid_search,
 )
+from contextmine_core.lsp import shutdown_lsp_manager
 from contextmine_core.models import KnowledgeNode
 from contextmine_worker import flows
 from git import Repo
@@ -376,5 +377,13 @@ async def _run() -> None:
     print(json.dumps(summary, indent=2, sort_keys=True))
 
 
+async def main() -> None:
+    """Run the gate and close any language server started by traceability."""
+    try:
+        await _run()
+    finally:
+        await shutdown_lsp_manager()
+
+
 if __name__ == "__main__":
-    asyncio.run(_run())
+    asyncio.run(main())

--- a/scripts/smoke/run-model-free-system.sh
+++ b/scripts/smoke/run-model-free-system.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 git config --global --add safe.directory /fixtures/repository
 git config --global --add safe.directory /fixtures/repository/.git
 
+/app/.venv/bin/python /smoke/contextmine_lsp.py
+
 cd /app/packages/core
 /app/.venv/bin/alembic upgrade head
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ members = [
     "contextmine-core",
     "contextmine-worker",
 ]
+overrides = [{ name = "requests", specifier = ">=2.34.2" }]
 
 [[package]]
 name = "aiofile"
@@ -280,6 +281,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -508,7 +522,7 @@ name = "contextmine-api"
 version = "0.1.0"
 source = { editable = "apps/api" }
 dependencies = [
-    { name = "contextmine-core" },
+    { name = "contextmine-core", extra = ["lsp"] },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "httpx" },
@@ -520,7 +534,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "contextmine-core", editable = "packages/core" },
+    { name = "contextmine-core", extras = ["lsp"], editable = "packages/core" },
     { name = "fastapi", specifier = ">=0.138.0" },
     { name = "fastmcp", specifier = ">=3.4.2" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -566,6 +580,11 @@ dependencies = [
     { name = "tree-sitter-language-pack" },
 ]
 
+[package.optional-dependencies]
+lsp = [
+    { name = "multilspy" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
@@ -582,6 +601,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.2.6" },
     { name = "leidenalg", specifier = ">=0.12.0" },
     { name = "lizard", specifier = ">=1.23.0" },
+    { name = "multilspy", marker = "extra == 'lsp'", git = "https://github.com/microsoft/multilspy?rev=6f4c0b7c287f2ff6917fc4008ba0d98a26d6aa24" },
     { name = "openai", specifier = ">=2.44.0" },
     { name = "opentelemetry-api", specifier = ">=1.43.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.43.0" },
@@ -598,6 +618,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "tree-sitter-language-pack", specifier = ">=1.10.9" },
 ]
+provides-extras = ["lsp"]
 
 [[package]]
 name = "contextmine-worker"
@@ -605,7 +626,7 @@ version = "0.1.0"
 source = { editable = "apps/worker" }
 dependencies = [
     { name = "anthropic" },
-    { name = "contextmine-core" },
+    { name = "contextmine-core", extra = ["lsp"] },
     { name = "gitpython" },
     { name = "google-genai" },
     { name = "langchain-text-splitters" },
@@ -620,7 +641,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.112.0" },
-    { name = "contextmine-core", editable = "packages/core" },
+    { name = "contextmine-core", extras = ["lsp"], editable = "packages/core" },
     { name = "gitpython", specifier = ">=3.1.50" },
     { name = "google-genai", specifier = ">=2.10.0" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
@@ -881,6 +902,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "docstring-to-markdown"
+version = "0.17"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/d8/8abe80d62c5dce1075578031bcfde07e735bcf0afe2886dd48b470162ab4/docstring_to_markdown-0.17.tar.gz", hash = "sha256:df72a112294c7492487c9da2451cae0faeee06e86008245c188c5761c9590ca3", size = 32260, upload-time = "2025-05-02T15:09:07.932Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7b/af3d0da15bed3a8665419bb3a630585756920f4ad67abfdfef26240ebcc0/docstring_to_markdown-0.17-py3-none-any.whl", hash = "sha256:fd7d5094aa83943bf5f9e1a13701866b7c452eac19765380dead666e36d3711c", size = 23479, upload-time = "2025-05-02T15:09:06.676Z" },
 ]
 
 [[package]]
@@ -1457,6 +1491,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6f/7e/1e7e8dc30634b93ebb3d58a3dea569ad146e656218d3960ab04f62047b29/importlib_metadata-9.0.1.tar.gz", hash = "sha256:ab830580bc0ef3db61ce8fae716389e5462b67e033018bab6d8f80ef17172f99", size = 59124, upload-time = "2026-08-28T15:30:34.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/55/ecca97ae19075f1fac62def77731e7f535e6c1fb8f92ff08160c5e6dade8/importlib_metadata-9.0.1-py3-none-any.whl", hash = "sha256:bba5600596a7e21f3eef53281cf28d6a5195634d2f2b78ff9501a3272c6eaab0", size = 27920, upload-time = "2026-08-28T15:30:33.433Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1505,6 +1551,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "jedi-language-server"
+version = "0.41.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cattrs" },
+    { name = "docstring-to-markdown" },
+    { name = "jedi" },
+    { name = "lsprotocol" },
+    { name = "pygls" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/34/4a35094c680040c8dd598b1ee9153a701289351c1dcbad1a0f2d196c524b/jedi_language_server-0.41.3.tar.gz", hash = "sha256:113ec22b95fadaceefbb704b5f365384bed296b82ede59026be375ecc97a9f8a", size = 29113, upload-time = "2024-02-26T04:28:05.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/67/2cf4419a8c418b0e5cba0b43dc1ea33a0bb42907694d6a786a3644889f32/jedi_language_server-0.41.3-py3-none-any.whl", hash = "sha256:7411f7479cdc9e9ea495f91e20b182a5d00170c0a8a4a87d3a147462282c06af", size = 27615, upload-time = "2024-02-26T04:28:02.084Z" },
 ]
 
 [[package]]
@@ -1930,6 +2004,19 @@ wheels = [
 ]
 
 [[package]]
+name = "lsprotocol"
+version = "2023.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/f6/6e80484ec078d0b50699ceb1833597b792a6c695f90c645fbaf54b947e6f/lsprotocol-2023.0.1.tar.gz", hash = "sha256:cc5c15130d2403c18b734304339e51242d3018a05c4f7d0f198ad6e0cd21861d", size = 69434, upload-time = "2024-01-09T17:21:12.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/37/2351e48cb3309673492d3a8c59d407b75fb6630e560eb27ecd4da03adc9a/lsprotocol-2023.0.1-py3-none-any.whl", hash = "sha256:c75223c9e4af2f24272b14c6375787438279369236cd568f596d4951052a60f2", size = 70826, upload-time = "2024-01-09T17:21:14.491Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2163,6 +2250,17 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
+]
+
+[[package]]
+name = "multilspy"
+version = "0.0.15"
+source = { git = "https://github.com/microsoft/multilspy?rev=6f4c0b7c287f2ff6917fc4008ba0d98a26d6aa24#6f4c0b7c287f2ff6917fc4008ba0d98a26d6aa24" }
+dependencies = [
+    { name = "jedi-language-server" },
+    { name = "psutil" },
+    { name = "requests" },
+    { name = "typing-extensions" },
 ]
 
 [[package]]
@@ -2562,6 +2660,15 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
 name = "pathable"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2774,6 +2881,34 @@ wheels = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "py-key-value-aio"
 version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2975,6 +3110,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/c0/800c602c01a3fea829b2cb564b1ce667f983ac191ef6faf9dac8ba86bd30/pydocket-0.22.0.tar.gz", hash = "sha256:de6a6011df94e3da30279ff0b9732a793feaf77f9e6b23a09f2ae12b134993d6", size = 407557, upload-time = "2026-06-15T12:56:01.325Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/8e/35d61a731524557269052de721ace1a2576cb8232def60795b798c3dd9f0/pydocket-0.22.0-py3-none-any.whl", hash = "sha256:a8ee4d08be5eb40b99b945ba72583364b26a5c6b197520bb2379216b79f36a07", size = 122198, upload-time = "2026-06-15T12:56:00.071Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/b9/41d173dad9eaa9db9c785a85671fc3d68961f08d67706dc2e79011e10b5c/pygls-1.3.1.tar.gz", hash = "sha256:140edceefa0da0e9b3c533547c892a42a7d2fd9217ae848c330c53d266a55018", size = 45527, upload-time = "2024-03-26T18:44:25.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/19/b74a10dd24548e96e8c80226cbacb28b021bc3a168a7d2709fb0d0185348/pygls-1.3.1-py3-none-any.whl", hash = "sha256:6e00f11efc56321bdeb6eac04f6d86131f654c7d49124344a9ebb968da3dd91e", size = 56031, upload-time = "2024-03-26T18:44:24.249Z" },
 ]
 
 [[package]]
@@ -4535,6 +4683,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/df/61beb9e061ddaa349f1a6e75ef14f174af1439de0308d63f2561039eb522/xxhash-3.7.1-cp314-cp314t-win32.whl", hash = "sha256:02ad31001ca4f8241b5edc38f009a189d075f270b023e1a1ba01b1aadf7240a8", size = 32026, upload-time = "2026-06-24T08:20:11.383Z" },
     { url = "https://files.pythonhosted.org/packages/78/b1/c6a5ba0ecba582d9302daf67fdb13a5081b122ea5ce18aa6df3e59001cbe/xxhash-3.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:68ee1b9903252e80437559d32ae6d0a752e6a26fa6416925c7e6282500948838", size = 32887, upload-time = "2026-06-24T08:20:13.004Z" },
     { url = "https://files.pythonhosted.org/packages/c7/88/70b85fdae219f77d8e70035cef3d6527e4d000aa7038ff046279d47aa39a/xxhash-3.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5795037fb23aa33bdb1d6daa6a68b001c4462de447c1a31917ae1aebca691286", size = 29160, upload-time = "2026-06-24T08:20:14.297Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- declare `multilspy` as the `contextmine-core[lsp]` optional extra and enable that extra explicitly in the API and worker runtimes
- pin the official multilspy v0.1.0 release commit and keep the workspace on `requests>=2.34.2` instead of accepting the release metadata's `requests==2.32.3` downgrade
- reuse the preinstalled, version-pinned TypeScript language server rather than downloading a server at runtime
- answer the `workspace/configuration` and `workspace/workspaceFolders` client requests required by current TypeScript language servers
- shut down cached language servers explicitly during API, worker, and finite smoke-run lifecycles
- add a real `LspManager` system smoke for client reuse, hover, and cross-file definition resolution

## Context

ContextMine already has advisory LSP fallback paths in its traceability and Twin surfaces, but the runtime dependency was not installed. This meant those paths degraded as designed instead of being available in the shipped API and worker images.

The latest published PyPI package remains 0.0.15. The official v0.1.0 release tag contains the server-binary configuration and lifecycle fixes needed here, but its package metadata still reports 0.0.15 and pins `requests==2.32.3`. This change therefore pins the immutable release commit and uses uv's explicit override to retain the current patched Requests version. The compatibility is exercised through the real ContextMine adapter and the full model-free system gate.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- 67 focused LSP/worker lifecycle tests plus the API health/lifespan tests
- API and worker production images built successfully
- real `LspManager` smoke passed in both non-root images with TypeScript 6.0.3 and typescript-language-server 6.0.0
- full model-free system gate passed against `fastapi/full-stack-fastapi-template@486f054cc8d1aead59ec96cc0a16933d06c10e0d`
  - 210 documents, 691 chunks, 553 symbols
  - 4 SCIP projects and 5,998 SCIP relations
  - 4,665 knowledge nodes and 4,621 active Twin nodes
  - clean no-op second sync
  - no model calls and no runtime language-server download
  - explicit LSP shutdown without async-generator cleanup errors
