### PR TITLE
Update remaining GitHub Actions to Node 24 releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
       # SonarQube scan. Advisory: a Sonar server outage (e.g. HTTP 500 from the
       # analysis API) should not fail the build. The quality gate below is also
       # intentionally not enforced.
-      - uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
+      - uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         continue-on-error: true
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Upload Playwright failure artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-failure-${{ github.run_attempt }}
           path: |
@@ -204,10 +204,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}-${{ matrix.name }}
           tags: |
@@ -223,7 +223,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push ${{ matrix.name }}
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -245,7 +245,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
         run: semgrep scan --config auto --config p/python --config p/security-audit --error --json --output semgrep-results.json .
 
       - name: Upload results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: semgrep-results
@@ -40,7 +40,7 @@ jobs:
         run: uvx bandit -r apps packages -c pyproject.toml -f json -o bandit-results.json
 
       - name: Upload results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: bandit-results


### PR DESCRIPTION
## Summary

- update actions/upload-artifact to v7.0.1
- update the Docker setup, login, metadata, and build/push actions to their current major releases
- update Azure/setup-helm to v5.0.1
- update SonarSource/sonarqube-scan-action to v8.2.1
- keep every third-party action pinned to its verified full commit SHA
- complete the move of active JavaScript actions to current Node 24-based releases

## Compatibility review

- reviewed each upstream major-release migration note
- confirmed the workflows do not use removed setup-buildx inputs or removed build-push environment variables
- retained signature verification for the official SonarScanner download
- GitHub-hosted runners satisfy the documented minimum runner requirement

## Validation

- git diff --check
- verified every release tag against its upstream commit SHA
- completed the model-free full-system gate against fastapi/full-stack-fastapi-template at 486f054cc8d1aead59ec96cc0a16933d06c10e0d
- verified API and web builds, browser login and API proxying, TLS definition/hover/initialize, worker startup, multilspy, migrations, and a real sync
- first sync persisted 210 documents, 691 chunks, 553 symbols, 4,665 knowledge nodes, and 4,621 twin nodes
- metrics gate and second-sync no-op assertion passed

Joern remained advisory because joern-parse is not installed in the gate environment.