### PR TITLE
ci: schedule system smokes by change scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,27 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+  workflow_dispatch:
+    inputs:
+      cold_cache:
+        description: Ignore existing BuildKit caches while refreshing them
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Exercise the full cold-cache path weekly, away from the top of the hour.
+    - cron: "17 3 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   PYTHON_VERSION: "3.14"
   NODE_VERSION: "24"
   UV_CACHE_DIR: /tmp/.uv-cache
+  CONTEXTMINE_SMOKE_COLD_BUILD: ${{ github.event_name == 'schedule' || inputs.cold_cache }}
 
 jobs:
   lint:
@@ -25,6 +41,9 @@ jobs:
 
       - name: Set up Python
         run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Test system smoke change classifier
+        run: ./scripts/ci/test-classify-system-smoke-changes.sh
 
       - name: Install dependencies
         run: uv sync --all-packages
@@ -178,8 +197,46 @@ jobs:
       - name: Run tests
         run: cargo test --locked --all-targets --all-features
 
+  smoke-changes:
+    name: Classify System Smoke Changes
+    runs-on: ubuntu-latest
+    outputs:
+      model_free: ${{ steps.classify.outputs.model_free }}
+      otel: ${{ steps.classify.outputs.otel }}
+    steps:
+      - name: Check out pull request history
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            printf 'model_free=false\notel=false\n' >>"${GITHUB_OUTPUT}"
+            echo "System smokes are selected by the ${GITHUB_EVENT_NAME} schedule, not changed files."
+            exit 0
+          fi
+
+          if [[ -z "${BASE_SHA}" || -z "${HEAD_SHA}" ]]; then
+            echo "Pull request base/head SHA is unavailable" >&2
+            exit 1
+          fi
+
+          changed_files="${RUNNER_TEMP}/contextmine-smoke-changed-files.txt"
+          git diff --name-only "${BASE_SHA}" "${HEAD_SHA}" >"${changed_files}"
+          classification="$(./scripts/ci/classify-system-smoke-changes.sh <"${changed_files}")"
+          printf '%s\n' "${classification}"
+          printf '%s\n' "${classification}" >>"${GITHUB_OUTPUT}"
+
   model-free-system-smoke:
     name: Model-free System & Live Web Smoke
+    needs: [smoke-changes]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -187,33 +244,51 @@ jobs:
       CONTEXTMINE_SMOKE_WEB_IMAGE: contextmine-smoke-web:${{ github.sha }}
       CONTEXTMINE_SMOKE_WORKER_IMAGE: contextmine-smoke-analyzer:${{ github.sha }}
       CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES: "true"
+      RUN_SYSTEM_SMOKE: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft && needs.smoke-changes.outputs.model_free == 'true') }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Require successful change classification
+        if: needs.smoke-changes.result != 'success'
+        run: |
+          echo "System smoke change classification did not succeed" >&2
+          exit 1
+
+      - name: Record intentional skip
+        if: env.RUN_SYSTEM_SMOKE != 'true'
+        run: echo "Model-free system smoke is not required for this event and change set."
+
+      - if: env.RUN_SYSTEM_SMOKE == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build cached API smoke image
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: apps/api/Dockerfile
           load: true
           tags: ${{ env.CONTEXTMINE_SMOKE_API_IMAGE }}
-          cache-from: type=gha,scope=contextmine-api
+          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
+          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-api' }}
           cache-to: type=gha,scope=contextmine-api,mode=max
 
       - name: Build cached web smoke image
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./apps/web
           file: apps/web/Dockerfile
           load: true
           tags: ${{ env.CONTEXTMINE_SMOKE_WEB_IMAGE }}
-          cache-from: type=gha,scope=contextmine-web
+          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
+          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-web' }}
           cache-to: type=gha,scope=contextmine-web,mode=max
 
       - name: Build cached analyzer smoke image
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -221,37 +296,57 @@ jobs:
           target: analyzer
           load: true
           tags: ${{ env.CONTEXTMINE_SMOKE_WORKER_IMAGE }}
-          cache-from: type=gha,scope=contextmine-analyzer
+          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
+          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-analyzer' }}
           cache-to: type=gha,scope=contextmine-analyzer,mode=max
 
       - name: Run pinned repository sync gate
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         run: ./scripts/smoke/model-free-system.sh
 
   otel-enabled-smoke:
     name: OpenTelemetry Enabled Smoke
+    needs: [smoke-changes]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       CONTEXTMINE_SMOKE_API_IMAGE: contextmine-smoke-api:${{ github.sha }}
       CONTEXTMINE_SMOKE_WORKER_IMAGE: contextmine-smoke-worker:${{ github.sha }}
       CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES: "true"
+      RUN_SYSTEM_SMOKE: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft && needs.smoke-changes.outputs.otel == 'true') }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Require successful change classification
+        if: needs.smoke-changes.result != 'success'
+        run: |
+          echo "System smoke change classification did not succeed" >&2
+          exit 1
+
+      - name: Record intentional skip
+        if: env.RUN_SYSTEM_SMOKE != 'true'
+        run: echo "OpenTelemetry system smoke is not required for this event and change set."
+
+      - if: env.RUN_SYSTEM_SMOKE == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build cached API smoke image
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: apps/api/Dockerfile
           load: true
           tags: ${{ env.CONTEXTMINE_SMOKE_API_IMAGE }}
-          cache-from: type=gha,scope=contextmine-api
+          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
+          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-api' }}
           cache-to: type=gha,scope=contextmine-api,mode=max
 
       - name: Build cached worker smoke image
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -259,16 +354,18 @@ jobs:
           target: worker
           load: true
           tags: ${{ env.CONTEXTMINE_SMOKE_WORKER_IMAGE }}
-          cache-from: type=gha,scope=contextmine-worker
+          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
+          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-worker' }}
           cache-to: type=gha,scope=contextmine-worker,mode=max
 
       - name: Verify exported application telemetry
+        if: env.RUN_SYSTEM_SMOKE == 'true'
         run: ./scripts/smoke/otel-enabled.sh
 
   build:
     name: Build & Push Containers
     runs-on: ubuntu-latest
-    needs: [lint, test, web, web-e2e, rust, model-free-system-smoke, otel-enabled-smoke]
+    needs: [lint, test, web, web-e2e, rust]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/scripts/ci/classify-system-smoke-changes.sh
+++ b/scripts/ci/classify-system-smoke-changes.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+model_free="false"
+otel="false"
+
+while IFS= read -r path || [[ -n "${path}" ]]; do
+  [[ -z "${path}" ]] && continue
+
+  case "${path}" in
+    .dockerignore | \
+      .github/workflows/ci.yml | \
+      docker-compose.yml | \
+      pyproject.toml | \
+      uv.lock | \
+      apps/* | \
+      packages/* | \
+      rust/* | \
+      scripts/ci/* | \
+      scripts/docker/* | \
+      scripts/smoke/*)
+      model_free="true"
+      ;;
+  esac
+
+  case "${path}" in
+    .dockerignore | \
+      .github/workflows/ci.yml | \
+      docker-compose.yml | \
+      pyproject.toml | \
+      uv.lock | \
+      apps/api/* | \
+      apps/worker/* | \
+      packages/* | \
+      rust/* | \
+      scripts/ci/* | \
+      scripts/docker/* | \
+      scripts/smoke/docker-compose.yml | \
+      scripts/smoke/otel-enabled.sh | \
+      scripts/smoke/otel_enabled.py | \
+      scripts/smoke/verify_otel_output.py)
+      otel="true"
+      ;;
+  esac
+done
+
+printf 'model_free=%s\n' "${model_free}"
+printf 'otel=%s\n' "${otel}"

--- a/scripts/ci/test-classify-system-smoke-changes.sh
+++ b/scripts/ci/test-classify-system-smoke-changes.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+classifier="${script_dir}/classify-system-smoke-changes.sh"
+
+assert_classification() {
+  local name="$1"
+  local expected_model_free="$2"
+  local expected_otel="$3"
+  shift 3
+
+  local expected
+  local actual
+  expected="$(printf 'model_free=%s\notel=%s' "${expected_model_free}" "${expected_otel}")"
+  actual="$(printf '%s\n' "$@" | "${classifier}")"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    printf 'Classification failed for %s\nExpected:\n%s\nActual:\n%s\n' \
+      "${name}" "${expected}" "${actual}" >&2
+    return 1
+  fi
+}
+
+assert_classification "documentation only" false false \
+  README.md docs/operations.md
+assert_classification "web application" true false \
+  apps/web/src/App.tsx
+assert_classification "shared Python package" true true \
+  packages/core/contextmine_core/config.py
+assert_classification "OpenTelemetry smoke" true true \
+  scripts/smoke/otel_enabled.py
+assert_classification "CI policy" true true \
+  .github/workflows/ci.yml
+assert_classification "deployment only" false false \
+  deploy/helm/contextmine/values.yaml
+assert_classification "combined changes" true true \
+  README.md apps/web/src/App.tsx apps/api/contextmine_api/main.py
+
+echo "System smoke change classifier tests passed"


### PR DESCRIPTION
## Summary

- classify pull-request changes separately for the model-free system smoke and the OpenTelemetry smoke
- keep both existing required check names present while skipping their expensive work for draft or unrelated pull requests
- cancel superseded pull-request runs and run both full smokes for relevant updates after a pull request is ready for review
- run a weekly cold-cache exercise and allow the same full cold path to be triggered manually
- avoid repeating the full system smokes after merge while the main-branch container publishing pipeline runs

The classifier is deliberately conservative: CI policy, runtime dependencies, shared packages, Docker inputs, and smoke harness changes select the affected system gates. A classifier failure is propagated to both required smoke checks instead of silently skipping them.

## Scheduling policy

| Event | Fast checks | Model-free smoke | OpenTelemetry smoke |
| --- | --- | --- | --- |
| Draft pull request | Always | Recorded skip | Recorded skip |
| Ready pull request, unrelated paths | Always | Recorded skip | Recorded skip |
| Ready pull request, relevant paths | Always | Run when selected | Run when selected |
| Push to `main` | Always, then publish | Recorded skip | Recorded skip |
| Weekly schedule | Always | Full cold-cache run | Full cold-cache run |
| Manual dispatch | Always | Full run | Full run |

## Validation

- `bash -n scripts/ci/classify-system-smoke-changes.sh scripts/ci/test-classify-system-smoke-changes.sh`
- `./scripts/ci/test-classify-system-smoke-changes.sh`
- parsed all workflow YAML files locally
- `git diff --cached --check`

This pull request changes the CI policy itself, so its ready-for-review CI run must execute both complete system smokes and provide live fixture and telemetry evidence.

## CI evidence

- all fast, security, web E2E, and Rust checks passed
- change classification selected both system smokes
- OpenTelemetry smoke passed in 6m36s after executing the real worker flow and verifying the collector output
- model-free system and live-web smoke passed in 16m51s against `fastapi/full-stack-fastapi-template@486f054cc8d1aead59ec96cc0a16933d06c10e0d`
  - model calls remained disabled
  - the initial sync, persisted data checks, search, and no-op resync passed
  - Chromium verified the login surface, API proxy, and static assets
