### PR TITLE
Align Prefect client with the pinned server

### DIFF
--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -5,7 +5,7 @@ description = "ContextMine Prefect worker for syncing sources"
 requires-python = ">=3.12"
 dependencies = [
     "contextmine-core[lsp]",
-    "prefect>=3.7.5",
+    "prefect==3.8.4",
     "gitpython>=3.1.50",
     "langchain-text-splitters>=1.1.2",
     "openai>=2.44.0",

--- a/scripts/smoke/model-free-system.sh
+++ b/scripts/smoke/model-free-system.sh
@@ -41,6 +41,17 @@ docker compose \
   up --build --detach --wait --wait-timeout 300 \
   postgres prefect-server api web browser
 
+prefect_server_version="$(
+  docker compose \
+    --project-name "${compose_project}" \
+    --file "${compose_file}" \
+    exec --no-TTY prefect-server python -c 'import prefect; print(prefect.__version__)'
+)"
+if [[ -z "${prefect_server_version}" ]]; then
+  echo "Prefect server version could not be determined" >&2
+  exit 1
+fi
+
 docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
@@ -59,4 +70,6 @@ docker compose \
 docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
-  run --build --rm --no-deps smoke
+  run --build --rm --no-deps \
+  --env CONTEXTMINE_SMOKE_PREFECT_SERVER_VERSION="${prefect_server_version}" \
+  smoke

--- a/scripts/smoke/model_free_system.py
+++ b/scripts/smoke/model_free_system.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import prefect
 from contextmine_core import (
     Chunk,
     Collection,
@@ -60,6 +61,7 @@ def _require_environment(name: str) -> str:
 
 FIXTURE_PATH = Path(_require_environment("CONTEXTMINE_SMOKE_FIXTURE_DIR")).resolve()
 FIXTURE_REVISION = _require_environment("CONTEXTMINE_SMOKE_FIXTURE_REVISION")
+PREFECT_SERVER_VERSION = _require_environment("CONTEXTMINE_SMOKE_PREFECT_SERVER_VERSION")
 
 
 def _assert_fixture() -> None:
@@ -85,6 +87,16 @@ def _assert_api_health() -> None:
         connection.close()
     if payload != {"status": "ok"}:
         raise AssertionError(f"Unexpected API health response: {payload}")
+
+
+def _assert_prefect_versions() -> str:
+    client_version = prefect.__version__
+    if client_version != PREFECT_SERVER_VERSION:
+        raise AssertionError(
+            "Prefect client/server version mismatch: "
+            f"client={client_version}, server={PREFECT_SERVER_VERSION}"
+        )
+    return client_version
 
 
 def _forbid_model_provider(*_args: object, **_kwargs: object) -> None:
@@ -305,6 +317,7 @@ def _assert_noop_sync(result: dict[str, Any]) -> None:
 async def _run() -> None:
     _assert_fixture()
     _assert_api_health()
+    prefect_client_version = _assert_prefect_versions()
     settings = get_settings()
     if settings.model_calls_enabled:
         raise AssertionError("MODEL_CALLS_ENABLED must be false for this gate")
@@ -353,6 +366,10 @@ async def _run() -> None:
     summary = {
         "fixture": f"{FIXTURE_OWNER}/{FIXTURE_REPOSITORY}@{FIXTURE_REVISION}",
         "model_calls_enabled": False,
+        "prefect": {
+            "client": prefect_client_version,
+            "server": PREFECT_SERVER_VERSION,
+        },
         "first_sync": {
             key: first_stats.get(key)
             for key in (

--- a/uv.lock
+++ b/uv.lock
@@ -648,7 +648,7 @@ requires-dist = [
     { name = "lizard", specifier = ">=1.23.0" },
     { name = "lxml-html-clean", specifier = ">=0.4.5" },
     { name = "openai", specifier = ">=2.44.0" },
-    { name = "prefect", specifier = ">=3.7.5" },
+    { name = "prefect", specifier = "==3.8.4" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "trafilatura", specifier = ">=2.1.0" },
 ]
@@ -944,7 +944,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.138.0"
+version = "0.141.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -953,9 +953,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/58/ff455d9fe47c60abadb34b9e05a304b1f05f5ab8000ac01565156b6f5e43/fastapi-0.138.0.tar.gz", hash = "sha256:d445a4877636ad191e7053e08c9bf98cb921a6756776848400bb773d1740c061", size = 419240, upload-time = "2026-06-20T01:18:05.259Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/ff/8496d9847a5fedae775eb49460722d3efaa80487854273e9647ae876218c/fastapi-0.138.0-py3-none-any.whl", hash = "sha256:b6f54fd1bd72c80b0f899f172c61a600f6f7af9b43d4d772a018f35624048cb0", size = 126779, upload-time = "2026-06-20T01:18:03.483Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -2777,7 +2777,7 @@ wheels = [
 
 [[package]]
 name = "prefect"
-version = "3.7.5"
+version = "3.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2838,9 +2838,9 @@ dependencies = [
     { name = "websockets" },
     { name = "whenever", marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/b4/ba44a2263940b53db323d059770e005aac959d272ba2025ad6fc7de10cba/prefect-3.7.5.tar.gz", hash = "sha256:e2838fa80562bfb7e27e67ea63c7b13d6fdead8052dbe76eb394c6b919ef3dcd", size = 13881122, upload-time = "2026-06-18T22:39:17.378Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/8d/0844fb814a6a02f03fe87a1c26cc3b8236a9c1f3e16364883f89d101d99d/prefect-3.8.4.tar.gz", hash = "sha256:ab7d7980db95e90a949b09732147324b939d1daf9a754b19c122040ff6a3a559", size = 14614713, upload-time = "2026-08-25T17:37:40.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/30/e9c5ad5f3fd17f7309bcd9bab6af5cb5811ae3b50d7d0fd15a3ea899f5e0/prefect-3.7.5-py3-none-any.whl", hash = "sha256:214837b7cb1e10f8fec59018253cd8ef65c8b394b7df29c511b645b0ff5e4478", size = 14766992, upload-time = "2026-06-18T22:39:14.383Z" },
+    { url = "https://files.pythonhosted.org/packages/76/87/39588aab2c3b2e12bfd84d64bcb2fe605376dbd6450edaf9da0a30ea814e/prefect-3.8.4-py3-none-any.whl", hash = "sha256:f7b4a5be5e186c34ca73485060062ebb4277771df8441f78fcaea5f86c8aa012", size = 15563985, upload-time = "2026-08-25T17:37:36.818Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pin the worker Prefect dependency to 3.8.4, matching the self-hosted server image already pinned by immutable digest.
- Refresh the lockfile for Prefect 3.8.4 and its required FastAPI update from 0.138.0 to 0.141.1.
- Extend the model-free system gate to read the running server version and fail if the production worker client differs.

## Rationale

The worker lock still resolved Prefect 3.7.5 while the self-hosted server was already on 3.8.4. An exact client pin makes the intended pairing explicit and prevents an unrelated future lock refresh from silently reintroducing version drift.

Prefect 3.8.4 requires FastAPI 0.139.0 or newer. The resolver selected FastAPI 0.141.1, which is also the version contained in the pinned Prefect server image.

## Verification

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- Python test suite against a migrated PostgreSQL database: 4,974 passed and 12 skipped; the sole host-temporary-root failure caused by an unrelated `/tmp/.git` marker passed when rerun with a clean temporary base.
- `./scripts/smoke/model-free-system.sh`

The complete live gate used `fastapi/full-stack-fastapi-template@486f054cc8d1aead59ec96cc0a16933d06c10e0d` with model calls disabled and proved:

- Prefect client 3.8.4 communicating with Prefect server 3.8.4;
- live API, web, Chromium, TypeScript LSP, and multilspy checks;
- 210 indexed documents, 691 chunks, 553 persisted symbols, four SCIP projects, 2,652 SCIP symbols, and 5,998 SCIP relations;
- 4,665 persisted knowledge nodes and 4,621 persisted Twin nodes;
- ten search results and a successful no-op second synchronization.

Joern remains advisory in this model-free gate and was skipped because `joern-parse` is not installed.