### PR TITLE
Prevent uncoordinated Prefect image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -247,6 +247,10 @@ updates:
       default-days: 7
     commit-message:
       prefix: "chore(deps/compose)"
+    ignore:
+      - dependency-name: "prefecthq/prefect"
+        versions:
+          - "*.dev*"
     groups:
       prefect-images:
         applies-to: "version-updates"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -249,8 +249,6 @@ updates:
       prefix: "chore(deps/compose)"
     ignore:
       - dependency-name: "prefecthq/prefect"
-        versions:
-          - "*.dev*"
     groups:
       prefect-images:
         applies-to: "version-updates"

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -193,9 +193,10 @@ No Dependabot pull request is merged automatically: the normal branch
 protection and change-classified CI gates still decide whether a proposal is
 mergeable.
 
-Docker Compose proposals for `prefecthq/prefect` exclude `.dev` image tags.
-Prefect pre-releases are not production upgrade candidates even after the
-general release cooldown has elapsed.
+Docker Compose version proposals for `prefecthq/prefect` are disabled. Docker
+ignore rules cannot express a stable-only tag policy, and Prefect pre-releases
+are not production upgrade candidates. A stable uv Prefect proposal remains
+the signal for a manually synchronized client, Compose, and Helm update.
 
 The Prefect Python client and Prefect server images are grouped within their
 respective ecosystems, but Dependabot cannot combine a selective

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -193,6 +193,10 @@ No Dependabot pull request is merged automatically: the normal branch
 protection and change-classified CI gates still decide whether a proposal is
 mergeable.
 
+Docker Compose proposals for `prefecthq/prefect` exclude `.dev` image tags.
+Prefect pre-releases are not production upgrade candidates even after the
+general release cooldown has elapsed.
+
 The Prefect Python client and Prefect server images are grouped within their
 respective ecosystems, but Dependabot cannot combine a selective
 multi-ecosystem Prefect group with normal updates for the same uv and Compose


### PR DESCRIPTION
## Summary

- disable automatic Docker Compose version proposals for `prefecthq/prefect`
- keep stable uv Prefect proposals as the update signal for a coordinated client, Compose, and Helm change
- document why Prefect image updates remain a manually synchronized compatibility boundary

## Rationale

Dependabot selected the pre-release image `3.8.5.dev4-python3.14` as a patch update from `3.8.4-python3.14`. Docker ignore rules use Bundler version syntax and cannot express a durable stable-only suffix policy. Ignoring the Compose image dependency entirely prevents both pre-release noise and server-only proposals that cannot pass the existing client/server compatibility gate.

## Validation

- parsed the resulting Compose ignore policy with `yq`
- ran Dependabot CLI v1.92.0 against both `/` and `/scripts/smoke` on this branch
- verified that both `prefecthq/prefect` occurrences report `All versions ... ignored`
- verified that the updater exits successfully with no pull-request operation and no update-job error
- `git diff --check`

No runtime manifest, lockfile, image reference, or application code changes in this PR. The live fixture is intentionally left to future coordinated Prefect update PRs, which remain selected by the existing system gate.
