### PR TITLE
Configure review-driven Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,254 @@
+version: 2
+
+# Version updates are deliberately review-driven. These cooldowns and groups do
+# not apply to security updates, whose availability is controlled by the
+# repository-level Dependabot security update setting. This repository does not
+# auto-merge Dependabot pull requests.
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps/python)"
+    groups:
+      prefect-client:
+        applies-to: "version-updates"
+        patterns:
+          - "prefect"
+        update-types:
+          - "minor"
+          - "patch"
+      model-stack:
+        applies-to: "version-updates"
+        patterns:
+          - "anthropic"
+          - "claude-agent-sdk"
+          - "google-genai"
+          - "langchain-*"
+          - "langgraph*"
+          - "langsmith"
+          - "openai"
+        update-types:
+          - "minor"
+          - "patch"
+      opentelemetry:
+        applies-to: "version-updates"
+        patterns:
+          - "opentelemetry-*"
+        update-types:
+          - "minor"
+          - "patch"
+      api-stack:
+        applies-to: "version-updates"
+        patterns:
+          - "fastapi"
+          - "fastmcp"
+          - "pydantic*"
+          - "starlette"
+          - "uvicorn"
+        update-types:
+          - "minor"
+          - "patch"
+      database-stack:
+        applies-to: "version-updates"
+        patterns:
+          - "alembic"
+          - "asyncpg"
+          - "pgvector"
+          - "psycopg*"
+          - "sqlalchemy"
+        update-types:
+          - "minor"
+          - "patch"
+      code-intelligence:
+        applies-to: "version-updates"
+        patterns:
+          - "grpcio*"
+          - "multilspy"
+          - "protobuf"
+          - "tree-sitter*"
+        update-types:
+          - "minor"
+          - "patch"
+      python-tooling:
+        applies-to: "version-updates"
+        patterns:
+          - "bandit"
+          - "pre-commit"
+          - "pytest*"
+          - "ruff"
+          - "ty"
+          - "vulture"
+        update-types:
+          - "minor"
+          - "patch"
+      routine-python-patches:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:15"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps/web)"
+    groups:
+      grafana-faro:
+        applies-to: "version-updates"
+        patterns:
+          - "@grafana/faro-*"
+        update-types:
+          - "minor"
+          - "patch"
+      web-runtime:
+        applies-to: "version-updates"
+        dependency-type: "production"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      web-tooling:
+        applies-to: "version-updates"
+        dependency-type: "development"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "cargo"
+    directory: "/rust/spider_md"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps/rust)"
+    groups:
+      rust-runtime:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "rust-toolchain"
+    directory: "/rust/spider_md"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:45"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps/rust-toolchain)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps/actions)"
+    groups:
+      github-actions:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/apps/api"
+      - "/apps/web"
+      - "/apps/worker"
+      - "/scripts/docker/postgres"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps/docker)"
+    groups:
+      base-images:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"
+
+  - package-ecosystem: "docker-compose"
+    directories:
+      - "/"
+      - "/scripts/smoke"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 3
+    rebase-strategy: "auto"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps/compose)"
+    groups:
+      prefect-images:
+        applies-to: "version-updates"
+        patterns:
+          - "prefecthq/prefect"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"
+      compose-images:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+        group-by: "dependency-name"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
       default-days: 7
     commit-message:
       prefix: "chore(deps/python)"
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "indirect"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       prefect-client:
         applies-to: "version-updates"
@@ -148,6 +154,12 @@ updates:
       default-days: 7
     commit-message:
       prefix: "chore(deps/rust)"
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "indirect"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       rust-runtime:
         applies-to: "version-updates"

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -185,6 +185,10 @@ setting; the configuration file does not enable that setting.
 
 Patch and minor releases are grouped only where the repository already has a
 shared compatibility boundary. Major releases remain individual proposals.
+For uv and Cargo, direct dependencies remain eligible for every update type,
+while indirect dependencies are limited to patch and minor proposals. This
+keeps transitive lockfiles maintained without opening unbounded transitive
+major-upgrade pull requests.
 No Dependabot pull request is merged automatically: the normal branch
 protection and change-classified CI gates still decide whether a proposal is
 mergeable.

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -4,13 +4,13 @@ This document records the dependency surfaces that must move together, the
 checks that protect them, and the commands used to refresh the snapshot.
 
 Snapshot date: **2026-09-01**  
-Repository baseline: **5691da2e591781847cc2be81f9cd9c4abda9b8c4**
+Repository baseline: **5c08653044523ba321efbc0abc9cb2d1854d2912**
 
 ## Inventory Summary
 
 | Surface | Manifest and lock | Current size | Runtime role |
 | --- | --- | ---: | --- |
-| Python workspace | `pyproject.toml`, three workspace `pyproject.toml` files, `uv.lock` | 244 locked packages | API, MCP, sync worker, analysis, search, graph, telemetry |
+| Python workspace | `pyproject.toml`, three workspace `pyproject.toml` files, `uv.lock` | 246 locked packages | API, MCP, sync worker, analysis, search, graph, telemetry |
 | Web application | `apps/web/package.json`, `apps/web/package-lock.json` | 12 runtime and 20 development declarations; 481 lock entries | React cockpit, diagrams, observability |
 | Rust crawler | `rust/spider_md/Cargo.toml`, `rust/spider_md/Cargo.lock` | 9 direct declarations; 339 locked packages | Deterministic website crawling binary embedded in the worker image |
 | Runtime images | Dockerfiles, Compose files, Helm values | API, worker, web, PostgreSQL/pg4ai, Prefect, CodeCharta, OpenTelemetry | Build and deployment compatibility |
@@ -172,3 +172,33 @@ Use small, independently revertible changes in this order:
 Dependabot or Renovate can create the routine proposals after these groups and
 required checks are defined. Automation is an input to this process; it does
 not replace compatibility grouping, release-note review, or the system gate.
+
+## Automated Update Policy
+
+Dependabot checks the uv workspace, web application, Rust crawler and
+toolchain, GitHub Actions, Dockerfiles, and Compose manifests every Monday.
+Each ecosystem is limited to three open version-update pull requests. A
+seven-day cooldown reduces exposure to freshly published releases; Dependabot
+security updates are not delayed by that cooldown. Automated security pull
+requests additionally require the repository-level Dependabot security update
+setting; the configuration file does not enable that setting.
+
+Patch and minor releases are grouped only where the repository already has a
+shared compatibility boundary. Major releases remain individual proposals.
+No Dependabot pull request is merged automatically: the normal branch
+protection and change-classified CI gates still decide whether a proposal is
+mergeable.
+
+The Prefect Python client and Prefect server images are grouped within their
+respective ecosystems, but Dependabot cannot combine a selective
+multi-ecosystem Prefect group with normal updates for the same uv and Compose
+directories without overlapping update entries. Any Prefect proposal must
+therefore be completed in its branch by synchronizing the client, Compose, and
+Helm references before merge. The model-free system gate verifies the real
+client/server version match. Image references in Helm values are synchronized
+manually because Dependabot does not update arbitrary Helm values.
+
+The Dependabot cooldown controls when proposals are opened; it does not alter
+uv's resolver cutoff. A matching `[tool.uv] exclude-newer` setting remains a
+separate controlled workspace refresh, so introducing this policy does not
+re-resolve or downgrade the current lockfile.


### PR DESCRIPTION
## Summary

- add weekly Dependabot version-update coverage for uv, npm, Cargo, the Rust toolchain, GitHub Actions, Dockerfiles, and Compose manifests
- group compatible patch/minor families, leave major upgrades as individual proposals, cap each ecosystem at three open PRs, and apply a seven-day release cooldown
- include indirect uv and Cargo patch/minor lockfile updates while keeping transitive major upgrades out of scope
- document the review policy, Prefect's required client/server synchronization, Helm image handling, and the boundary between Dependabot and uv cooldowns

## Safety properties

- no automerge is introduced
- direct uv and Cargo dependencies remain eligible for every update type; indirect dependencies are limited to patch and minor proposals
- no dependency manifest, lockfile, image pin, toolchain pin, or runtime code changes in this PR
- Prefect updates remain visible, but the existing model-free system gate prevents a client/server mismatch from being merged
- security updates are not subject to version-update grouping or cooldown; the repository-level Dependabot security-update setting remains a separate operational control

## Validation

- validated `.github/dependabot.yml` against the current public Dependabot 2.0 JSON schema
- parsed the YAML and checked all seven ecosystem schedules, three-PR limits, seven-day cooldowns, and the indirect uv/Cargo patch/minor policy
- ran Dependabot CLI v1.92.0 against this branch for uv: the updater completed successfully and emitted no pull-request operation under the current dependency constraints and cooldown
- ran Dependabot CLI v1.92.0 against `rust/spider_md` for Cargo: the updater completed successfully across the lockfile graph and emitted no pull-request operation under the current dependency constraints
- `uv lock --check`
- `./scripts/ci/test-classify-system-smoke-changes.sh`
- verified that all dependency manifests, lockfiles, image pins, and runtime sources are unchanged from `main`

The live fixture is intentionally not run for this policy-only change. Future Dependabot PRs change their actual dependency surfaces and are therefore selected by the existing change-classified system gates.

The CLI runs exercise the real Dependabot updaters but do not fully simulate the GitHub service's scheduling, grouping, or pull-request lifecycle. The first post-merge service run remains the final operational verification.

## Follow-up after merge

- trigger or observe the first Dependabot service run and verify that all configured ecosystems are recognized under **Insights → Dependency graph → Dependabot**
- decide whether to enable the currently disabled repository-level Dependabot security-update setting
