### PR TITLE
Constrain incompatible web toolchain majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,6 +116,17 @@ updates:
       default-days: 7
     commit-message:
       prefix: "chore(deps/web)"
+    ignore:
+      # The web compiler remains on TypeScript 5 until openapi-typescript and
+      # typescript-eslint publish a compatible upgrade path.
+      - dependency-name: "typescript"
+        versions:
+          - ">=6.0.0"
+      # Keep the ambient Node API aligned with the Node 24 runtime images and
+      # CI toolchain. Remove this boundary as part of a coordinated Node bump.
+      - dependency-name: "@types/node"
+        versions:
+          - ">=25.0.0"
     groups:
       grafana-faro:
         applies-to: "version-updates"

--- a/docs/diataxis/reference/dependency_inventory.md
+++ b/docs/diataxis/reference/dependency_inventory.md
@@ -60,9 +60,11 @@ The snapshot-date modernization is applied:
   SQLAlchemy 2.0.52, and the OpenTelemetry 1.44/0.65 family.
 - Web runtime and tooling dependencies are current except where the active
   runtime or peer contract requires a lower major. TypeScript stays on 5.9
-  because openapi-typescript 7 and typescript-eslint 8 reject TypeScript 7;
-  `@types/node` stays on 24 to match the Node 24 production runtime. The current
-  lock reports zero `npm audit` vulnerabilities.
+  because openapi-typescript 7 requires TypeScript 5 and typescript-eslint 8
+  requires a TypeScript version below 6.1; `@types/node` stays on 24 to match the
+  Node 24 production runtime. Dependabot preserves these compatibility
+  boundaries while continuing to propose updates within the supported majors.
+  The current lock reports zero `npm audit` vulnerabilities.
 - Shipped code intelligence uses the native TypeScript 7 LSP because TypeScript
   7 removed the JavaScript `tsserver` wrapped by `typescript-language-server`.
   The model-free fixture exercises this native server end to end.


### PR DESCRIPTION
## Summary

- ignore TypeScript releases from 6.0.0 onward until the web toolchain has a released compatible upgrade path
- ignore @types/node releases from 25.0.0 onward while ContextMine builds and runs on Node 24
- document both compatibility boundaries in the dependency inventory

## Why

Dependabot PR #38 demonstrated that TypeScript 7 cannot currently be installed with the web toolchain: openapi-typescript 7.13.0 requires TypeScript 5, and typescript-eslint 8 requires TypeScript below 6.1.

Dependabot PR #39 passed CI, but moving ambient Node types ahead of the Node 24 CI and production runtime could allow code to type-check against APIs that are unavailable at runtime.

Version-specific ignore ranges prevent these known-incompatible major proposals from recurring while preserving normal updates within TypeScript 5 and @types/node 24. The constraints should be revisited as part of the corresponding coordinated toolchain or runtime upgrades.

## Validation

- `yq eval '.' .github/dependabot.yml`
- `git diff --check`
- official Dependabot CLI v1.92.0 npm update job against commit `3e706688`
  - recognized `typescript >=6.0.0` and `@types/node >=25.0.0` as ignore conditions from `.github/dependabot.yml`
  - reported all available updates for both dependencies as ignored
  - emitted only `update_dependency_list` and `mark_as_processed`, with no pull-request or error operation
- complete GitHub CI passed

The change only affects Dependabot policy and documentation, so the change-classified system smoke jobs exercised their successful skip paths rather than rebuilding the fixture.
