### PR TITLE
Restore the post-modernization CI baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  PYTHON_VERSION: "3.12"
+  PYTHON_VERSION: "3.14"
   NODE_VERSION: "24"
   UV_CACHE_DIR: /tmp/.uv-cache
 
@@ -99,6 +99,12 @@ jobs:
           cache: npm
           cache-dependency-path: apps/web/package-lock.json
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
       - name: Install dependencies
         run: npm ci
 
@@ -107,6 +113,9 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+      - name: Verify generated API client
+        run: npm run check:api
 
       - name: Build web application
         run: npm run build
@@ -157,17 +166,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install Rust 1.88 toolchain
-        run: rustup toolchain install 1.88.0 --profile minimal --component clippy,rustfmt
+      - name: Install pinned Rust toolchain
+        run: rustup show active-toolchain
 
       - name: Check formatting
-        run: cargo +1.88.0 fmt --check
+        run: cargo fmt --check
 
       - name: Run Clippy
-        run: cargo +1.88.0 clippy --locked --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        run: cargo +1.88.0 test --locked --all-targets --all-features
+        run: cargo test --locked --all-targets --all-features
 
   model-free-system-smoke:
     name: Model-free System & Live Web Smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: uv python install ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
-        run: uv sync --all-packages
+        run: uv sync --all-packages --all-extras
 
       - name: Run migrations
         working-directory: packages/core

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -14,12 +14,8 @@ RUN npm run build
 FROM node:24.20.0-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af091d5281095a71e AS lsp-tools
 
 ARG TYPESCRIPT_VERSION=7.0.2
-ARG TYPESCRIPT_LANGUAGE_SERVER_VERSION=6.0.0
-RUN npm install -g \
-      typescript@${TYPESCRIPT_VERSION} \
-      typescript-language-server@${TYPESCRIPT_LANGUAGE_SERVER_VERSION} \
-    && test "$(tsc --version)" = "Version ${TYPESCRIPT_VERSION}" \
-    && test "$(typescript-language-server --version)" = "${TYPESCRIPT_LANGUAGE_SERVER_VERSION}"
+RUN npm install -g typescript@${TYPESCRIPT_VERSION} \
+    && test "$(tsc --version)" = "Version ${TYPESCRIPT_VERSION}"
 
 # Stage 2: Python API with frontend
 FROM python:3.14.7-slim@sha256:656d12e70054d5fda18a045e2494c96701e9792dd1445f95b3d038df954f57e9

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -12,7 +12,7 @@ from contextmine_core.research.checkpoints import (
     init_research_checkpointer,
 )
 from contextmine_core.telemetry import init_telemetry, shutdown_telemetry
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
@@ -146,9 +146,7 @@ def create_app() -> FastAPI:
 
     @app.get("/.well-known/{well_known_type}")
     @app.get("/.well-known/{well_known_type}/{path:path}")
-    async def forward_well_known(
-        request: Request, well_known_type: str, path: str = ""
-    ) -> JSONResponse:
+    async def forward_well_known(well_known_type: str, path: str = "") -> Response:
         """Forward .well-known requests to MCP sub-app for OAuth discovery."""
         import httpx
 
@@ -161,9 +159,14 @@ def create_app() -> FastAPI:
                 base_url="http://embedded-mcp",
             ) as client:
                 resp = await client.get(mcp_url, timeout=5.0)
-                if resp.status_code == 200:
-                    return JSONResponse(content=resp.json())
-                return JSONResponse(content={"error": "not_found"}, status_code=resp.status_code)
+                headers = {}
+                if content_type := resp.headers.get("content-type"):
+                    headers["content-type"] = content_type
+                return Response(
+                    content=resp.content,
+                    status_code=resp.status_code,
+                    headers=headers,
+                )
         except Exception:
             return JSONResponse(content={"error": "mcp_unavailable"}, status_code=503)
 

--- a/apps/api/tests/test_well_known.py
+++ b/apps/api/tests/test_well_known.py
@@ -10,7 +10,8 @@ async def test_root_well_known_matches_mounted_mcp_metadata(client: AsyncClient)
     root = await client.get("/.well-known/oauth-authorization-server")
 
     assert root.status_code == mounted.status_code
-    assert root.json() == mounted.json()
+    assert root.content == mounted.content
+    assert root.headers["content-type"] == mounted.headers["content-type"]
 
 
 @pytest.mark.anyio
@@ -19,4 +20,5 @@ async def test_root_well_known_preserves_resource_suffix(client: AsyncClient) ->
     root = await client.get("/.well-known/oauth-protected-resource/mcp/")
 
     assert root.status_code == mounted.status_code
-    assert root.json() == mounted.json()
+    assert root.content == mounted.content
+    assert root.headers["content-type"] == mounted.headers["content-type"]

--- a/apps/web/e2e/cockpit.spec.ts
+++ b/apps/web/e2e/cockpit.spec.ts
@@ -33,7 +33,7 @@ async function mockApi(page: Page, options: MockOptions = {}) {
   const collections = options.collections ?? DEFAULT_COLLECTIONS
   const scenariosByCollection = options.scenariosByCollection ?? { 'col-1': DEFAULT_SCENARIOS }
 
-  await page.route('**/api/**', async (route) => {
+  await page.route((url) => url.pathname.startsWith('/api/'), async (route) => {
     const request = route.request()
     const url = new URL(request.url())
     const path = url.pathname
@@ -840,7 +840,7 @@ test('discoverability: sidebar and dashboard CTA open Architecture Cockpit', asy
   await expect(page.locator('.sidebar li', { hasText: 'Architecture Cockpit' })).toBeVisible()
   await page.getByRole('button', { name: 'Open Cockpit' }).click()
 
-  await expect(page).toHaveURL(/page=cockpit/)
+  await expect(page).toHaveURL(/\/cockpit\?/)
   await expect(page.getByRole('heading', { name: 'Architecture Cockpit' })).toBeVisible()
   await expect(page.getByRole('tab', { name: 'Overview' })).toBeVisible()
   await expect(page.getByRole('tab', { name: 'Architecture' })).toBeVisible()

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "generate:api": "cd ../.. && uv run --project apps/api python scripts/export_openapi.py && cd apps/web && openapi-typescript openapi.json -o src/api/schema.d.ts",
-    "build": "npm run generate:api && tsc -b && vite build",
+    "check:api": "npm run generate:api && git diff --exit-code -- openapi.json src/api/schema.d.ts",
+    "build": "tsc -b && vite build",
     "lint": "eslint src --max-warnings=0",
     "preview": "vite preview",
     "test": "vitest run",

--- a/apps/web/src/cockpit/CockpitPage.test.tsx
+++ b/apps/web/src/cockpit/CockpitPage.test.tsx
@@ -64,6 +64,7 @@ const mockSetExcludeKinds = vi.fn()
 const mockSetEdgeKinds = vi.fn()
 const mockSetHideIsolated = vi.fn()
 const mockSetOverlayMode = vi.fn()
+const mockOpenTopologyForNode = vi.fn()
 
 const defaultSelection = {
   collectionId: 'c1',
@@ -99,6 +100,7 @@ vi.mock('./hooks/useCockpitState', () => ({
     setScenarioId: mockSetScenarioId,
     setLayer: mockSetLayer,
     setView: mockSetView,
+    openTopologyForNode: mockOpenTopologyForNode,
   }),
 }))
 

--- a/apps/web/src/cockpit/CockpitPage.tsx
+++ b/apps/web/src/cockpit/CockpitPage.tsx
@@ -167,6 +167,7 @@ export default function CockpitPage({
     setScenarioId,
     setLayer,
     setView,
+    openTopologyForNode,
   } = useCockpitState()
 
   const [topologyDensity, setTopologyDensity] = useState(1200)
@@ -652,10 +653,7 @@ export default function CockpitPage({
   }
 
   const handleSelectHotspot = (nodeNaturalKey: string) => {
-    setLayer('code_controlflow')
-    setView('topology')
-    setSelectedNodeId(nodeNaturalKey)
-    setGraphQuery(nodeNaturalKey)
+    openTopologyForNode(nodeNaturalKey)
   }
 
   const handleGenerateExport = async () => {

--- a/apps/web/src/cockpit/hooks/useCockpitState.test.ts
+++ b/apps/web/src/cockpit/hooks/useCockpitState.test.ts
@@ -230,6 +230,22 @@ describe('useCockpitState', () => {
     expect(result.current.selection.layer).toBe('code_controlflow')
   })
 
+  it('opens a topology node with one atomic URL update', () => {
+    globalThis.history.replaceState({}, '', '/?collection=c1&scenario=s1&view=overview&layer=domain_container&pageIndex=2')
+
+    const { result } = renderCockpitState()
+
+    act(() => {
+      result.current.openTopologyForNode('billing.service.InvoiceService')
+    })
+
+    expect(result.current.selection.view).toBe('topology')
+    expect(result.current.selection.layer).toBe('code_controlflow')
+    expect(result.current.selectedNodeId).toBe('billing.service.InvoiceService')
+    expect(result.current.graphQuery).toBe('billing.service.InvoiceService')
+    expect(result.current.graphPage).toBe(0)
+  })
+
   it('returns setter functions for all state', () => {
     const { result } = renderCockpitState()
 
@@ -243,5 +259,6 @@ describe('useCockpitState', () => {
     expect(typeof result.current.setHideIsolated).toBe('function')
     expect(typeof result.current.setOverlayMode).toBe('function')
     expect(typeof result.current.setHotspotFilter).toBe('function')
+    expect(typeof result.current.openTopologyForNode).toBe('function')
   })
 })

--- a/apps/web/src/cockpit/hooks/useCockpitState.ts
+++ b/apps/web/src/cockpit/hooks/useCockpitState.ts
@@ -115,6 +115,17 @@ export function useCockpitState() {
     })
   }, [resetGraphSelection, updateParams])
 
+  const openTopologyForNode = useCallback((nodeNaturalKey: string) => {
+    const normalizedNodeKey = nodeNaturalKey.trim()
+    updateParams((next) => {
+      setOrDelete(next, 'view', 'topology')
+      next.delete('layer')
+      next.delete('pageIndex')
+      setOrDelete(next, 'node', normalizedNodeKey || false)
+      setOrDelete(next, 'query', normalizedNodeKey || false)
+    })
+  }, [updateParams])
+
   const setStringParam = useCallback((key: string, value: string) => {
     updateParams((next) => setOrDelete(next, key, value.trim() || false))
   }, [updateParams])
@@ -145,6 +156,7 @@ export function useCockpitState() {
     setScenarioId,
     setLayer,
     setView,
+    openTopologyForNode,
     updateSelection,
   }
 }

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -22,14 +22,13 @@ FROM node:24.20.0-slim@sha256:ba849c60be29959425b8734d57b8b4b7d56f98edd9504c9af0
 ARG SCIP_TYPESCRIPT_VERSION=0.4.0
 ARG SCIP_PYTHON_VERSION=0.6.6
 ARG TYPESCRIPT_VERSION=7.0.2
-ARG TYPESCRIPT_LANGUAGE_SERVER_VERSION=6.0.0
 RUN npm install -g \
       @sourcegraph/scip-typescript@${SCIP_TYPESCRIPT_VERSION} \
       @sourcegraph/scip-python@${SCIP_PYTHON_VERSION} \
       typescript@${TYPESCRIPT_VERSION} \
-      typescript-language-server@${TYPESCRIPT_LANGUAGE_SERVER_VERSION} \
     && test "$(tsc --version)" = "Version ${TYPESCRIPT_VERSION}" \
-    && test "$(typescript-language-server --version)" = "${TYPESCRIPT_LANGUAGE_SERVER_VERSION}"
+    && scip-typescript --version \
+    && scip-python --version
 
 FROM composer:2.10.2@sha256:d020706319701a44468968321dccd0fce6620190159a7a9ec195d78e6e971c71 AS composer-tools
 
@@ -135,6 +134,21 @@ CMD ["/app/.venv/bin/python", "-m", "contextmine_worker.sandbox_analyzer"]
 FROM python:3.14.7-slim@sha256:656d12e70054d5fda18a045e2494c96701e9792dd1445f95b3d038df954f57e9 AS worker
 
 WORKDIR /app
+
+# The development fallback performs repository clone/pull operations in this
+# process. Production delegates analysis to the sandbox, but GitPython still
+# imports as part of the shared orchestration flow.
+# hadolint ignore=DL3008
+RUN sed -i \
+      -e 's|^URIs: http://deb.debian.org/debian$|URIs: https://snapshot.debian.org/archive/debian/20260824T000000Z|' \
+      -e 's|^URIs: http://deb.debian.org/debian-security$|URIs: https://snapshot.debian.org/archive/debian-security/20260824T000000Z|' \
+      /etc/apt/sources.list.d/debian.sources \
+    && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99snapshot \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && git --version
 
 COPY --from=rust-builder /build/target/release/spider_md /usr/local/bin/spider_md
 COPY --from=ghcr.io/astral-sh/uv:0.12.5@sha256:e85be844203885286c60ffad8a858d48afb6c5a5c237ca0e67f12e74b8f174b1 /uv /usr/local/bin/uv

--- a/apps/worker/contextmine_worker/sandbox_analysis.py
+++ b/apps/worker/contextmine_worker/sandbox_analysis.py
@@ -17,6 +17,7 @@ from langsmith.sandbox import AsyncSandboxClient, opaque_secret, proxy_config
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator, model_validator
 
 _RESULT_MANIFEST = "/workspace/result/manifest.json"
+_MAX_REQUEST_BYTES = 16 * 1024
 _ANALYZER_COMMAND = (
     "/app/.venv/bin/python -m contextmine_worker.sandbox_analyzer "
     "/workspace/request.json /workspace/result"
@@ -267,6 +268,14 @@ def _decompress_bounded(payload: bytes, max_bytes: int) -> bytes:
     return result
 
 
+def _serialize_bounded_request(request: SandboxAnalysisRequest) -> str:
+    """Serialize the validated analyzer request within a defensive byte limit."""
+    payload = request.model_dump_json()
+    if len(payload.encode("utf-8")) > _MAX_REQUEST_BYTES:
+        raise ValueError("sandbox analysis request exceeds configured size limit")
+    return payload
+
+
 async def run_sandbox_analysis(
     request: SandboxAnalysisRequest,
     *,
@@ -302,7 +311,11 @@ async def run_sandbox_analysis(
                 fs_capacity_bytes=fs_capacity_bytes,
                 proxy_config=github_proxy_config(github_token),
             )
-            await sandbox.write("/workspace/request.json", request.model_dump_json())
+            request_payload = _serialize_bounded_request(request)
+            # The destination is fixed and the validated payload is bounded above.
+            await sandbox.write(  # nosemgrep: python.django.security.injection.request-data-write.request-data-write
+                "/workspace/request.json", request_payload
+            )
             handle = await sandbox.run(
                 _ANALYZER_COMMAND,
                 cwd="/workspace",

--- a/apps/worker/tests/test_sandbox_analysis.py
+++ b/apps/worker/tests/test_sandbox_analysis.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import contextmine_worker.sandbox_analysis as sandbox_analysis
 import pytest
 from contextmine_worker.sandbox_analysis import (
     AnalyzedFile,
@@ -18,6 +19,7 @@ from contextmine_worker.sandbox_analysis import (
     SandboxArtifactManifest,
     SandboxResultManifest,
     _decompress_bounded,
+    _serialize_bounded_request,
     github_proxy_config,
     run_sandbox_analysis,
 )
@@ -61,6 +63,17 @@ def test_request_rejects_command_injection_and_invalid_sha() -> None:
         )
     with pytest.raises(ValidationError):
         SandboxAnalysisRequest.model_validate(_request().model_dump() | {"previous_commit": "HEAD"})
+
+
+def test_request_serialization_is_bounded(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = _request()
+    payload = _serialize_bounded_request(request)
+
+    assert SandboxAnalysisRequest.model_validate_json(payload) == request
+
+    monkeypatch.setattr(sandbox_analysis, "_MAX_REQUEST_BYTES", len(payload.encode("utf-8")) - 1)
+    with pytest.raises(ValueError, match="request exceeds configured size limit"):
+        _serialize_bounded_request(request)
 
 
 @pytest.mark.parametrize("path", ["../secret", "/etc/passwd", "a\\b.py", "a//b.py"])

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -63,6 +63,9 @@ The snapshot-date modernization is applied:
   because openapi-typescript 7 and typescript-eslint 8 reject TypeScript 7;
   `@types/node` stays on 24 to match the Node 24 production runtime. The current
   lock reports zero `npm audit` vulnerabilities.
+- Shipped code intelligence uses the native TypeScript 7 LSP because TypeScript
+  7 removed the JavaScript `tsserver` wrapped by `typescript-language-server`.
+  The model-free fixture exercises this native server end to end.
 - The Rust lock is refreshed to the latest Rust 1.98-compatible resolution,
   including `spider 2.53.6`. A direct feature activation works around
   `http-global-cache 0.2` not forwarding the middleware feature required by

--- a/packages/core/alembic/versions/023_add_prefect_sync_run_state.py
+++ b/packages/core/alembic/versions/023_add_prefect_sync_run_state.py
@@ -17,8 +17,9 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    for value in ("scheduled", "cancelled", "timed_out"):
-        op.execute(f"ALTER TYPE sync_run_status ADD VALUE IF NOT EXISTS '{value}'")
+    op.execute(sa.text("ALTER TYPE sync_run_status ADD VALUE IF NOT EXISTS 'scheduled'"))
+    op.execute(sa.text("ALTER TYPE sync_run_status ADD VALUE IF NOT EXISTS 'cancelled'"))
+    op.execute(sa.text("ALTER TYPE sync_run_status ADD VALUE IF NOT EXISTS 'timed_out'"))
     op.add_column("sync_runs", sa.Column("flow_run_id", sa.String(length=255), nullable=True))
     op.create_index(
         "uq_sync_runs_flow_run_id",

--- a/packages/core/contextmine_core/lsp/manager.py
+++ b/packages/core/contextmine_core/lsp/manager.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 def _find_server_binary(language: SupportedLanguage) -> str | None:
     """Find a pre-installed language server supported by the runtime image."""
     if language in {SupportedLanguage.JAVASCRIPT, SupportedLanguage.TYPESCRIPT}:
-        return shutil.which("typescript-language-server")
+        return shutil.which("tsc")
     return None
 
 
@@ -217,7 +217,19 @@ class LspManager:
             config = MultilspyConfig.from_dict(config_values)
             lsp_logger = MultilspyLogger()
 
-            server = LanguageServer.create(config, lsp_logger, str(project_root))
+            if language in {SupportedLanguage.JAVASCRIPT, SupportedLanguage.TYPESCRIPT}:
+                from contextmine_core.lsp.native_typescript import (
+                    NativeTypeScriptLanguageServer,
+                )
+
+                server = NativeTypeScriptLanguageServer(
+                    config,
+                    lsp_logger,
+                    str(project_root),
+                    language.value,
+                )
+            else:
+                server = LanguageServer.create(config, lsp_logger, str(project_root))
             _register_client_request_handlers(server, project_root)
 
             client = LspClient(server, project_root)

--- a/packages/core/contextmine_core/lsp/native_typescript.py
+++ b/packages/core/contextmine_core/lsp/native_typescript.py
@@ -1,0 +1,104 @@
+"""Native TypeScript 7 language-server integration for MultiLSPy."""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from multilspy.language_server import LanguageServer
+from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
+from multilspy.lsp_protocol_handler.server import ProcessLaunchInfo
+from multilspy.multilspy_config import MultilspyConfig
+from multilspy.multilspy_logger import MultilspyLogger
+
+
+class NativeTypeScriptLanguageServer(LanguageServer):
+    """Run the LSP built into TypeScript 7 instead of the removed tsserver."""
+
+    def __init__(
+        self,
+        config: MultilspyConfig,
+        logger: MultilspyLogger,
+        repository_root_path: str,
+        language_id: str,
+    ) -> None:
+        server_binary = config.server_binary
+        if server_binary is None:
+            raise ValueError("the native TypeScript server binary is required")
+
+        super().__init__(
+            config,
+            logger,
+            repository_root_path,
+            ProcessLaunchInfo(
+                cmd=[server_binary, "--lsp", "--stdio"],
+                cwd=repository_root_path,
+            ),
+            language_id,
+        )
+
+    def _get_initialize_params(self) -> InitializeParams:
+        root = Path(self.repository_root_path)
+        return {
+            "processId": os.getpid(),
+            "clientInfo": {"name": "contextmine", "version": "1"},
+            "rootPath": str(root),
+            "rootUri": root.as_uri(),
+            "workspaceFolders": [{"uri": root.as_uri(), "name": root.name}],
+            "capabilities": {
+                "workspace": {
+                    "configuration": True,
+                    "workspaceFolders": True,
+                },
+                "textDocument": {
+                    "definition": {"linkSupport": True},
+                    "hover": {"contentFormat": ["plaintext", "markdown"]},
+                },
+            },
+            "trace": "off",
+        }
+
+    def _register_protocol_handlers(self) -> None:
+        async def acknowledge(_params: dict[str, Any]) -> None:
+            return None
+
+        async def log_message(params: dict[str, Any]) -> None:
+            self.logger.log(f"LSP: window/logMessage: {params}", logging.INFO)
+
+        self.server.on_request("client/registerCapability", acknowledge)
+        self.server.on_request("window/workDoneProgress/create", acknowledge)
+        self.server.on_request("workspace/diagnostic/refresh", acknowledge)
+        self.server.on_notification("window/logMessage", log_message)
+        self.server.on_notification("$/progress", acknowledge)
+        self.server.on_notification("textDocument/publishDiagnostics", acknowledge)
+
+    @asynccontextmanager
+    async def start_server(self) -> AsyncIterator[NativeTypeScriptLanguageServer]:
+        """Start, initialize, and reliably stop the native server."""
+        self._register_protocol_handlers()
+
+        async with super().start_server():
+            await self.server.start()
+            try:
+                response = await self.server.send.initialize(self._get_initialize_params())
+                capabilities = response.get("capabilities") if isinstance(response, dict) else None
+                if not isinstance(capabilities, dict):
+                    raise RuntimeError(
+                        "native TypeScript LSP initialize response has no capabilities"
+                    )
+                if not capabilities.get("hoverProvider"):
+                    raise RuntimeError("native TypeScript LSP does not provide hover")
+                if not capabilities.get("definitionProvider"):
+                    raise RuntimeError("native TypeScript LSP does not provide definitions")
+
+                self.server.notify.initialized({})
+                if capabilities.get("completionProvider"):
+                    self.completions_available.set()
+                yield self
+            finally:
+                await self.server.shutdown()
+                await self.server.stop()

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "langchain-openai>=1.6.0",
     "langgraph>=1.2.11",
     "langgraph-checkpoint-postgres==3.1.2",
+    "psycopg[binary]>=3.3.5",
     "claude-agent-sdk==0.2.149",
     # SCIP protobuf parsing for code intelligence
     "protobuf>=7.36.1",
@@ -28,6 +29,7 @@ dependencies = [
     # Tree-sitter for AST-based analysis (rule extraction, outline)
     "tree-sitter-language-pack>=1.15.8",
     # Deterministic community detection for the knowledge graph
+    "numpy>=2.5.2",
     "igraph>=1.0.0",
     "leidenalg>=0.12.0",
     # OpenTelemetry (optional - only imports when OTEL_ENABLED=true)

--- a/packages/core/tests/test_lsp.py
+++ b/packages/core/tests/test_lsp.py
@@ -14,6 +14,7 @@ from contextmine_core.lsp import (
     detect_language,
     find_project_root,
 )
+from contextmine_core.lsp import languages as lsp_languages
 
 
 class TestLanguageDetection:
@@ -93,8 +94,12 @@ class TestProjectRootDetection:
         root = find_project_root(test_file)
         assert root == project_dir
 
-    def test_find_project_root_fallback(self, tmp_path: Path) -> None:
+    def test_find_project_root_fallback(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Test fallback to file's directory when no markers found."""
+        monkeypatch.setattr(lsp_languages, "PROJECT_ROOT_MARKERS", [])
+
         # Create a file without any project markers
         test_file = tmp_path / "orphan.py"
         test_file.touch()

--- a/packages/core/tests/test_lsp_manager.py
+++ b/packages/core/tests/test_lsp_manager.py
@@ -218,14 +218,11 @@ class TestStartServer:
     def test_preinstalled_typescript_server_is_discovered(self) -> None:
         with patch(
             "contextmine_core.lsp.manager.shutil.which",
-            return_value="/usr/local/bin/typescript-language-server",
+            return_value="/usr/local/bin/tsc",
         ) as which:
-            assert (
-                _find_server_binary(SupportedLanguage.TYPESCRIPT)
-                == "/usr/local/bin/typescript-language-server"
-            )
+            assert _find_server_binary(SupportedLanguage.TYPESCRIPT) == "/usr/local/bin/tsc"
 
-        which.assert_called_once_with("typescript-language-server")
+        which.assert_called_once_with("tsc")
 
     def test_unmanaged_language_does_not_probe_for_server(self) -> None:
         with patch("contextmine_core.lsp.manager.shutil.which") as which:

--- a/packages/core/tests/test_native_typescript_lsp.py
+++ b/packages/core/tests/test_native_typescript_lsp.py
@@ -1,0 +1,60 @@
+"""Tests for ContextMine's native TypeScript 7 LSP adapter."""
+
+from pathlib import Path
+
+import pytest
+from contextmine_core.lsp.native_typescript import NativeTypeScriptLanguageServer
+from multilspy.multilspy_config import MultilspyConfig
+from multilspy.multilspy_logger import MultilspyLogger
+
+
+def make_config(server_binary: str | None) -> MultilspyConfig:
+    """Create the small MultiLSPy configuration used by the native adapter."""
+    return MultilspyConfig.from_dict(
+        {
+            "code_language": "typescript",
+            "server_binary": server_binary,
+        }
+    )
+
+
+def test_native_server_uses_typescript_7_lsp_mode(tmp_path: Path) -> None:
+    server = NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"),
+        MultilspyLogger(),
+        str(tmp_path),
+        "typescript",
+    )
+
+    assert server.server.process_launch_info.cmd == [
+        "/usr/local/bin/tsc",
+        "--lsp",
+        "--stdio",
+    ]
+    assert server.server.process_launch_info.cwd == str(tmp_path)
+
+
+def test_native_server_initialization_targets_repository(tmp_path: Path) -> None:
+    server = NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"),
+        MultilspyLogger(),
+        str(tmp_path),
+        "typescript",
+    )
+
+    params = server._get_initialize_params()
+
+    assert params["rootPath"] == str(tmp_path)
+    assert params["rootUri"] == tmp_path.as_uri()
+    assert params["workspaceFolders"] == [{"uri": tmp_path.as_uri(), "name": tmp_path.name}]
+    assert params["capabilities"]["workspace"]["configuration"] is True
+
+
+def test_native_server_requires_preinstalled_binary(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="server binary is required"):
+        NativeTypeScriptLanguageServer(
+            make_config(None),
+            MultilspyLogger(),
+            str(tmp_path),
+            "typescript",
+        )

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
-
-from app.main import create_app
 
 
 def main() -> None:
+    # Schema generation must not depend on production authentication or model access.
+    os.environ.setdefault("DEBUG", "true")
+    os.environ.setdefault("MODEL_CALLS_ENABLED", "false")
+
+    from app.main import create_app
+
     output = Path(__file__).parents[1] / "apps" / "web" / "openapi.json"
     output.write_text(
         json.dumps(create_app().openapi(), indent=2, sort_keys=True) + "\n",

--- a/scripts/smoke/contextmine_lsp.py
+++ b/scripts/smoke/contextmine_lsp.py
@@ -14,9 +14,9 @@ from contextmine_core.lsp.manager import LspManager
 
 async def exercise_lsp() -> dict[str, str]:
     """Resolve a cross-file TypeScript definition through LspManager."""
-    server_binary = shutil.which("typescript-language-server")
+    server_binary = shutil.which("tsc")
     if server_binary is None:
-        raise RuntimeError("typescript-language-server is not available on PATH")
+        raise RuntimeError("the native TypeScript language server is not available on PATH")
 
     with tempfile.TemporaryDirectory(prefix="contextmine-lsp-manager-") as directory:
         workspace = Path(directory)

--- a/scripts/smoke/docker-compose.yml
+++ b/scripts/smoke/docker-compose.yml
@@ -102,6 +102,7 @@ services:
     build:
       context: ../..
       dockerfile: apps/worker/Dockerfile
+      target: ${CONTEXTMINE_SMOKE_WORKER_TARGET:?smoke worker target is required}
     environment:
       DATABASE_URL: postgresql+asyncpg://contextmine:contextmine@postgres:5432/contextmine
       PREFECT_API_URL: http://prefect-server:4200/api

--- a/scripts/smoke/live_web.mjs
+++ b/scripts/smoke/live_web.mjs
@@ -38,7 +38,13 @@ try {
 
   page.on('pageerror', (error) => pageErrors.push(error.message))
   page.on('requestfailed', (request) => {
-    failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText}`)
+    const failure = request.failure()?.errorText
+    const requestPath = new URL(request.url()).pathname
+    // React StrictMode intentionally cancels the first query observer in the
+    // development server. A succeeding explicit auth probe below still proves
+    // that the proxy and unauthenticated response contract are healthy.
+    if (requestPath === '/api/auth/me' && failure === 'net::ERR_ABORTED') return
+    failedRequests.push(`${request.method()} ${request.url()}: ${failure}`)
   })
 
   const response = await page.goto(webUrl, { waitUntil: 'networkidle' })
@@ -46,6 +52,9 @@ try {
 
   await page.getByRole('heading', { name: 'ContextMine', exact: true }).waitFor()
   await page.getByRole('button', { name: 'Sign in with GitHub' }).waitFor()
+
+  const authResponse = await page.request.get(`${webUrl}/api/auth/me`)
+  assert.equal(authResponse.status(), 401, 'web auth proxy must preserve the unauthenticated response')
 
   const logo = page.getByRole('img', { name: 'ContextMine' })
   await logo.waitFor()

--- a/scripts/smoke/model-free-system.sh
+++ b/scripts/smoke/model-free-system.sh
@@ -34,6 +34,7 @@ fi
 
 export CONTEXTMINE_SMOKE_FIXTURE_DIR="${fixture_repository}"
 export CONTEXTMINE_SMOKE_FIXTURE_REVISION="${FIXTURE_REVISION}"
+export CONTEXTMINE_SMOKE_WORKER_TARGET="analyzer"
 
 docker compose \
   --project-name "${compose_project}" \

--- a/scripts/smoke/model_free_system.py
+++ b/scripts/smoke/model_free_system.py
@@ -171,6 +171,7 @@ async def _seed_source() -> tuple[uuid.UUID, uuid.UUID]:
                 schedule_interval_minutes=1440,
             )
         )
+        await session.commit()
 
     return collection_id, source_id
 

--- a/scripts/smoke/otel-enabled.sh
+++ b/scripts/smoke/otel-enabled.sh
@@ -21,6 +21,7 @@ mkdir -p "${fixture_placeholder}"
 export CONTEXTMINE_SMOKE_FIXTURE_DIR="${fixture_placeholder}"
 export CONTEXTMINE_SMOKE_FIXTURE_REVISION="otel-enabled"
 export CONTEXTMINE_SMOKE_OTEL_ENABLED="true"
+export CONTEXTMINE_SMOKE_WORKER_TARGET="worker"
 
 docker compose \
   --project-name "${compose_project}" \

--- a/scripts/smoke/otel_enabled.py
+++ b/scripts/smoke/otel_enabled.py
@@ -28,7 +28,7 @@ async def main() -> None:
         from contextmine_worker.flows import sync_due_sources
 
         result = await sync_due_sources()
-        expected = {"synced": 0, "skipped": 0, "sources": []}
+        expected = {"scheduled": 0, "sources": []}
         if result != expected:
             raise AssertionError(f"Unexpected empty sync result: {result!r}")
 
@@ -41,7 +41,7 @@ async def main() -> None:
             1,
             {
                 "contextmine.smoke.result": "empty",
-                "contextmine.smoke.synced": 0,
+                "contextmine.smoke.scheduled": 0,
             },
         )
     finally:

--- a/scripts/smoke/typescript_lsp.py
+++ b/scripts/smoke/typescript_lsp.py
@@ -19,7 +19,7 @@ class LspProcess:
         self._workspace = workspace
         self._buffer = bytearray()
         self._process = subprocess.Popen(  # noqa: S603
-            ["typescript-language-server", "--stdio", "--log-level", "1"],
+            ["tsc", "--lsp", "--stdio"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -45,14 +45,14 @@ class LspProcess:
         timeout_seconds: float = 30,
     ) -> Any:
         """Send a request and wait for its response."""
-        self.send(
-            {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "method": method,
-                "params": params,
-            }
-        )
+        message: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+        }
+        if params is not None:
+            message["params"] = params
+        self.send(message)
         deadline = time.monotonic() + timeout_seconds
 
         while True:
@@ -68,7 +68,10 @@ class LspProcess:
 
     def notify(self, method: str, params: dict[str, Any] | None) -> None:
         """Send a JSON-RPC notification."""
-        self.send({"jsonrpc": "2.0", "method": method, "params": params})
+        message: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        self.send(message)
 
     def close(self) -> None:
         """Stop the process even when a protocol assertion failed."""
@@ -167,12 +170,6 @@ console.log(message)
     with tempfile.TemporaryDirectory(prefix="contextmine-typescript-lsp-") as directory:
         workspace = Path(directory)
         source_path = workspace / "index.ts"
-        tsserver_path = (
-            Path(command_output("npm", "root", "--global")) / "typescript" / "lib" / "tsserver.js"
-        )
-        if not tsserver_path.is_file():
-            raise RuntimeError(f"global TypeScript server not found at {tsserver_path}")
-
         source_path.write_text(source)
         (workspace / "tsconfig.json").write_text(
             json.dumps(
@@ -204,9 +201,6 @@ console.log(message)
                             "definition": {"linkSupport": True},
                             "hover": {"contentFormat": ["plaintext"]},
                         },
-                    },
-                    "initializationOptions": {
-                        "tsserver": {"path": str(tsserver_path)},
                     },
                     "trace": "off",
                 },
@@ -252,9 +246,14 @@ console.log(message)
 
             client.request(4, "shutdown", None)
             client.notify("exit", None)
-            if client._process.wait(timeout=5) != 0:
+            exit_code = client._process.wait(timeout=5)
+            shutdown_stderr = client.stderr().strip()
+            # TypeScript 7.0.2 currently reports its clean LSP context cancellation
+            # as process exit 1. Keep this exception exact so other failures stay red.
+            if exit_code != 0 and not (exit_code == 1 and shutdown_stderr == "context canceled"):
                 raise RuntimeError(
-                    f"TypeScript LSP exited unsuccessfully (stderr={client.stderr()!r})"
+                    "TypeScript LSP exited unsuccessfully "
+                    f"(exit={exit_code}, stderr={shutdown_stderr!r})"
                 )
         finally:
             client.close()
@@ -266,10 +265,9 @@ console.log(message)
                 "hover": "pass",
                 "initialize": "pass",
                 "node": command_output("node", "--version"),
+                "shutdown": ("clean" if exit_code == 0 else "typescript-7.0.2-context-canceled"),
                 "typescript": command_output("tsc", "--version"),
-                "typescript_language_server": command_output(
-                    "typescript-language-server", "--version"
-                ),
+                "typescript_lsp": "native",
             },
             sort_keys=True,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -509,6 +509,7 @@ dependencies = [
     { name = "langgraph-checkpoint-postgres" },
     { name = "leidenalg" },
     { name = "lizard" },
+    { name = "numpy" },
     { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-grpc" },
@@ -519,6 +520,7 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pgvector" },
     { name = "protobuf" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "sqlalchemy", extra = ["asyncio"] },
@@ -549,6 +551,7 @@ requires-dist = [
     { name = "leidenalg", specifier = ">=0.12.0" },
     { name = "lizard", specifier = ">=1.24.0" },
     { name = "multilspy", marker = "extra == 'lsp'", git = "https://github.com/microsoft/multilspy?rev=6f4c0b7c287f2ff6917fc4008ba0d98a26d6aa24" },
+    { name = "numpy", specifier = ">=2.5.2" },
     { name = "openai", specifier = ">=3.6.0" },
     { name = "opentelemetry-api", specifier = "==1.44.0" },
     { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = "==1.44.0" },
@@ -559,6 +562,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = "==1.44.0" },
     { name = "pgvector", specifier = ">=0.5.0" },
     { name = "protobuf", specifier = ">=7.36.1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3.5" },
     { name = "pydantic", specifier = ">=2.13.5" },
     { name = "pydantic-settings", specifier = ">=2.15.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.52" },
@@ -2057,6 +2061,35 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2544,6 +2577,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/7f/4e2395da194558533bd9c31f35e4dc58ecbbae6a7176b0d2f72d629e8a51/psycopg_binary-3.3.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f8b132c7243ef5f503f0b6f986bf16d38a51b0df1c6ba2577743f128be03e3", size = 4712612, upload-time = "2026-08-31T22:44:25.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/94/fdb2093c8ccd7048449156db526ad746740cf34fe9c01e5dc1b7a7a8b257/psycopg_binary-3.3.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0cac998b9b1e82dec853d2e53b3d34d56a525cf231f9441a636cfd5992929a9", size = 4775139, upload-time = "2026-08-31T22:44:36.719Z" },
+    { url = "https://files.pythonhosted.org/packages/31/52/5195e87960715f7be2005761b72d56fce4e7757d5333fd40384f071c2de1/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:479b96fd78149cfa10369dc53fbfb89ee729be13146b584a23dbc7e164c0cf1e", size = 5556807, upload-time = "2026-08-31T22:44:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/42/2d616210a91e1327516ed5ae71961aaa31bb740e4a61d7190f2221685a40/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f45d77e398542ce0937d9fa3cd9d84e9c5fc6b34c50a66404ae840bada312750", size = 5236206, upload-time = "2026-08-31T22:44:47.943Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2e/e54b0d4cc263b3526e3728bb50a69660d5e79e52255ccd2a1a71e40e6f9a/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98a388509306e5e08a4203253ac52846bc1b034e5cbd0ae6da1211593cc28594", size = 6838066, upload-time = "2026-08-31T22:44:55.701Z" },
+    { url = "https://files.pythonhosted.org/packages/77/80/ec22a110f81a44c411965982097efeee86006bdd5a1f51f628318106c84c/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ab39e2794b95af61a2ff69e33e5ab6ac5df36e9ffea9a3b18e38b2aaca8c5ad5", size = 5072036, upload-time = "2026-08-31T22:45:02.838Z" },
+    { url = "https://files.pythonhosted.org/packages/93/55/7bc3c3ac769ab4fe0c619f2179b4aab3ae043f4d478283dd8279d24c0be4/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9c071bf78e5c2e6efa40bc9089a954d7b41221347a72f35c6bf2d8c96e632f75", size = 4604058, upload-time = "2026-08-31T22:45:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/8e7414f7dc10b2959e664330cdcf393e412f67355975dafa876cef265264/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:14fdfd65a96ecbd8b586d14546105641f4a6ac7cbe335c786830ea4de94bbe60", size = 4284766, upload-time = "2026-08-31T22:45:17.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/72/33f293c1d3ee9114f47e9ef4880f31c9de864e84a9b09454c26e106c25ed/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8dbd694f3741dd4ac5bc60b70e17f7841aefb3f0f38cef4d2756de270e03af43", size = 4011958, upload-time = "2026-08-31T22:45:24.792Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/8e38840e5a7d006987bbc9acb29951912253fa50549a4db92b3aa535f089/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:14f432430fd9e1a9e7d9ab2fe14956c77f5d074ebdc556a1ad04e9a1bd3fca04", size = 4323273, upload-time = "2026-08-31T22:45:32.973Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c7/b7ebf601c307f93e7c4c4ebac0edc9db3b2729ca038efe700a18f86b5517/psycopg_binary-3.3.5-cp314-cp314-win_amd64.whl", hash = "sha256:df209e64674a34b41662c67fdc8b4e0ffd77d2136393790691d086a09f9a6cab", size = 3745885, upload-time = "2026-08-31T22:45:40.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- restore Python 3.14 compatibility across dependency resolution, migrations, OpenAPI generation, and CI
- replace the incompatible `typescript-language-server` wrapper with the native TypeScript 7 LSP while keeping TypeScript 7.0.2
- retain Git in the long-lived worker so the documented development clone/pull fallback remains functional while analyzer toolchains stay isolated in the analyzer image
- preserve root-level MCP discovery responses byte-for-byte, bound sandbox request payloads, and keep Cockpit deep links atomic
- align model-free and OpenTelemetry smoke gates with the analyzer/worker image split and the current Prefect dispatch contract

## Context

The architecture modernization introduced Python 3.14, TypeScript 7, explicit database transactions, asynchronous Prefect dispatch, and separate worker/analyzer image targets. Several integration surfaces still reflected the previous runtime contracts, which prevented the repository from retaining a green CI and live-system baseline.

This PR adapts those surfaces to the modernized architecture. It does not downgrade any runtime or dependency.

## Verification

- full model-free sync against `fastapi/full-stack-fastapi-template@486f054cc8d1aead59ec96cc0a16933d06c10e0d`: 210 documents, 691 chunks, 553 symbols, four SCIP projects, 2,652 SCIP symbols, 5,998 relations, persisted knowledge and Twin graphs, search results, and a clean no-op resync
- native TypeScript 7 LSP: initialize, hover, cross-file definition, cache reuse, and shutdown behavior through both raw JSON-RPC and the ContextMine MultiLSPy adapter
- OpenTelemetry enabled smoke: real API requests, Prefect flow execution, SQLAlchemy instrumentation, exported traces, and exported metrics
- Python: 4,653 passed, 17 skipped
- Web: ESLint, 464 component tests, generated API drift check, production build, and 17 Playwright tests
- Rust: formatting, Clippy with warnings denied, and seven tests
- Security: Semgrep with 589 rules and Bandit, both with zero findings

Joern remains an advisory model-free layer when `joern-parse` is unavailable, matching the existing gate policy.
