### PR TITLE
Cache smoke container builds with BuildKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,8 +182,47 @@ jobs:
     name: Model-free System & Live Web Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      CONTEXTMINE_SMOKE_API_IMAGE: contextmine-smoke-api:${{ github.sha }}
+      CONTEXTMINE_SMOKE_WEB_IMAGE: contextmine-smoke-web:${{ github.sha }}
+      CONTEXTMINE_SMOKE_WORKER_IMAGE: contextmine-smoke-analyzer:${{ github.sha }}
+      CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build cached API smoke image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          load: true
+          tags: ${{ env.CONTEXTMINE_SMOKE_API_IMAGE }}
+          cache-from: type=gha,scope=contextmine-api
+          cache-to: type=gha,scope=contextmine-api,mode=max
+
+      - name: Build cached web smoke image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./apps/web
+          file: apps/web/Dockerfile
+          load: true
+          tags: ${{ env.CONTEXTMINE_SMOKE_WEB_IMAGE }}
+          cache-from: type=gha,scope=contextmine-web
+          cache-to: type=gha,scope=contextmine-web,mode=max
+
+      - name: Build cached analyzer smoke image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          target: analyzer
+          load: true
+          tags: ${{ env.CONTEXTMINE_SMOKE_WORKER_IMAGE }}
+          cache-from: type=gha,scope=contextmine-analyzer
+          cache-to: type=gha,scope=contextmine-analyzer,mode=max
 
       - name: Run pinned repository sync gate
         run: ./scripts/smoke/model-free-system.sh
@@ -192,8 +231,36 @@ jobs:
     name: OpenTelemetry Enabled Smoke
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CONTEXTMINE_SMOKE_API_IMAGE: contextmine-smoke-api:${{ github.sha }}
+      CONTEXTMINE_SMOKE_WORKER_IMAGE: contextmine-smoke-worker:${{ github.sha }}
+      CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES: "true"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build cached API smoke image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          load: true
+          tags: ${{ env.CONTEXTMINE_SMOKE_API_IMAGE }}
+          cache-from: type=gha,scope=contextmine-api
+          cache-to: type=gha,scope=contextmine-api,mode=max
+
+      - name: Build cached worker smoke image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/worker/Dockerfile
+          target: worker
+          load: true
+          tags: ${{ env.CONTEXTMINE_SMOKE_WORKER_IMAGE }}
+          cache-from: type=gha,scope=contextmine-worker
+          cache-to: type=gha,scope=contextmine-worker,mode=max
 
       - name: Verify exported application telemetry
         run: ./scripts/smoke/otel-enabled.sh
@@ -249,8 +316,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=contextmine-${{ matrix.name }}
+          cache-to: type=gha,scope=contextmine-${{ matrix.name }},mode=max
 
   helm:
     name: Publish Helm Chart

--- a/scripts/smoke/docker-compose.yml
+++ b/scripts/smoke/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - ../../scripts/docker/otel/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
 
   api:
+    image: ${CONTEXTMINE_SMOKE_API_IMAGE:-contextmine-smoke-api:local}
     build:
       context: ../..
       dockerfile: apps/api/Dockerfile
@@ -74,6 +75,7 @@ services:
       start_period: 15s
 
   web:
+    image: ${CONTEXTMINE_SMOKE_WEB_IMAGE:-contextmine-smoke-web:local}
     build:
       context: ../../apps/web
       dockerfile: Dockerfile
@@ -99,6 +101,7 @@ services:
     shm_size: 1gb
 
   smoke:
+    image: ${CONTEXTMINE_SMOKE_WORKER_IMAGE:-contextmine-smoke-worker:local}
     build:
       context: ../..
       dockerfile: apps/worker/Dockerfile

--- a/scripts/smoke/model-free-system.sh
+++ b/scripts/smoke/model-free-system.sh
@@ -11,6 +11,23 @@ fixture_root="$(mktemp -d -t contextmine-model-free-smoke.XXXXXX)"
 fixture_repository="${fixture_root}/repository"
 compose_file="${repository_root}/scripts/smoke/docker-compose.yml"
 compose_project="contextmine-model-free-smoke-${BASHPID}"
+compose_up_build_args=(--build)
+compose_run_build_args=(--build)
+
+if [[ "${CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES:-false}" == "true" ]]; then
+  compose_up_build_args=(--no-build)
+  compose_run_build_args=()
+
+  for image in \
+    "${CONTEXTMINE_SMOKE_API_IMAGE:?prebuilt API image is required}" \
+    "${CONTEXTMINE_SMOKE_WEB_IMAGE:?prebuilt web image is required}" \
+    "${CONTEXTMINE_SMOKE_WORKER_IMAGE:?prebuilt analyzer image is required}"; do
+    if ! docker image inspect "${image}" >/dev/null; then
+      echo "Required prebuilt smoke image is unavailable: ${image}" >&2
+      exit 1
+    fi
+  done
+fi
 
 cleanup() {
   docker compose \
@@ -39,7 +56,7 @@ export CONTEXTMINE_SMOKE_WORKER_TARGET="analyzer"
 docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
-  up --build --detach --wait --wait-timeout 300 \
+  up "${compose_up_build_args[@]}" --detach --wait --wait-timeout 300 \
   postgres prefect-server api web browser
 
 prefect_server_version="$(
@@ -71,6 +88,6 @@ docker compose \
 docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
-  run --build --rm --no-deps \
+  run "${compose_run_build_args[@]}" --rm --no-deps \
   --env CONTEXTMINE_SMOKE_PREFECT_SERVER_VERSION="${prefect_server_version}" \
   smoke

--- a/scripts/smoke/otel-enabled.sh
+++ b/scripts/smoke/otel-enabled.sh
@@ -7,6 +7,22 @@ smoke_root="$(mktemp -d -t contextmine-otel-smoke.XXXXXX)"
 fixture_placeholder="${smoke_root}/fixture-placeholder"
 compose_file="${repository_root}/scripts/smoke/docker-compose.yml"
 compose_project="contextmine-otel-smoke-${BASHPID}"
+compose_up_build_args=(--build)
+compose_run_build_args=(--build)
+
+if [[ "${CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES:-false}" == "true" ]]; then
+  compose_up_build_args=(--no-build)
+  compose_run_build_args=()
+
+  for image in \
+    "${CONTEXTMINE_SMOKE_API_IMAGE:?prebuilt API image is required}" \
+    "${CONTEXTMINE_SMOKE_WORKER_IMAGE:?prebuilt worker image is required}"; do
+    if ! docker image inspect "${image}" >/dev/null; then
+      echo "Required prebuilt smoke image is unavailable: ${image}" >&2
+      exit 1
+    fi
+  done
+fi
 
 cleanup() {
   docker compose \
@@ -26,7 +42,7 @@ export CONTEXTMINE_SMOKE_WORKER_TARGET="worker"
 docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
-  up --build --detach --wait --wait-timeout 300 \
+  up "${compose_up_build_args[@]}" --detach --wait --wait-timeout 300 \
   postgres prefect-server otel-collector api
 
 # Exercise the production FastAPI instrumentation with application routes.
@@ -41,7 +57,7 @@ docker compose \
 docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
-  run --build --rm --no-deps smoke /bin/bash -c \
+  run "${compose_run_build_args[@]}" --rm --no-deps smoke /bin/bash -c \
   "cd /app/packages/core && /app/.venv/bin/alembic upgrade head && cd /app && /app/.venv/bin/python /smoke/otel_enabled.py"
 
 verified="false"


### PR DESCRIPTION
## Summary

- prebuild and locally load the API, web, worker, and analyzer smoke images with Docker Buildx
- persist BuildKit layers in the GitHub Actions cache under explicit per-image scopes
- align the main container publication job with the same API, web, and worker cache scopes
- preserve fresh local Compose builds while making CI fail early if a required prebuilt image is missing

## Validation

- `bash -n scripts/smoke/model-free-system.sh scripts/smoke/otel-enabled.sh`
- rendered `scripts/smoke/docker-compose.yml` with all required smoke variables
- parsed `.github/workflows/ci.yml` as YAML
- `git diff --check`
- complete OpenTelemetry and pinned FastAPI fixture smoke runs with the prebuilt images
- all required pull-request checks pass

## Performance measurement

Both measurements ran against unchanged commit `912e6bed59b0d2f7341bf2cbc908348bd8a66298`. [Attempt 1](https://github.com/mayflower/contextmine/actions/runs/33537885003/attempts/1) populated the new cache scopes; [attempt 2](https://github.com/mayflower/contextmine/actions/runs/33537885003/attempts/2) repeated the same workflow and SHA.

| Smoke job | Previous reference | Cold cache | Warm cache | Warm vs. reference |
| --- | ---: | ---: | ---: | ---: |
| OpenTelemetry | 5m 13s | 9m 44s | **4m 01s** | **-1m 12s (-23%)** |
| Model-free fixture | 12m 37s | 18m 58s | **10m 06s** | **-2m 31s (-20%)** |

The cold-cache cost is expected when the scopes are first populated. Compared with that first population run, the warm OTel job is 5m 43s faster and the warm fixture job is 8m 52s faster.

The warm logs explicitly report GitHub Actions cache imports and cached layers for all four images. The functional portions remained stable: fixture sync took 8m 11s cold and 8m 15s warm; telemetry verification took 1m 07s cold and 1m 18s warm. The measured improvement therefore comes from the container build path rather than reduced smoke coverage.