### PR TITLE
Install dirmngr for SonarScanner signature verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,11 @@ jobs:
       # SonarQube scan. Advisory: a Sonar server outage (e.g. HTTP 500 from the
       # analysis API) should not fail the build. The quality gate below is also
       # intentionally not enforced.
+      - name: Install SonarScanner signature verification dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends dirmngr
+
       - uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         continue-on-error: true
         env:


### PR DESCRIPTION
## Summary

- install dirmngr before running SonarSource/sonarqube-scan-action v8.2.1
- allow GPG to contact the SonarSource primary and fallback keyservers
- retain the secure default signature verification instead of setting skipSignatureVerification

## Context

The first main run after the Sonar action upgrade exposed a missing runner dependency. GPG was present, but both key imports failed before network access because /usr/bin/dirmngr was not installed. The existing advisory continue-on-error setting kept the overall workflow green, so this failure was only visible in the step annotations and logs.

## Validation

- git diff --check
- reviewed the Sonar v8.2.1 action definition and GPG implementation
- completed the model-free full-system gate against fastapi/full-stack-fastapi-template at 486f054cc8d1aead59ec96cc0a16933d06c10e0d
- verified API and web builds, browser login and API proxying, TLS and multilspy checks, migrations, and a real Prefect sync
- first sync persisted 210 documents, 691 chunks, 553 symbols, 4,665 knowledge nodes, and 4,621 twin nodes
- metrics gate and second-sync no-op assertion passed

The Sonar step only runs on main, so its successful signed scanner download will also be verified on the post-merge main workflow.