### PR TITLE
Update and verify OpenTelemetry dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,10 +179,20 @@ jobs:
       - name: Run pinned repository sync gate
         run: ./scripts/smoke/model-free-system.sh
 
+  otel-enabled-smoke:
+    name: OpenTelemetry Enabled Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify exported application telemetry
+        run: ./scripts/smoke/otel-enabled.sh
+
   build:
     name: Build & Push Containers
     runs-on: ubuntu-latest
-    needs: [lint, test, web, web-e2e, rust, model-free-system-smoke]
+    needs: [lint, test, web, web-e2e, rust, model-free-system-smoke, otel-enabled-smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -43,17 +43,6 @@ _INDEX_HTML = STATIC_DIR / "index.html"
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     """Application lifespan handler - integrates MCP and telemetry."""
-    # Initialize telemetry FIRST (before any other setup)
-    telemetry_enabled = init_telemetry(service_suffix="-api")
-
-    if telemetry_enabled:
-        # Auto-instrument FastAPI (must be done before routes are accessed)
-        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
-
-        FastAPIInstrumentor.instrument_app(app)
-        HTTPXClientInstrumentor().instrument()
-
     # Run MCP lifespan (initializes StreamableHTTPSessionManager)
     async with mcp_lifespan(app):
         # Startup
@@ -62,6 +51,18 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await shutdown_lsp_manager()
     await close_engine()
     await shutdown_telemetry()
+
+
+def _configure_telemetry(app: FastAPI) -> None:
+    """Initialize and instrument the app before its middleware stack is built."""
+    if not init_telemetry(service_suffix="-api"):
+        return
+
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+
+    FastAPIInstrumentor.instrument_app(app)
+    HTTPXClientInstrumentor().instrument()
 
 
 def _register_api_routes(app: FastAPI) -> None:
@@ -167,6 +168,7 @@ def create_app() -> FastAPI:
     )
     instrumentator.instrument(app)
     _register_spa_routes(app, instrumentator)
+    _configure_telemetry(app)
 
     return app
 

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -120,6 +120,7 @@ Dependency changes additionally run:
 
 ```bash
 ./scripts/smoke/model-free-system.sh
+./scripts/smoke/otel-enabled.sh
 ```
 
 The system gate deliberately takes longer than a unit smoke test. It:
@@ -153,6 +154,13 @@ The system gate deliberately takes longer than a unit smoke test. It:
 Joern is advisory in this gate, so this test does not qualify Joern/CPG changes.
 Authenticated browser workflows, web crawling, and model-provider behavior also
 need their own targeted checks when those surfaces change.
+
+The OpenTelemetry gate keeps the default-disabled path above intact and starts
+the pinned collector separately with telemetry enabled. It requires exported
+FastAPI route spans, distinct API and worker service resources, a real Prefect
+flow with its semantic attributes, SQLAlchemy telemetry, and a flushed result
+metric. This verifies useful OTLP data rather than startup or exporter calls
+alone.
 
 ## Refresh Commands
 

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -30,13 +30,13 @@ dependencies = [
     "igraph>=1.0.0",
     "leidenalg>=0.12.0",
     # OpenTelemetry (optional - only imports when OTEL_ENABLED=true)
-    "opentelemetry-sdk>=1.43.0",
-    "opentelemetry-api>=1.43.0",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.43.0",
-    "opentelemetry-instrumentation-fastapi>=0.64b0",
-    "opentelemetry-instrumentation-sqlalchemy>=0.64b0",
-    "opentelemetry-instrumentation-httpx>=0.64b0",
-    "opentelemetry-instrumentation-logging>=0.64b0",
+    "opentelemetry-sdk==1.44.0",
+    "opentelemetry-api==1.44.0",
+    "opentelemetry-exporter-otlp-proto-grpc==1.44.0",
+    "opentelemetry-instrumentation-fastapi==0.65b0",
+    "opentelemetry-instrumentation-sqlalchemy==0.65b0",
+    "opentelemetry-instrumentation-httpx==0.65b0",
+    "opentelemetry-instrumentation-logging==0.65b0",
     "defusedxml>=0.7.1",
 ]
 

--- a/scripts/smoke/docker-compose.yml
+++ b/scripts/smoke/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       retries: 30
       start_period: 15s
 
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest@sha256:1f2c54a30e713fac6b3ae77a1ec84010c2007e29ced8ec666214fc2f6739c1cc
+    volumes:
+      - ../../scripts/docker/otel/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+
   api:
     build:
       context: ../..
@@ -45,7 +50,9 @@ services:
       DATABASE_URL: postgresql+asyncpg://contextmine:contextmine@postgres:5432/contextmine
       PREFECT_API_URL: http://prefect-server:4200/api
       MODEL_CALLS_ENABLED: "false"
-      OTEL_ENABLED: "false"
+      OTEL_ENABLED: ${CONTEXTMINE_SMOKE_OTEL_ENABLED:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      OTEL_TRACES_SAMPLER: always_on
       GITHUB_CLIENT_ID: contextmine-smoke
       GITHUB_CLIENT_SECRET: contextmine-smoke-not-a-real-secret
       PUBLIC_BASE_URL: https://contextmine-smoke.invalid
@@ -100,7 +107,9 @@ services:
       PREFECT_API_URL: http://prefect-server:4200/api
       PREFECT_LOGGING_LEVEL: INFO
       MODEL_CALLS_ENABLED: "false"
-      OTEL_ENABLED: "false"
+      OTEL_ENABLED: ${CONTEXTMINE_SMOKE_OTEL_ENABLED:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
+      OTEL_TRACES_SAMPLER: always_on
       SCIP_LANGUAGES: python,typescript,javascript
       SCIP_INSTALL_DEPS_MODE: never
       SCIP_BEST_EFFORT: "false"

--- a/scripts/smoke/otel-enabled.sh
+++ b/scripts/smoke/otel-enabled.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+smoke_root="$(mktemp -d -t contextmine-otel-smoke.XXXXXX)"
+fixture_placeholder="${smoke_root}/fixture-placeholder"
+compose_file="${repository_root}/scripts/smoke/docker-compose.yml"
+compose_project="contextmine-otel-smoke-${BASHPID}"
+
+cleanup() {
+  docker compose \
+    --project-name "${compose_project}" \
+    --file "${compose_file}" \
+    down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "${smoke_root}"
+}
+trap cleanup EXIT
+
+mkdir -p "${fixture_placeholder}"
+export CONTEXTMINE_SMOKE_FIXTURE_DIR="${fixture_placeholder}"
+export CONTEXTMINE_SMOKE_FIXTURE_REVISION="otel-enabled"
+export CONTEXTMINE_SMOKE_OTEL_ENABLED="true"
+
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  up --build --detach --wait --wait-timeout 300 \
+  postgres prefect-server otel-collector api
+
+# Exercise the production FastAPI instrumentation with application routes.
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  exec --no-TTY api /app/.venv/bin/python -c \
+  "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health').read(); urllib.request.urlopen('http://localhost:8000/api/config').read()"
+
+# Exercise the production worker flow and SQLAlchemy instrumentation, then
+# force-flush the trace and metric providers during graceful shutdown.
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  run --build --rm --no-deps smoke /bin/bash -c \
+  "cd /app/packages/core && /app/.venv/bin/alembic upgrade head && cd /app && /app/.venv/bin/python /smoke/otel_enabled.py"
+
+verified="false"
+collector_output="${smoke_root}/otel-collector.log"
+for _ in $(seq 1 30); do
+  docker compose \
+    --project-name "${compose_project}" \
+    --file "${compose_file}" \
+    logs --no-color otel-collector >"${collector_output}" 2>/dev/null
+  if python3 "${repository_root}/scripts/smoke/verify_otel_output.py" \
+    <"${collector_output}" >/dev/null 2>&1; then
+    verified="true"
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${verified}" != "true" ]]; then
+  python3 "${repository_root}/scripts/smoke/verify_otel_output.py" <"${collector_output}" || true
+  grep -E -n \
+    "service.name|Name:|prefect\\.|contextmine\\.|http\\.|url\\." \
+    "${collector_output}" >&2 || true
+  exit 1
+fi
+
+echo "OpenTelemetry enabled smoke passed"

--- a/scripts/smoke/otel_enabled.py
+++ b/scripts/smoke/otel_enabled.py
@@ -1,0 +1,55 @@
+"""Emit real ContextMine traces and a metric through the OTLP exporter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from contextmine_core import close_engine
+from contextmine_core.telemetry import (
+    get_meter,
+    init_telemetry,
+    shutdown_telemetry,
+)
+
+
+async def main() -> None:
+    """Run an empty real sync flow and flush its telemetry."""
+    initialized = init_telemetry(
+        service_suffix="-smoke-worker",
+        extra_resource_attributes={"contextmine.smoke.gate": "otel-enabled"},
+    )
+    if not initialized:
+        raise AssertionError("OpenTelemetry must be enabled for this smoke gate")
+
+    try:
+        # Import after SDK initialization so all application spans use the
+        # configured provider and exporter.
+        from contextmine_worker.flows import sync_due_sources
+
+        result = await sync_due_sources()
+        expected = {"synced": 0, "skipped": 0, "sources": []}
+        if result != expected:
+            raise AssertionError(f"Unexpected empty sync result: {result!r}")
+
+        counter = get_meter("contextmine.smoke").create_counter(
+            "contextmine.smoke.sync_due_sources.runs",
+            description="Successful sync_due_sources smoke executions",
+            unit="{run}",
+        )
+        counter.add(
+            1,
+            {
+                "contextmine.smoke.result": "empty",
+                "contextmine.smoke.synced": 0,
+            },
+        )
+    finally:
+        await close_engine()
+        await shutdown_telemetry()
+
+    print(json.dumps({"otel_enabled": True, "sync_due_sources": result}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/smoke/verify_otel_output.py
+++ b/scripts/smoke/verify_otel_output.py
@@ -1,0 +1,45 @@
+"""Verify that the collector received useful ContextMine telemetry."""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    output = sys.stdin.read()
+    required_signals = {
+        "API service resource": ("service.name: Str(contextmine-api)",),
+        "API health span": (
+            "http.route: Str(/api/health)",
+            "http.method: Str(GET)",
+            "http.status_code: Int(200)",
+        ),
+        "worker service resource": ("service.name: Str(contextmine-smoke-worker)",),
+        "real sync flow span": (
+            "prefect.flow.name: Str(sync_due_sources)",
+            "prefect.type: Str(flow)",
+        ),
+        "SQLAlchemy telemetry": ("db.client.connections.usage",),
+        "smoke gate resource attribute": (
+            "contextmine.smoke.gate",
+            "otel-enabled",
+        ),
+        "sync result metric": (
+            "contextmine.smoke.sync_due_sources.runs",
+            "contextmine.smoke.result",
+            "empty",
+        ),
+    }
+    missing = [
+        label
+        for label, markers in required_signals.items()
+        if not all(marker in output for marker in markers)
+    ]
+    if missing:
+        raise AssertionError("Collector output is missing required signals: " + ", ".join(missing))
+
+    print("OpenTelemetry collector received API, worker flow, and metric signals")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -603,13 +603,13 @@ requires-dist = [
     { name = "lizard", specifier = ">=1.23.0" },
     { name = "multilspy", marker = "extra == 'lsp'", git = "https://github.com/microsoft/multilspy?rev=6f4c0b7c287f2ff6917fc4008ba0d98a26d6aa24" },
     { name = "openai", specifier = ">=2.44.0" },
-    { name = "opentelemetry-api", specifier = ">=1.43.0" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.43.0" },
-    { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.64b0" },
-    { name = "opentelemetry-instrumentation-httpx", specifier = ">=0.64b0" },
-    { name = "opentelemetry-instrumentation-logging", specifier = ">=0.64b0" },
-    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.64b0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.43.0" },
+    { name = "opentelemetry-api", specifier = "==1.44.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = "==1.44.0" },
+    { name = "opentelemetry-instrumentation-fastapi", specifier = "==0.65b0" },
+    { name = "opentelemetry-instrumentation-httpx", specifier = "==0.65b0" },
+    { name = "opentelemetry-instrumentation-logging", specifier = "==0.65b0" },
+    { name = "opentelemetry-instrumentation-sqlalchemy", specifier = "==0.65b0" },
+    { name = "opentelemetry-sdk", specifier = "==1.44.0" },
     { name = "pgvector", specifier = ">=0.4.2" },
     { name = "protobuf", specifier = ">=6.33.6" },
     { name = "pydantic", specifier = ">=2.13.4" },
@@ -2365,31 +2365,31 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.43.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.43.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.43.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -2400,14 +2400,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/1d/6336453716ca0a240d4417d19e6d5b77a5e7163e5670ec4f7ec4d3ede7bf/opentelemetry_exporter_otlp_proto_grpc-1.43.0.tar.gz", hash = "sha256:1b3e0627daa9bc21884d4a13946807c255eb558bfe5bdd543dffb6f4c9faee0d", size = 27213, upload-time = "2026-06-24T15:20:00.907Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/74/2700b5d5c946bf2dba87073fce3dfc198c46bc92ea3d5693f54bc51c90b1/opentelemetry_exporter_otlp_proto_grpc-1.43.0-py3-none-any.whl", hash = "sha256:6a10d1feacffffda19acacbf277b736094b1e2f4dbb98c90ccb2c6e1962e2ec6", size = 19626, upload-time = "2026-06-24T15:19:42.233Z" },
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2415,14 +2415,14 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880, upload-time = "2026-06-24T15:18:17.277Z" },
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-asgi"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
@@ -2431,14 +2431,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/0c/71c696fccb86d37af383ea1604af4729fabad0af2fabaf203e4c79c1e859/opentelemetry_instrumentation_asgi-0.64b0.tar.gz", hash = "sha256:4dd3eee566a4303f8e6b9b84f2a0a7abc57a6640df768926c68a3868bf5b2090", size = 26136, upload-time = "2026-06-24T15:19:17.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/83/8e8e83b7ac285281687c7be2fd305213ccccbb8c0a2dd4fb45a8ccaf12c7/opentelemetry_instrumentation_asgi-0.65b0.tar.gz", hash = "sha256:892bca67c56522ffa85a8a83cf934d7b50b3be2132e45cbee705825f0a5ba426", size = 26140, upload-time = "2026-07-16T15:25:54.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/20/218b65a63d847a7ed28d1bea84c39234689160b74480b8702272e37f4240/opentelemetry_instrumentation_asgi-0.64b0-py3-none-any.whl", hash = "sha256:e0840b66e15303a9254b0540946010bd008aa0504f4d89b8e1b7fb63490a36f0", size = 15906, upload-time = "2026-06-24T15:18:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/9c/376962840b619d2d55fe8ee2285f8c70971c090e5fff614516fc654a6f3a/opentelemetry_instrumentation_asgi-0.65b0-py3-none-any.whl", hash = "sha256:3a845a8ebd1c4ef0d8263401e6545f5b219b2feee612090d50f578a87e71fd65", size = 15903, upload-time = "2026-07-16T15:24:57.198Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-fastapi"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2447,14 +2447,14 @@ dependencies = [
     { name = "opentelemetry-semantic-conventions" },
     { name = "opentelemetry-util-http" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/a1/52282e2cc5c08f4df13b087896d9907258fe2ff4f34035d3b21aa92684c3/opentelemetry_instrumentation_fastapi-0.64b0.tar.gz", hash = "sha256:05f75149929e433c1630de381688e650bf651c1e1cce7f9a7b649a807dac8a98", size = 26236, upload-time = "2026-06-24T15:19:27.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/23/b057f8196d06efdc1b50e3ff11fbc499a7d96b35c87f217eb7885542f4ea/opentelemetry_instrumentation_fastapi-0.65b0.tar.gz", hash = "sha256:10a3a95486036230413a58fe4fdf4a83fa6bba46918407e527476994bd92bd97", size = 26236, upload-time = "2026-07-16T15:26:05.954Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/2d/4f48dc2d6f289f2febc5b871940dbea9f3b04ab9186d23342581b49cb984/opentelemetry_instrumentation_fastapi-0.64b0-py3-none-any.whl", hash = "sha256:43cbbfb2d3079dc81104478a2950ae93ac6d0e90a5020fa3987a236f8f2bdef1", size = 13263, upload-time = "2026-06-24T15:18:38.553Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b0/c9b0300d33349ecc3dfd2362516eaffc44877e90970e6a52178ff953fec3/opentelemetry_instrumentation_fastapi-0.65b0-py3-none-any.whl", hash = "sha256:cda2610a0ec1b22d19886f33e4d861e9f5dbb886aeaa3a1263b47aff82c36943", size = 13261, upload-time = "2026-07-16T15:25:12.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-httpx"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2463,28 +2463,28 @@ dependencies = [
     { name = "opentelemetry-util-http" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/2a/2893a8781b93894f1e8014904c0342da7e4302de6597c2d5c0cb6c1a552e/opentelemetry_instrumentation_httpx-0.64b0.tar.gz", hash = "sha256:c2cfcd03d3665762860ebd0c28038c6e47fbb48d7942dec31dd75fc634d25c92", size = 23555, upload-time = "2026-06-24T15:19:29.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/03/a529140241addd4d0acc73bafbd6f74691651b92fc0ae9b4513cf80f07fa/opentelemetry_instrumentation_httpx-0.65b0.tar.gz", hash = "sha256:4627aa9c6bb99bf4462c8b565b0ef6aeb9ffad95c6c92868be1ef7895de112ee", size = 26309, upload-time = "2026-07-16T15:26:07.973Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/29/a20309bd3f5a8051b61ca475e78623410c3b077e3deccae19aa4f8b5b9a2/opentelemetry_instrumentation_httpx-0.64b0-py3-none-any.whl", hash = "sha256:04829e5723941b5ceb0c88b44d63983e226b5c75b2b2e34a57739fdd0e060608", size = 16336, upload-time = "2026-06-24T15:18:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0f/c6144096b4914bbf44b43ba21c962e8f333ff045770b50a3e79ed8bd455f/opentelemetry_instrumentation_httpx-0.65b0-py3-none-any.whl", hash = "sha256:400f1b78afa4ee2332b5debe58e1ed1b317913d58812c952576be76660aeadb1", size = 17436, upload-time = "2026-07-16T15:25:15.772Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-logging"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/8e/3b7191ba5817f139867612e960fbe06a69fe0d522d3b2c5e9c8e89b3ef8c/opentelemetry_instrumentation_logging-0.64b0.tar.gz", hash = "sha256:6435b4d215bf8183e15f7e3416a10ebe1c411810d3411fbfc62667daae3abacb", size = 20000, upload-time = "2026-06-24T15:19:30.946Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/0a/b70a9cddbc7b314a783e62739dbb1184f8538c1f85e8ded6d340142b9b54/opentelemetry_instrumentation_logging-0.65b0.tar.gz", hash = "sha256:c0a50cade5d54db6c6af12e2c69227ecd26f2b3b779e99ff850561d3d8dd77e3", size = 19783, upload-time = "2026-07-16T15:26:09.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/07/9f97b0ccbb38363d12c7a2bfe44912ae7440c97aae250e2eedb32739f662/opentelemetry_instrumentation_logging-0.64b0-py3-none-any.whl", hash = "sha256:9b56f19648798ddb331c206b74d36c5f2a71e5c6b771e96298f167b2b590e40d", size = 16062, upload-time = "2026-06-24T15:18:44.019Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/8e/7577914681d77b180f8d6dcbac435be8e4ca6add6315da2d01ac4289eaa3/opentelemetry_instrumentation_logging-0.65b0-py3-none-any.whl", hash = "sha256:68365b31755c844f1e85f07dcd217839ff92f2d278a214bdf02d4dc806f9d915", size = 15727, upload-time = "2026-07-16T15:25:18.774Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-sqlalchemy"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -2493,57 +2493,57 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/d7/86e333dede47a67a0f989f383da5d0840162ee21e0b252ca56cf61351c59/opentelemetry_instrumentation_sqlalchemy-0.64b0.tar.gz", hash = "sha256:dd737e0b0a72500961aa0dbb6fb2a10525f8dbb5299f9315ddf82d415cc64719", size = 18006, upload-time = "2026-06-24T15:19:40.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/9d/72af21527ce6f286ac78dc2c75ce44b76cc45343a28f0bcbb13f213421fc/opentelemetry_instrumentation_sqlalchemy-0.65b0.tar.gz", hash = "sha256:8ec2e79f1e00808c5dc639ab5b2cfcdf9dcdef55efd6442c6019707fe2894028", size = 18007, upload-time = "2026-07-16T15:26:19.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/90/5424365cb111d2383747b36ca3dbc558e86ef5ec6694efb53bfcb771f046/opentelemetry_instrumentation_sqlalchemy-0.64b0-py3-none-any.whl", hash = "sha256:687ee4c453020c7db009a7f3e390bb2b28eab4e61517e6d267e6e448c3eedcfb", size = 14410, upload-time = "2026-06-24T15:18:57.287Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/3eb3195a60b894cc1852a5657a2b64764a998085c50d7fb3452148af8f18/opentelemetry_instrumentation_sqlalchemy-0.65b0-py3-none-any.whl", hash = "sha256:4d8a2e5afc7b505a48d05cb1fb6db5f8b31681814c1d7767bd6d4b5bdd3a3047", size = 14410, upload-time = "2026-07-16T15:25:32.04Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.43.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489, upload-time = "2026-06-24T15:19:51.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.43.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
 name = "opentelemetry-util-http"
-version = "0.64b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/1b/1029a805fd7242f7dfce91633b244c3b14a94d703232878f71e01ce862b1/opentelemetry_util_http-0.64b0.tar.gz", hash = "sha256:8a86a220dbfc56d736f47f1e5c4e7932a21fcf69052312e1bcf166444dc79322", size = 11102, upload-time = "2026-06-24T15:19:48.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/c7/5f8ec5b30546f2dc22cd5fc5759bce2ab5be6e89a2e710a405ac9ef64ed3/opentelemetry_util_http-0.64b0-py3-none-any.whl", hash = "sha256:c1e5350d25507c1afcd6076cf9ac062485a0a4f79cd9971366996fd3056bacdb", size = 8204, upload-time = "2026-06-24T15:19:09.02Z" },
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- initialize OpenTelemetry before FastAPI builds its middleware stack, so application route spans are actually exported
- add an enabled OTLP integration gate backed by a digest-pinned OpenTelemetry Collector
- require useful API, Prefect flow, SQLAlchemy, resource, and metric signals instead of treating exporter startup as sufficient
- pin the directly declared OpenTelemetry packages to the synchronized `1.44.0` / `0.65b0` release family and refresh only that family in `uv.lock`

## Why

The existing model-free system gate deliberately keeps telemetry disabled, so it cannot detect exporter or instrumentation regressions. Enabling telemetry also exposed that FastAPI instrumentation happened inside the lifespan, after Starlette had already built the middleware stack; the exporter worked, but API route spans were absent.

The new gate exercises the production initialization path with a real OTLP gRPC exporter and fails unless the collector receives semantic application data. Exact direct pins make the synchronized stable and instrumentation release lines explicit and prevent an unrelated re-lock from moving one part of the family independently.

## Verification

- `uv lock --check --offline`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -v --basetemp=<isolated-temp-dir>` — 4,975 passed, 12 skipped
- `./scripts/smoke/otel-enabled.sh` — exported FastAPI route spans, distinct API and worker service resources, a real `sync_due_sources` Prefect flow, SQLAlchemy telemetry, and the result metric
- `./scripts/smoke/model-free-system.sh` — full pass against `fastapi/full-stack-fastapi-template@486f054cc8d1aead59ec96cc0a16933d06c10e0d`, including the no-op second sync

The full fixture run indexed 210 files and documents, 553 symbols, 2,652 SCIP symbols, 5,998 SCIP relations, and 691 chunks, and returned 10 search results.
