### PR TITLE
Pin runtime inputs and update Python development tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: ghcr.io/mayflower/pg4ai:latest
+        image: ghcr.io/mayflower/pg4ai:latest@sha256:6489ff6174117b54fa25bebd5bce5c647258f833c1c68ff015e4f7c46f2f7802
         env:
           POSTGRES_USER: contextmine
           POSTGRES_PASSWORD: contextmine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: ghcr.io/mayflower/pg4ai:latest
+        image: ghcr.io/mayflower/pg4ai:latest@sha256:6489ff6174117b54fa25bebd5bce5c647258f833c1c68ff015e4f7c46f2f7802
         env:
           POSTGRES_USER: contextmine
           POSTGRES_PASSWORD: contextmine

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,7 +13,7 @@ jobs:
     name: Semgrep
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:latest@sha256:f1f7b71861c7b28b6e0f661225a2c4f58a484f5d0f182465c6d6b3b22f972ade
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build frontend
-FROM node:24-alpine AS frontend-builder
+FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf AS frontend-builder
 
 WORKDIR /app
 
@@ -10,34 +10,35 @@ RUN npm ci
 COPY apps/web/ ./
 RUN npm run build
 
+# Supply the runtime Node.js installation from an immutable official image
+# instead of executing the mutable NodeSource setup script during the build.
+FROM node:24-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e AS node-runtime
+
 # Stage 2: Python API with frontend
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:e5c9fa26ffb76e11e0f054f30dc2523a2f9693f0c36c0cf1e39b27e152d899fc
 
 WORKDIR /app
 
-ARG NODE_VERSION=24
+ARG NODE_VERSION=24.20.0
 ARG TYPESCRIPT_VERSION=6.0.3
 ARG TYPESCRIPT_LANGUAGE_SERVER_VERSION=6.0.0
+
+COPY --from=node-runtime /usr/local/ /usr/local/
 
 # Install system dependencies for LSP servers and TypeScript language server
 # - Node.js: Required for TypeScript/JavaScript language server
 # - git: Required by some language servers for project detection
-# - curl and gnupg: Required to install a supported Node.js release
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    curl \
     git \
-    gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
-    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/* \
     && npm install -g \
        typescript@${TYPESCRIPT_VERSION} \
        typescript-language-server@${TYPESCRIPT_LANGUAGE_SERVER_VERSION} \
-    && node --version | grep -Eq "^v${NODE_VERSION}\\." \
+    && test "$(node --version)" = "v${NODE_VERSION}" \
     && test "$(tsc --version)" = "Version ${TYPESCRIPT_VERSION}" \
     && test "$(typescript-language-server --version)" = "${TYPESCRIPT_LANGUAGE_SERVER_VERSION}"
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:latest@sha256:d1cbaeadc234fe19c0d93daabcf5e98738cd93c6d1dd4918ef6aa30735feb23a /uv /usr/local/bin/uv
 
 # Copy workspace files
 COPY pyproject.toml uv.lock ./

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-alpine
+FROM node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf
 
 WORKDIR /app
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage for Rust spider_md binary
 # spider_md dependencies currently require rustc >= 1.88.
-FROM rust:1.88-slim AS rust-builder
+FROM rust:1.88-slim@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89 AS rust-builder
 
 WORKDIR /build
 
@@ -12,24 +12,36 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* \
     && cargo build --release
 
+# Supply the runtime Node.js installation from an immutable official image
+# instead of executing the mutable NodeSource setup script during the build.
+FROM node:24-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e AS node-runtime
+
 # Python worker stage
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:e5c9fa26ffb76e11e0f054f30dc2523a2f9693f0c36c0cf1e39b27e152d899fc
 
 # SCIP tool versions (pinned for reproducibility)
 ARG SCIP_TYPESCRIPT_VERSION=0.3.14
 ARG SCIP_PYTHON_VERSION=0.6.6
 ARG SCIP_JAVA_VERSION=0.10.3
-ARG SCIP_PHP_VERSION=dev-main
-ARG SCIP_PHP_REPO_URL=https://github.com/mayflower/scip-php.git
-ARG NODE_VERSION=24
+ARG SCIP_PHP_COMMIT=efaf87cd05cf174db8ac25ad4d07eb646d4883d1
+ARG SCIP_PHP_ARCHIVE_SHA256=28c6c05da118d8d052d2b6f99d63956f72dd7d656cf6e90166396ee62dbcc939
+ARG COURSIER_LAUNCHER_COMMIT=15f36c167c30be237105f923151adaf177e7ee61
+ARG COURSIER_LAUNCHER_AMD64_SHA256=62b141b186e4dfdef03af64c36bdcdfeaab2df30de14950ca220e6e43e72c26b
+ARG COURSIER_LAUNCHER_ARM64_SHA256=11d980e5714abdebe93688f22cedfa8ac227a95f4de9f96c53c4779d2547cff7
+ARG COMPOSER_VERSION=2.10.3
+ARG COMPOSER_SHA256=7a2d379d5b8ffdaa028580ef26494c36d2feef4b178d3dd1473a4dbc5e17c8d6
+ARG NODE_VERSION=24.20.0
 ARG TYPESCRIPT_VERSION=6.0.3
 ARG TYPESCRIPT_LANGUAGE_SERVER_VERSION=6.0.0
+
+COPY --from=node-runtime /usr/local/ /usr/local/
+COPY --from=node-runtime /opt/ /opt/
 
 # Install system dependencies
 # - git: for cloning repos
 # - cloc: language census for multi-language detection
 # - ca-certificates, libssl3: for spider_md and HTTPS
-# - curl: for installing Node.js and Coursier
+# - curl: for installing pinned Coursier, Composer, and scip-php artifacts
 # - openjdk-21-jre-headless: for scip-java
 # - php-cli, composer: for scip-php
 RUN apt-get update && apt-get install -y \
@@ -38,15 +50,11 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
     curl \
-    gnupg \
     unzip \
     openjdk-21-jre-headless \
     php-cli \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/* \
-    && node --version | grep -Eq "^v${NODE_VERSION}\\." \
+    && test "$(node --version)" = "v${NODE_VERSION}" \
     && corepack enable \
     && npm install -g \
        @sourcegraph/scip-typescript@${SCIP_TYPESCRIPT_VERSION} \
@@ -56,41 +64,52 @@ RUN apt-get update && apt-get install -y \
     && test "$(tsc --version)" = "Version ${TYPESCRIPT_VERSION}" \
     && test "$(typescript-language-server --version)" = "${TYPESCRIPT_LANGUAGE_SERVER_VERSION}"
 
-# Install Coursier/scip-java, Composer/scip-php, and verify SCIP tools
-ENV COMPOSER_HOME=/opt/composer
-ENV PATH="${PATH}:${COMPOSER_HOME}/vendor/bin"
+# Install Coursier/scip-java, Composer/scip-php, and verify SCIP tools.
+# Every downloaded artifact is selected by an immutable revision and checksum.
+ENV SCIP_PHP_HOME=/opt/scip-php
+ENV PATH="${PATH}:${SCIP_PHP_HOME}/bin"
 RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then \
-      CS_URL="https://github.com/coursier/launchers/raw/master/cs-aarch64-pc-linux.gz"; \
-    else \
-      CS_URL="https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz"; \
-    fi && \
-    curl -fL "$CS_URL" | gzip -d > /usr/local/bin/cs && \
+    case "$ARCH" in \
+      arm64) CS_ARTIFACT="cs-aarch64-pc-linux.gz"; CS_SHA256="${COURSIER_LAUNCHER_ARM64_SHA256}" ;; \
+      amd64) CS_ARTIFACT="cs-x86_64-pc-linux.gz"; CS_SHA256="${COURSIER_LAUNCHER_AMD64_SHA256}" ;; \
+      *) echo "Unsupported Coursier architecture: $ARCH" >&2; exit 1 ;; \
+    esac && \
+    CS_URL="https://raw.githubusercontent.com/coursier/launchers/${COURSIER_LAUNCHER_COMMIT}/${CS_ARTIFACT}" && \
+    curl -fsSL "$CS_URL" -o /tmp/cs.gz && \
+    echo "${CS_SHA256}  /tmp/cs.gz" | sha256sum -c - && \
+    gzip -d /tmp/cs.gz && \
+    mv /tmp/cs /usr/local/bin/cs && \
     chmod +x /usr/local/bin/cs && \
     /usr/local/bin/cs install --contrib \
       scip-java:${SCIP_JAVA_VERSION} \
       --install-dir /usr/local/bin && \
-    curl -sS https://getcomposer.org/installer \
-      | php -- --install-dir=/usr/local/bin --filename=composer && \
-    composer global config -g github-protocols https && \
-    composer global config repositories.scip-php "{\"type\":\"vcs\",\"url\":\"${SCIP_PHP_REPO_URL}\",\"no-api\":true}" && \
-    composer global require davidrjenni/scip-php:${SCIP_PHP_VERSION} && \
+    curl -fsSL "https://getcomposer.org/download/${COMPOSER_VERSION}/composer.phar" \
+      -o /usr/local/bin/composer && \
+    echo "${COMPOSER_SHA256}  /usr/local/bin/composer" | sha256sum -c - && \
+    chmod +x /usr/local/bin/composer && \
+    test "$(composer --no-ansi --version | cut -d' ' -f3)" = "${COMPOSER_VERSION}" && \
+    curl -fsSL "https://github.com/mayflower/scip-php/archive/${SCIP_PHP_COMMIT}.tar.gz" \
+      -o /tmp/scip-php.tar.gz && \
+    echo "${SCIP_PHP_ARCHIVE_SHA256}  /tmp/scip-php.tar.gz" | sha256sum -c - && \
+    mkdir -p ${SCIP_PHP_HOME} && \
+    tar -xzf /tmp/scip-php.tar.gz --strip-components=1 -C ${SCIP_PHP_HOME} && \
+    rm /tmp/scip-php.tar.gz && \
     composer install \
-      --working-dir=${COMPOSER_HOME}/vendor/davidrjenni/scip-php \
+      --working-dir=${SCIP_PHP_HOME} \
       --no-interaction --prefer-dist --no-progress --no-dev && \
-    test -f ${COMPOSER_HOME}/vendor/davidrjenni/scip-php/vendor/autoload.php && \
-    chmod -R 755 ${COMPOSER_HOME} && \
+    test -f ${SCIP_PHP_HOME}/vendor/autoload.php && \
+    chmod -R a+rX ${SCIP_PHP_HOME} && \
     scip-typescript --version && \
     scip-python --version && \
     scip-java --help | head -1 && \
-    test -x ${COMPOSER_HOME}/vendor/bin/scip-php && \
+    test -x ${SCIP_PHP_HOME}/bin/scip-php && \
     php --version
 
 WORKDIR /app
 
 # Copy spider_md binary and uv from build stages
 COPY --from=rust-builder /build/target/release/spider_md /usr/local/bin/spider_md
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:latest@sha256:d1cbaeadc234fe19c0d93daabcf5e98738cd93c6d1dd4918ef6aa30735feb23a /uv /usr/local/bin/uv
 RUN chmod +x /usr/local/bin/spider_md
 
 # Copy workspace files

--- a/deploy/helm/contextmine/templates/api/deployment.yaml
+++ b/deploy/helm/contextmine/templates/api/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       initContainers:
         # Wait for PostgreSQL to be ready
         - name: wait-for-postgres
-          image: busybox:1.36
+          image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "contextmine.postgresql.host" . }} {{ include "contextmine.postgresql.port" . }}; do echo waiting for postgres; sleep 2; done']
         # Run database migrations
         - name: migrations

--- a/deploy/helm/contextmine/templates/prefect/deployment.yaml
+++ b/deploy/helm/contextmine/templates/prefect/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       initContainers:
         # Wait for PostgreSQL to be ready
         - name: wait-for-postgres
-          image: busybox:1.36
+          image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "contextmine.postgresql.host" . }} {{ include "contextmine.postgresql.port" . }}; do echo waiting for postgres; sleep 2; done']
       containers:
         - name: prefect

--- a/deploy/helm/contextmine/templates/worker/deployment.yaml
+++ b/deploy/helm/contextmine/templates/worker/deployment.yaml
@@ -32,11 +32,11 @@ spec:
       initContainers:
         # Wait for PostgreSQL to be ready
         - name: wait-for-postgres
-          image: busybox:1.36
+          image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "contextmine.postgresql.host" . }} {{ include "contextmine.postgresql.port" . }}; do echo waiting for postgres; sleep 2; done']
         # Wait for Prefect server to be ready
         - name: wait-for-prefect
-          image: busybox:1.36
+          image: busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
           command: ['sh', '-c', 'until nc -z {{ include "contextmine.fullname" . }}-prefect {{ .Values.prefect.service.port }}; do echo waiting for prefect; sleep 2; done']
       containers:
         - name: worker

--- a/deploy/helm/contextmine/values.yaml
+++ b/deploy/helm/contextmine/values.yaml
@@ -14,7 +14,7 @@ postgresql:
   enabled: true
   image:
     repository: ghcr.io/mayflower/pg4ai
-    tag: latest
+    tag: "latest@sha256:6489ff6174117b54fa25bebd5bce5c647258f833c1c68ff015e4f7c46f2f7802"
   # -- External PostgreSQL configuration (used when enabled: false)
   external:
     host: ""
@@ -74,7 +74,7 @@ api:
 prefect:
   image:
     repository: prefecthq/prefect
-    tag: 3-python3.12
+    tag: "3-python3.12@sha256:6c0dc14195cae814eddeb66104a8333810a0a9886a5d7f0c45443136f167b3e0"
   # -- Number of replicas (should be 1 for Prefect server)
   replicaCount: 1
   # -- Resource limits
@@ -146,7 +146,7 @@ codecharta:
   enabled: true
   image:
     repository: codecharta/codecharta-visualization
-    tag: latest
+    tag: "latest@sha256:c72f6ed979dcbaaf4e08289a5c3e34d9c872f564a70ceb4b5252318209f10d35"
   # -- Number of replicas
   replicaCount: 1
   # -- Service configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: ghcr.io/mayflower/pg4ai:latest
+    image: ghcr.io/mayflower/pg4ai:latest@sha256:6489ff6174117b54fa25bebd5bce5c647258f833c1c68ff015e4f7c46f2f7802
     platform: ${POSTGRES_PLATFORM:-linux/amd64}
     ports:
       - "5433:5432"
@@ -43,7 +43,7 @@ services:
       start_period: 10s
 
   codecharta:
-    image: codecharta/codecharta-visualization:latest
+    image: codecharta/codecharta-visualization:latest@sha256:c72f6ed979dcbaaf4e08289a5c3e34d9c872f564a70ceb4b5252318209f10d35
     ports:
       - "${CODECHARTA_PORT:-9001}:80"
     healthcheck:
@@ -54,7 +54,7 @@ services:
 
   # Prefect stack
   prefect-server:
-    image: prefecthq/prefect:3-python3.12
+    image: prefecthq/prefect:3-python3.12@sha256:6c0dc14195cae814eddeb66104a8333810a0a9886a5d7f0c45443136f167b3e0
     command: prefect server start --host 0.0.0.0
     ports:
       - "4200:4200"
@@ -105,7 +105,7 @@ services:
   # Optional: OpenTelemetry Collector for local development
   # Start with: docker compose --profile otel up
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
+    image: otel/opentelemetry-collector-contrib:latest@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc
     profiles: ["otel"]
     ports:
       - "4317:4317"   # OTLP gRPC

--- a/docs/KNOWLEDGE_GRAPH.md
+++ b/docs/KNOWLEDGE_GRAPH.md
@@ -98,6 +98,7 @@ await build_erm_graph(session, collection_id, schema)
 
 # Generate Mermaid ERD
 from contextmine_core.analyzer.extractors.erm import generate_mermaid_erd
+
 erd = generate_mermaid_erd(schema)
 ```
 
@@ -173,7 +174,12 @@ To disable LLM labeling, simply don't call `label_rule_candidates()`.
 Graph-augmented retrieval combines semantic search with knowledge graph:
 
 ```python
-from contextmine_core.graphrag import graph_rag_context, graph_rag_query, graph_neighborhood, trace_path
+from contextmine_core.graphrag import (
+    graph_rag_context,
+    graph_rag_query,
+    graph_neighborhood,
+    trace_path,
+)
 
 # Context retrieval (for building prompts)
 context = await graph_rag_context(
@@ -185,7 +191,7 @@ context = await graph_rag_context(
 )
 
 print(context.to_markdown())  # Human-readable with citations
-print(context.to_dict())      # JSON-serializable
+print(context.to_dict())  # JSON-serializable
 
 # Full answered query (with LLM)
 answer = await graph_rag_query(

--- a/docs/design/grounded-llm-detection.md
+++ b/docs/design/grounded-llm-detection.md
@@ -95,23 +95,33 @@ rules so individual detectors do not re-implement prompt plumbing or validation.
 
 ```python
 class Candidate(BaseModel):
-    id: str                      # stable id the LLM must reference
-    label: str                   # human-readable
-    payload: dict[str, Any]      # features shown to the model
+    id: str  # stable id the LLM must reference
+    label: str  # human-readable
+    payload: dict[str, Any]  # features shown to the model
+
 
 class Evidence(BaseModel):
-    id: str                      # "ev-N"
-    ref: str                     # file:line / node id / edge id
+    id: str  # "ev-N"
+    ref: str  # file:line / node id / edge id
     snippet: str
 
-class Finding(BaseModel):        # base class detectors extend
-    candidate_ids: list[str]     # validated subset of supplied candidates
-    evidence_ids: list[str]      # validated subset of supplied evidence
+
+class Finding(BaseModel):  # base class detectors extend
+    candidate_ids: list[str]  # validated subset of supplied candidates
+    evidence_ids: list[str]  # validated subset of supplied evidence
     rationale: str
 
+
 async def judge(
-    *, provider, system, task, candidates, evidence, output_schema,
-    allow_abstain=True, samples=1,
+    *,
+    provider,
+    system,
+    task,
+    candidates,
+    evidence,
+    output_schema,
+    allow_abstain=True,
+    samples=1,
 ) -> JudgeResult[T]: ...
 ```
 

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -6,7 +6,7 @@ the commands used to refresh the snapshot. It is not a request to upgrade every
 package in one change.
 
 Snapshot date: **2026-09-01**  
-Repository baseline: **5691da2e591781847cc2be81f9cd9c4abda9b8c4**
+Repository baseline: **ea266bd16c8fbebda569c1cb9b9f81e4be1801a2**
 
 ## Inventory Summary
 
@@ -22,6 +22,35 @@ The Python requirements use lower bounds while `uv.lock` supplies the exact
 resolved environment. This makes the lockfile essential: a fresh unlocked
 resolution may cross major-version boundaries even when a manifest was not
 edited.
+
+## Pinned Runtime Inputs
+
+Third-party image tags remain in each reference as a readable update channel,
+but an OCI digest fixes the bytes used by builds, local Compose, Helm defaults,
+and CI. The application image tags in the Helm values are release outputs and
+remain deployment overrides rather than upstream dependency pins.
+
+| Input | Immutable selector |
+| --- | --- |
+| Node build image | `node:24-alpine@sha256:e67514e5d0f6c46656005e1b693b2ec9d52e80b641307de684d4a015ba7a4eaf` |
+| Node runtime image | `node:24-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e` (`24.20.0`) |
+| Python runtime image | `python:3.12-slim@sha256:e5c9fa26ffb76e11e0f054f30dc2523a2f9693f0c36c0cf1e39b27e152d899fc` |
+| Rust builder image | `rust:1.88-slim@sha256:38bc5a86d998772d4aec2348656ed21438d20fcdce2795b56ca434cf21430d89` |
+| uv build image | `ghcr.io/astral-sh/uv:latest@sha256:d1cbaeadc234fe19c0d93daabcf5e98738cd93c6d1dd4918ef6aa30735feb23a` (`0.12.8`) |
+| pg4ai | `ghcr.io/mayflower/pg4ai:latest@sha256:6489ff6174117b54fa25bebd5bce5c647258f833c1c68ff015e4f7c46f2f7802` |
+| Prefect server | `prefecthq/prefect:3-python3.12@sha256:6c0dc14195cae814eddeb66104a8333810a0a9886a5d7f0c45443136f167b3e0` (`3.8.4`) |
+| CodeCharta | `codecharta/codecharta-visualization:latest@sha256:c72f6ed979dcbaaf4e08289a5c3e34d9c872f564a70ceb4b5252318209f10d35` |
+| OpenTelemetry Collector | `otel/opentelemetry-collector-contrib:latest@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc` (`0.159.0`) |
+| Semgrep CI image | `semgrep/semgrep:latest@sha256:f1f7b71861c7b28b6e0f661225a2c4f58a484f5d0f182465c6d6b3b22f972ade` |
+| Helm init image | `busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662` |
+| pgvector fallback image | `pgvector/pgvector:pg16@sha256:ccc6e83d6e35e931dc7c5def2022729d5a6c370318d099181995567ff1fb4d6b` |
+
+The worker additionally pins the Coursier launcher to commit
+`15f36c167c30be237105f923151adaf177e7ee61` with per-architecture checksums,
+Composer to version `2.10.3` with its PHAR checksum, and scip-php to commit
+`efaf87cd05cf174db8ac25ad4d07eb646d4883d1` with an archive checksum. scip-php
+is installed from its committed `composer.lock`, so its Composer dependency
+graph is not resolved from `dev-main` during an image build.
 
 ## Component Ownership
 
@@ -67,13 +96,11 @@ A read-only refresh on the snapshot date found a broad pending set:
 - `cargo update --dry-run` proposes 121 compatible lock changes, including
   `spider 2.52.4 -> 2.53.6`. This is a lock refresh, not evidence that a future
   direct major is safe.
-- Compose and the default Helm values still contain floating `latest` tags for
-  operational images. Docker base images and the copied uv binary are also tag
-  based. The worker additionally fetches the Coursier launcher from `master`,
-  the Composer installer dynamically, and scip-php from `dev-main`; the other
-  SCIP versions are build arguments with defaults. These are part of the
-  dependency inventory even though language package bots do not cover them
-  reliably.
+- Third-party operational images, Docker base images, the copied uv binary,
+  Coursier, Composer, and scip-php now have immutable selectors. The hosted
+  GitHub runner labels and the application image tags emitted by the release
+  workflow remain moving operational surfaces; the latter must be replaced by
+  release-specific tags or digests at deployment time.
 
 Do not combine these sets into one upgrade. The counts are a triage signal, not
 a target change list.
@@ -147,6 +174,13 @@ Also review image tags and action references:
 
 ```bash
 rg -n 'uses:|image:|FROM ' .github apps scripts docker-compose.yml deploy/helm
+```
+
+Resolve a reviewed image tag to its multi-platform manifest digest before
+changing a pin:
+
+```bash
+docker buildx imagetools inspect <image>:<tag>
 ```
 
 Record the date and baseline commit whenever the snapshot is refreshed.

--- a/docs/scip_polyglot_indexing.md
+++ b/docs/scip_polyglot_indexing.md
@@ -43,9 +43,9 @@ The same snapshot data is also the structural input for Twin/Cockpit real metric
 
 ```python
 from contextmine_core.semantic_snapshot import (
-    build_snapshot,      # Parse .scip file → Snapshot
-    detect_projects,     # Detect language projects in a repo
-    index_repo,          # Run SCIP indexers on detected projects
+    build_snapshot,  # Parse .scip file → Snapshot
+    detect_projects,  # Detect language projects in a repo
+    index_repo,  # Run SCIP indexers on detected projects
 )
 
 # Detect projects in a repository
@@ -71,11 +71,13 @@ class Language(Enum):
     JAVA = "java"
     PHP = "php"
 
+
 @dataclass
 class ProjectTarget:
     language: Language
     root_path: Path
     metadata: dict[str, Any]  # e.g., {"build_tool": "maven"}
+
 
 @dataclass
 class IndexArtifact:
@@ -88,6 +90,7 @@ class IndexArtifact:
     duration_s: float
     success: bool = True
     error_message: str | None = None
+
 
 @dataclass
 class IndexConfig:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ dependencies = []
 
 [dependency-groups]
 dev = [
-    "ruff>=0.15.19",
-    "ty>=0.0.53",
+    "ruff>=0.16.5",
+    "ty>=0.0.77",
     "pytest>=9.1.1",
     "pytest-cov>=7.1.0",
     "anyio[trio]>=4.14.1",
     "pytest-anyio>=0.0.0",
     "httpx>=0.28.1",
-    "pre-commit>=4.6.0",
+    "pre-commit>=4.6.2",
     "grpcio-tools>=1.81.1",
 ]
 

--- a/scripts/docker/postgres/Dockerfile
+++ b/scripts/docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM pgvector/pgvector:pg16
+FROM pgvector/pgvector:pg16@sha256:ccc6e83d6e35e931dc7c5def2022729d5a6c370318d099181995567ff1fb4d6b
 
 # Create init script inline to avoid permission issues
 RUN echo '#!/bin/sh\n\

--- a/uv.lock
+++ b/uv.lock
@@ -509,12 +509,12 @@ dev = [
     { name = "anyio", extras = ["trio"], specifier = ">=4.14.1" },
     { name = "grpcio-tools", specifier = ">=1.81.1" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "pre-commit", specifier = ">=4.6.0" },
+    { name = "pre-commit", specifier = ">=4.6.2" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-anyio", specifier = ">=0.0.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "ruff", specifier = ">=0.15.19" },
-    { name = "ty", specifier = ">=0.0.53" },
+    { name = "ruff", specifier = ">=0.16.5" },
+    { name = "ty", specifier = ">=0.0.77" },
 ]
 
 [[package]]
@@ -2761,7 +2761,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.0"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -2770,9 +2770,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
 ]
 
 [[package]]
@@ -3704,27 +3704,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.19"
+version = "0.16.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d5/e6/15800dfde183a1a106594016c912b4c12d050a301989d1aca6cb63759fe8/ruff-0.15.19.tar.gz", hash = "sha256:edc27f7172a93b32b102687009d6a588508815072141543ae603a8b9b0823063", size = 4772071, upload-time = "2026-06-24T01:10:46.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/4c/9ded7626c39a0440c575bf69e2bf500d443388272c842662c59852ee7fcd/ruff-0.15.19-py3-none-linux_armv6l.whl", hash = "sha256:922d1eb283161564759bd49f507e91dc6112c15da8bd5b84ed714e086243cf86", size = 10950859, upload-time = "2026-06-24T01:10:38.491Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/ef/c211505ece1d00ef493d58e54e3b6383c946a21e9874774eb531f2512cf3/ruff-0.15.19-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:4d190d8f62a0b94aba8f721116538a9ee29b1e74d26650846ba9b99f0ae21c40", size = 11294529, upload-time = "2026-06-24T01:10:36.481Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/93/78d462e7d39968e58094dc57be7d09ffb14ce37da5b68ed70338a35a1f21/ruff-0.15.19-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a2c86ba6870dd415a9d9eb8be94d7924ebec6a26ffc7958ec7ca29d4bff967d", size = 10641416, upload-time = "2026-06-24T01:10:48.923Z" },
-    { url = "https://files.pythonhosted.org/packages/76/c4/5cb66cfd1f865d5cca908b86c93ac785e7f572193d3c7426079ca6643e24/ruff-0.15.19-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b432bc087264aea70fd25ac198918b70bd9e2aa0db4297b0bb91bbfbbc63ce", size = 11015582, upload-time = "2026-06-24T01:10:30.089Z" },
-    { url = "https://files.pythonhosted.org/packages/51/9f/8ecfaec10cf5eecd28fbc00ff4fb867db90a1be54bf3d39ebf93f893cd52/ruff-0.15.19-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8530a09d03b3a8c994f8b559a7dcdabc690bcd3f78ef276c38c83166798ebf56", size = 10744059, upload-time = "2026-06-24T01:10:32.48Z" },
-    { url = "https://files.pythonhosted.org/packages/35/6b/983249d04562bc2d590edd75f32455cdb473affb3ba4bc8d883e939c697d/ruff-0.15.19-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87bf21fb3875fe69f0eacc825411657e2e85589cce633c35c0adf1113649c62b", size = 11568461, upload-time = "2026-06-24T01:10:17.435Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/39/bc7794f127b18f492a3b4ee82bba5a900c985ff13b72b46f46e3c171ba34/ruff-0.15.19-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b229cb3ef56ecc2c1c8ebeca64b7a7740ccaef40a9eb097e78dde5a8560b83", size = 12429690, upload-time = "2026-06-24T01:10:40.638Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/3b/0de6859e698ed11c8a49e765196c8d333599b6a546c0715df39b6ba1aa2e/ruff-0.15.19-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6c754515be7b76afe6e7e62df7776709571bcfc1631183828afcf3bafa869e3", size = 11693067, upload-time = "2026-06-24T01:10:25.681Z" },
-    { url = "https://files.pythonhosted.org/packages/89/3d/0b1f30f84bee9ae6ae8d349c2ba8b6f4b040966744efdd3acc804ae7c024/ruff-0.15.19-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a498f82e0f4d8904c4e0aea5139cdfac1f39d19a3c51d491292f63a36e83b2e", size = 11616911, upload-time = "2026-06-24T01:10:44.809Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/eb/c90bd3dfc12eed9032c2c1bfe05105b93a1b2c8bce555db6308315b853ce/ruff-0.15.19-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:d48caa34488fb521fd0ef4aea2b0e8fe758298df044138f0d67b687a6a0d07ed", size = 11649343, upload-time = "2026-06-24T01:10:23.472Z" },
-    { url = "https://files.pythonhosted.org/packages/82/91/01caa13602a2f12fae5edbe8caf78b3c1e6db1293132aee6959eecce095c/ruff-0.15.19-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4171b6613effa9363cd46dd4f75bd1827b6d1b946b5e278ed0c600d305379445", size = 10977610, upload-time = "2026-06-24T01:10:50.892Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/51/acb817922feab9ecbb3201377d4dbe7a25f1395e46545820061973f03468/ruff-0.15.19-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:27c15b2a241dd4d995557949a094fe78b8ad99122a38ccae1595849bcc947b3f", size = 10744900, upload-time = "2026-06-24T01:10:42.726Z" },
-    { url = "https://files.pythonhosted.org/packages/84/bc/5c8ca46b8a7a3f2b16cfbec88721d772b1c93912904e8f8c2e49470fea63/ruff-0.15.19-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ed03b7862d68f0a8771d50ee129980cbf1b113f96e250b73954bc292f689e0bb", size = 11293560, upload-time = "2026-06-24T01:10:21.262Z" },
-    { url = "https://files.pythonhosted.org/packages/81/e0/4a888cbe4d5523b3f77a2b1fa043f46cfeba1b32eac35dcfadee0578fa8a/ruff-0.15.19-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:08143f0685ae278b30727ea72e90c61e5bd9c31b91aac4f5bb989538f73d24b8", size = 11696533, upload-time = "2026-06-24T01:10:53.046Z" },
-    { url = "https://files.pythonhosted.org/packages/98/43/c34b2fcd79262a85161764a97aaca89c3e4f574340ab61430cefa2bdd2c1/ruff-0.15.19-py3-none-win32.whl", hash = "sha256:8f47f0f92952af2557212bb10cf3e695cd4cf28b2c6e42cdb18ec6c9ebfa19da", size = 10986299, upload-time = "2026-06-24T01:10:55.185Z" },
-    { url = "https://files.pythonhosted.org/packages/22/e8/15fd23e02b2442b56b2026b455977bc3057aa34b26e6323d1e99e8531a9f/ruff-0.15.19-py3-none-win_amd64.whl", hash = "sha256:efeca47ee3f9d4a7162655a3b8e6ee4a878646044233978d4d2c1ff8cdd914f0", size = 12123473, upload-time = "2026-06-24T01:10:27.74Z" },
-    { url = "https://files.pythonhosted.org/packages/30/66/9a73695e31eaee04f35d8475998bf8ab354465f9c638936d76111603dcc5/ruff-0.15.19-py3-none-win_arm64.whl", hash = "sha256:6c6b607466e47349332eb1d9be52fb1467423fc07c217341af41cd0f3f0573be", size = 11376779, upload-time = "2026-06-24T01:10:34.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
 ]
 
 [[package]]
@@ -4074,27 +4074,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.53"
+version = "0.0.77"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/87/d5a1d099a41ed22f939b9eec5af3c40bd907409e673cc0b8fcfd1e354ab2/ty-0.0.53.tar.gz", hash = "sha256:86e8c522b1a1ae267cd6442cc93c0c954a2a59b89565e4fb493c1133bd5a056e", size = 5998692, upload-time = "2026-06-24T06:53:57.021Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ef/a2024d1d33d5ba8436677a6fd734f87a137150aba99906fc009f7c5de956/ty-0.0.77.tar.gz", hash = "sha256:8898f3097610f4a772ead6bfad7b204c7d76e8eb3a010c7285b9186278e0fb82", size = 7005734, upload-time = "2026-09-01T00:26:26.901Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/4a/1364826b7747a6ca6de4c3b1a47b6ed6e4d27d76236c704f02ccc2624686/ty-0.0.53-py3-none-linux_armv6l.whl", hash = "sha256:637f3c8e4837973c530d659cbd9a6697c12141b61b458214570a95048064acf5", size = 12034508, upload-time = "2026-06-24T06:53:18.729Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/55/9edc86267086c1d0be32b0625f2cae4bd269f62e9f0084f5469d5a7ada9e/ty-0.0.53-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5b1079f5f18667362e6a2df0c08eef83b99cc7ec1f1e6bd6a43eb17087a62da2", size = 11793873, upload-time = "2026-06-24T06:53:21.188Z" },
-    { url = "https://files.pythonhosted.org/packages/17/9b/92f080253ca27ad60f4a982f1d6e67fce1ab117514b8b51a25ed3e64a6b2/ty-0.0.53-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0699807f3333c052120998d0f652f9e13d534b16cbb4f04397885569e2889e5", size = 11190702, upload-time = "2026-06-24T06:53:23.216Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/5b/fb3727c810bc9d131e74f21ed23ab04b2f6027a34f6399528c1adf1fc48c/ty-0.0.53-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fded06aeb8fbb0eb30d3164bba6d42446ca0f92268bd13668e636d984ff5ae32", size = 11711062, upload-time = "2026-06-24T06:53:25.312Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/0b/e542864d10d84f6bd7e19b76578cb1f80ef83aac208f3dc0cafdf22ce924/ty-0.0.53-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4c890c34364d020f9aead3737fd00b06bb57981d5689825dd7face9caf89b92", size = 11801237, upload-time = "2026-06-24T06:53:27.437Z" },
-    { url = "https://files.pythonhosted.org/packages/75/61/f00b26d3618b8e4399d7b86a380867ff62ade8347650234fd50f74585863/ty-0.0.53-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aeb2d2be32efc1c937551b5bdb6f94c96b330baac9cc12e69a91c82d2fdad5d9", size = 12324525, upload-time = "2026-06-24T06:53:29.537Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/01/63ce174e9a330e2c90f829fe523c737c2ecc7b5504a7a43f44866069e0fd/ty-0.0.53-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b175ce1a92e382991341a9ad2760de5d87b7b88c509a6ac26cbfcd5c723a3179", size = 12925679, upload-time = "2026-06-24T06:53:31.912Z" },
-    { url = "https://files.pythonhosted.org/packages/14/98/129a2cd39b0e5ba72b748b46134fd278c749802389899eefc9320689e39c/ty-0.0.53-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c9a145dfe24bb0be4a99d10480ccc0c7e5a7e36cf371d0a57bd7001cfd9bef5", size = 12551302, upload-time = "2026-06-24T06:53:33.993Z" },
-    { url = "https://files.pythonhosted.org/packages/23/0a/778deab4b31e3f6879073c668a4851de41f96174b5ff6bc8971c7d01d7b3/ty-0.0.53-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0664e9f707a4937e292ae83403e0486f610107b76f25e0987fec1bcda04121", size = 12353792, upload-time = "2026-06-24T06:53:36.347Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/d2/f0823fd73233b9fdec9f90af2069b4a05f86b57da3bf274bd18744e8a1be/ty-0.0.53-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9eef1fc8e273f946103b264431ef314b72d2cbf50f0ef790f09fd308ec061259", size = 12600311, upload-time = "2026-06-24T06:53:38.615Z" },
-    { url = "https://files.pythonhosted.org/packages/70/21/ac64b9253223379b2e8e34900d852b3f561d5bb1b818caafda64f561fe79/ty-0.0.53-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d0afb96763442dc3dead88573e24d991bee9d4c52dbb57dee4c900c401dc269b", size = 11671972, upload-time = "2026-06-24T06:53:40.893Z" },
-    { url = "https://files.pythonhosted.org/packages/55/1a/dc83c6b89683cc18a060611f7e7836abb3211744ace1ab0174cb96533a7b/ty-0.0.53-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f56edd323fcf95801c9487dd85e3b7bb329313adcd58d8d057b0823e30b579c4", size = 11832266, upload-time = "2026-06-24T06:53:43.048Z" },
-    { url = "https://files.pythonhosted.org/packages/45/e3/7c11d218da1b5ccadf4b6ddab83b54333703e0bcdadb1d912093c16324fb/ty-0.0.53-py3-none-musllinux_1_2_i686.whl", hash = "sha256:93f13cc1616fcf38df280263631121770e915d823b66b82a13a12d4e43bafb37", size = 11974033, upload-time = "2026-06-24T06:53:45.387Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/bb/af534430d07cf26b30f7ca76ac0f34df11bc3957d92eb29597ffa803626b/ty-0.0.53-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:de583808d93f7b6c93e1841deb4db5b181d8a7a1503c674f8143d6e06f2c67a2", size = 12462111, upload-time = "2026-06-24T06:53:47.76Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/cb/0ba395d495669d2c022f8c0df4451ec0fc8f0d81fbc5d4fcf6f4f25ab98d/ty-0.0.53-py3-none-win32.whl", hash = "sha256:c58318cd7835aab2d1cd26d6995d3b776bf40800aa45eeb32e8e60e912863fc8", size = 11297877, upload-time = "2026-06-24T06:53:50.575Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/49/7fe9cec8f0e35b71e6935d753c8c7acf7731f787355b5f6a85f10f9f07bb/ty-0.0.53-py3-none-win_amd64.whl", hash = "sha256:4e3e24605c960dc6ce8ee8cd2ccb6dee2a1acbbded96ac62329ee4f200605235", size = 12414620, upload-time = "2026-06-24T06:53:52.896Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/f8/355b115b42f74bce0be582232a68b7e21d9cac43c77e005dfaa486e79873/ty-0.0.53-py3-none-win_arm64.whl", hash = "sha256:ea0e13311c6f386b36f1c76be114121a1ad7da38f025b143ae193899816ca791", size = 11772715, upload-time = "2026-06-24T06:53:55.132Z" },
+    { url = "https://files.pythonhosted.org/packages/48/03/930f7454a6d797abc09aebbf537017825ebb08d9f8c2e2d905e74341dbb1/ty-0.0.77-py3-none-linux_armv6l.whl", hash = "sha256:ea76012f1ed387b6fc6500894fb8a7654b724c38713e263a23f12756f00e2469", size = 13241626, upload-time = "2026-09-01T00:25:51.02Z" },
+    { url = "https://files.pythonhosted.org/packages/65/41/7e064045775718673851f6c0e1cfde70d6e380b0db9d91d4484a362f2d67/ty-0.0.77-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:237a58c389e01d65c4693e0394feb0f0adea3fba0345c3b932d209084372f3d3", size = 12830037, upload-time = "2026-09-01T00:25:53.172Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/64/66f0b0dc89bd239922bdf12fa3e6d066aa7a425e8b70414368c4eb44a6e6/ty-0.0.77-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bbb8ae7a753b9a6af25725c314d0eca967e5fde5eebb7a35b04b0d763dfb9d7c", size = 12612071, upload-time = "2026-09-01T00:25:55.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/5c/bef8b1f471931a9395792be023613b6cee0ef1449815bf97b18be07f883c/ty-0.0.77-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:603620c063b718ddbe302f83fb0d7c01a13f1941c3b9763512a89c9bbfabba96", size = 12641403, upload-time = "2026-09-01T00:25:57.305Z" },
+    { url = "https://files.pythonhosted.org/packages/43/66/e4d32a0145162f79bc3dd6fca4770f88966c3b5206121ffeecd5f7b05e8b/ty-0.0.77-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03f128cb8b204e22a18f4b01ef0194aa445f4edb080cb7d77621cb2ab353885c", size = 13013526, upload-time = "2026-09-01T00:25:59.278Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/be/33493ee43d4db7d402ceaee55c5d6c22e2b1105f10b1ac5928c220f79650/ty-0.0.77-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:97d1600ef69fc8e3b2310de1915cd34ba3b712fdc730cb02b713520956baec0a", size = 13828076, upload-time = "2026-09-01T00:26:01.343Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d5/b6335fdc8c09aaaaf6541322076c5a7205fa16c29dbeddc1f24dd89b3894/ty-0.0.77-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dced0924a83b6d945fd48a29aa85e131fb98dc574f4c9a0e7c43d03eff373402", size = 14247770, upload-time = "2026-09-01T00:26:03.388Z" },
+    { url = "https://files.pythonhosted.org/packages/11/64/bbe96c1da26585919ac10f33df1d337d9b498013fc60c5178e76955c2a53/ty-0.0.77-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b14b002233a954115a04932b3a93d75a387569848276cf7bb0b5dc6b040001c4", size = 13926528, upload-time = "2026-09-01T00:26:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cdc94e9a1b69e9b7dd0ec3ad3ca75741245b8b5b2e3ffe9b365ca31d8052/ty-0.0.77-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:581adf1ae1e48e00e89ec162913d559ddf75a7805646a13ffd68943c1b5e8daa", size = 13290834, upload-time = "2026-09-01T00:26:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8c/4929dd8e924ddbd6284dcb3cfbda488bd6cb091e5384f8b7fb5dd3de9122/ty-0.0.77-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9bda523b40e06c643feb6d5d5bcbacc56a2bd9eed3d7cae1119452502bcd69b0", size = 13829048, upload-time = "2026-09-01T00:26:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f4/441a74ddc5e2db2690264c1ee0e478d46b8e42bd529472fdb1656b63bff2/ty-0.0.77-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4b8b04d8c3af8148e963e950094bd53c8cc4d3a11f5f8764ff8d39627bd6e64a", size = 12803755, upload-time = "2026-09-01T00:26:12.055Z" },
+    { url = "https://files.pythonhosted.org/packages/85/39/875bb7092ee1edb090b62eca74b7311f6416dc3aa7da442b4a1f95408251/ty-0.0.77-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:33a9ff9be488edf4d6fac46c456198cc848d9641f418f1a83aa123825e93c6ec", size = 13028244, upload-time = "2026-09-01T00:26:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/76/4b0a48f118dca6a32e1609f2d0bea2c3f7be9051af645fe5044ca35cbbb4/ty-0.0.77-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61ad5467206e5ea6531c8aebebf1276c6150989a94a1d5974a84d9e0eeed5c38", size = 13321068, upload-time = "2026-09-01T00:26:16.418Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/46/cd21bc6441df4b221d9e131551bab2a5f9c0b724e60e1c960622ee175128/ty-0.0.77-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1293b94f26d1f330424e3b97c20b434f7e2ac1938287b8588466c75ece6c0b10", size = 13609112, upload-time = "2026-09-01T00:26:18.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/0da4537a7eca4eb3ca72a2cb4539cfbb6fb3138d1dc4ae7a66299b941fb3/ty-0.0.77-py3-none-win32.whl", hash = "sha256:cb71152bdf56860375c790682cc3efc120aaf8e36f1cd6367773312905e82b50", size = 12573821, upload-time = "2026-09-01T00:26:20.404Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/aec75b11bfaa5a358f5a505afa6307fc4bee1c5f4c6444e18fa82c25f3be/ty-0.0.77-py3-none-win_amd64.whl", hash = "sha256:86f01d4af8b006c9442a2de0ab949cc24462f8f9431bebc0b73f6166fbbca19f", size = 13154851, upload-time = "2026-09-01T00:26:22.389Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e5/77772f95ff81bf7c817595cd08b52d007acab90dac0f2339faa486e6a525/ty-0.0.77-py3-none-win_arm64.whl", hash = "sha256:942a3bb2a4786c80bd8ef4503e5024046617cdfcc550b56c1acc4817ce7ac144", size = 12992392, upload-time = "2026-09-01T00:26:24.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This pull request contains two separately reviewable checkpoints:

1. Pin movable runtime and build inputs.
   - Pin third-party container references in Dockerfiles, Compose, Helm defaults, and CI to reviewed OCI digests.
   - Replace mutable NodeSource installation with a pinned official Node image.
   - Pin the Coursier launcher, Composer PHAR, and scip-php source by immutable revision and checksum.
   - Install scip-php from its committed lockfile instead of resolving `dev-main` during the worker build.
2. Update Python development tools.
   - Update Ruff from 0.15.19 to 0.16.5, ty from 0.0.53 to 0.0.77, and pre-commit from 4.6.0 to 4.6.2.
   - Keep pytest 9.1.1 and pytest-cov 7.1.0 because they are already current.
   - Apply only the Markdown code-block formatting newly required by Ruff 0.16.5.

## Live verification

Each checkpoint was independently exercised with the complete model-free system gate:

`./scripts/smoke/model-free-system.sh`

Both runs used `fastapi/full-stack-fastapi-template@486f054cc8d1aead59ec96cc0a16933d06c10e0d` and completed with model calls disabled. Each run proved:

- live API and web container startup, Chromium login/static/API-proxy smoke, and raw TypeScript LSP definition and hover requests;
- worker image construction with the pinned Node, Coursier, Composer, scip-php, SCIP, and LSP toolchain;
- real ContextMine multilspy cache, hover, and cross-file definition requests;
- a fresh PostgreSQL migration;
- 210 indexed documents, 691 chunks, 553 persisted symbols, four SCIP projects, 2,652 SCIP symbols, and 5,998 SCIP relations;
- 4,665 persisted knowledge nodes and 4,621 persisted Twin nodes;
- ten search results and a successful no-op second synchronization.

Joern remains advisory in this model-free gate and was skipped because `joern-parse` is not installed.

## Additional validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `docker compose -f scripts/smoke/docker-compose.yml config --quiet`
- `helm lint deploy/helm/contextmine`
- `git diff --check`
