### PR TITLE
Reduce fixture build time and TypeScript LSP log volume

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,9 @@ PREFECT_SYNC_DEPLOYMENT=sync_single_source/default
 PREFECT_DUE_INTERVAL_SECONDS=60
 PREFECT_WORKER_LIMIT=2
 
+# Native TypeScript protocol logs: INFO (default) or DEBUG
+LSP_PROTOCOL_LOG_LEVEL=INFO
+
 # SCIP Polyglot Indexing
 # Comma-separated list of languages to index
 SCIP_LANGUAGES=python,typescript,javascript,java,php

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -52,8 +52,7 @@ COPY --from=frontend-builder /app/dist /app/static
 
 COPY apps/api/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh \
-    && useradd --create-home --shell /bin/bash appuser \
-    && chown -R appuser:appuser /app
+    && useradd --create-home --shell /bin/bash appuser
 USER appuser
 
 EXPOSE 8000

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -108,13 +108,15 @@ COPY apps/api/pyproject.toml apps/api/
 
 RUN uv sync --frozen --no-dev --package contextmine-worker --extra analyzer \
     && useradd --create-home --shell /bin/bash appuser \
-    && mkdir -p /data/repos \
+    && mkdir -p /data \
+    && install -d -o appuser -g appuser \
+      /data/repos \
+      /data/joern-cpg \
       /home/appuser/.npm \
       /home/appuser/.m2 \
       /home/appuser/.gradle \
-      /home/appuser/.cache/pip \
+      /home/appuser/.cache \
       /home/appuser/.composer/cache \
-    && chown -R appuser:appuser /app /data /home/appuser \
     && ln -s /usr/lib/jvm/java-21-openjdk-* /usr/lib/jvm/java-21-openjdk
 
 ENV JAVA_HOME=/usr/lib/jvm/java-21-openjdk
@@ -161,7 +163,8 @@ COPY apps/api/pyproject.toml apps/api/
 
 RUN uv sync --frozen --no-dev --package contextmine-worker \
     && useradd --create-home --shell /bin/bash appuser \
-    && chown -R appuser:appuser /app /home/appuser
+    && mkdir -p /data \
+    && install -d -o appuser -g appuser /data/repos /data/joern-cpg
 
 USER appuser
 WORKDIR /app/apps/worker

--- a/packages/core/contextmine_core/lsp/native_typescript.py
+++ b/packages/core/contextmine_core/lsp/native_typescript.py
@@ -69,6 +69,12 @@ class NativeTypeScriptLanguageServer(LanguageServer):
         if server_binary is None:
             raise ValueError("the native TypeScript server binary is required")
 
+        protocol_log_level = os.getenv("LSP_PROTOCOL_LOG_LEVEL", "INFO").upper()
+        if protocol_log_level not in {"DEBUG", "INFO"}:
+            raise ValueError("LSP_PROTOCOL_LOG_LEVEL must be DEBUG or INFO")
+        logger.logger = logging.getLogger("contextmine.lsp.typescript.protocol")
+        logger.logger.setLevel(protocol_log_level)
+
         super().__init__(
             config,
             logger,

--- a/packages/core/contextmine_core/lsp/native_typescript.py
+++ b/packages/core/contextmine_core/lsp/native_typescript.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from collections.abc import AsyncIterator
@@ -11,9 +12,47 @@ from typing import Any
 
 from multilspy.language_server import LanguageServer
 from multilspy.lsp_protocol_handler.lsp_types import InitializeParams
-from multilspy.lsp_protocol_handler.server import ProcessLaunchInfo
+from multilspy.lsp_protocol_handler.server import ProcessLaunchInfo, Request
 from multilspy.multilspy_config import MultilspyConfig
 from multilspy.multilspy_logger import MultilspyLogger
+
+_LOG_PREFIX_CHARS = 8192
+_LOG_SUFFIX_CHARS = 1024
+
+
+def _bounded_message(message: str) -> str:
+    original_chars = len(message)
+    truncated = original_chars > _LOG_PREFIX_CHARS + _LOG_SUFFIX_CHARS
+    if truncated:
+        message = f"{message[:_LOG_PREFIX_CHARS]}...[truncated]...{message[-_LOG_SUFFIX_CHARS:]}"
+    return f"original_chars={original_chars} truncated={str(truncated).lower()} message={message}"
+
+
+def _format_log_message(params: Any) -> tuple[int, str]:
+    if not isinstance(params, dict):
+        return (
+            logging.WARNING,
+            f"LSP: invalid window/logMessage payload_type={type(params).__name__}",
+        )
+
+    message_type = params.get("type")
+    message = params.get("message")
+    if not isinstance(message, str):
+        return (
+            logging.WARNING,
+            f"LSP: invalid window/logMessage message_type={type(message).__name__}",
+        )
+    if type(message_type) is not int or message_type not in {1, 2, 3, 4}:
+        return (
+            logging.WARNING,
+            f"LSP: invalid window/logMessage {_bounded_message(message)}",
+        )
+
+    level = {1: logging.ERROR, 2: logging.WARNING}.get(message_type, logging.DEBUG)
+    return (
+        level,
+        f"LSP: window/logMessage type={message_type} {_bounded_message(message)}",
+    )
 
 
 class NativeTypeScriptLanguageServer(LanguageServer):
@@ -66,8 +105,9 @@ class NativeTypeScriptLanguageServer(LanguageServer):
         async def acknowledge(_params: dict[str, Any]) -> None:
             return None
 
-        async def log_message(params: dict[str, Any]) -> None:
-            self.logger.log(f"LSP: window/logMessage: {params}", logging.INFO)
+        async def log_message(params: Any) -> None:
+            level, message = _format_log_message(params)
+            self.logger.log(message, level)
 
         self.server.on_request("client/registerCapability", acknowledge)
         self.server.on_request("window/workDoneProgress/create", acknowledge)
@@ -75,6 +115,44 @@ class NativeTypeScriptLanguageServer(LanguageServer):
         self.server.on_notification("window/logMessage", log_message)
         self.server.on_notification("$/progress", acknowledge)
         self.server.on_notification("textDocument/publishDiagnostics", acknowledge)
+
+    async def _request_shutdown(self) -> None:
+        """Send TypeScript's parameterless shutdown request."""
+        request = Request()
+        request_id = self.server.request_id
+        self.server.request_id += 1
+        self.server._response_handlers[request_id] = request
+        try:
+            async with request.cv:
+                await self.server._send_payload(
+                    {"jsonrpc": "2.0", "id": request_id, "method": "shutdown"}
+                )
+                await request.cv.wait()
+        finally:
+            self.server._response_handlers.pop(request_id, None)
+        if request.error is not None:
+            raise request.error
+
+    async def _shutdown_server(self) -> None:
+        """Stop TypeScript without MultiLSPy's incompatible null parameters."""
+        error: Exception | None = None
+        try:
+            # ponytail: remove this shim when pinned MultiLSPy omits null params.
+            await asyncio.wait_for(self._request_shutdown(), timeout=30)
+        except Exception as exc:  # noqa: BLE001
+            error = exc
+
+        self.server._received_shutdown = True
+        try:
+            await self.server._send_payload({"jsonrpc": "2.0", "method": "exit"})
+        except Exception as exc:  # noqa: BLE001
+            error = error or exc
+
+        if error is not None:
+            self.logger.log(
+                f"Native TypeScript LSP shutdown failed: {_bounded_message(str(error))}",
+                logging.WARNING,
+            )
 
     @asynccontextmanager
     async def start_server(self) -> AsyncIterator[NativeTypeScriptLanguageServer]:
@@ -100,5 +178,7 @@ class NativeTypeScriptLanguageServer(LanguageServer):
                     self.completions_available.set()
                 yield self
             finally:
-                await self.server.shutdown()
-                await self.server.stop()
+                try:
+                    await self._shutdown_server()
+                finally:
+                    await self.server.stop()

--- a/packages/core/tests/test_native_typescript_lsp.py
+++ b/packages/core/tests/test_native_typescript_lsp.py
@@ -65,6 +65,45 @@ def test_native_server_requires_preinstalled_binary(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
+    ("configured_level", "expected_level"),
+    [(None, logging.INFO), ("debug", logging.DEBUG)],
+)
+def test_native_server_protocol_log_level_is_opt_in(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    configured_level: str | None,
+    expected_level: int,
+) -> None:
+    if configured_level is None:
+        monkeypatch.delenv("LSP_PROTOCOL_LOG_LEVEL", raising=False)
+    else:
+        monkeypatch.setenv("LSP_PROTOCOL_LOG_LEVEL", configured_level)
+
+    logger = MultilspyLogger()
+    NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"), logger, str(tmp_path), "typescript"
+    )
+
+    assert logger.logger.name == "contextmine.lsp.typescript.protocol"
+    assert logger.logger.level == expected_level
+    assert logger.logger.isEnabledFor(logging.DEBUG) is (expected_level == logging.DEBUG)
+
+
+def test_native_server_rejects_invalid_protocol_log_level(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LSP_PROTOCOL_LOG_LEVEL", "WARNING")
+
+    with pytest.raises(ValueError, match="LSP_PROTOCOL_LOG_LEVEL must be DEBUG or INFO"):
+        NativeTypeScriptLanguageServer(
+            make_config("/usr/local/bin/tsc"),
+            MultilspyLogger(),
+            str(tmp_path),
+            "typescript",
+        )
+
+
+@pytest.mark.parametrize(
     ("message_type", "expected_level"),
     [
         (1, logging.ERROR),

--- a/packages/core/tests/test_native_typescript_lsp.py
+++ b/packages/core/tests/test_native_typescript_lsp.py
@@ -1,6 +1,10 @@
 """Tests for ContextMine's native TypeScript 7 LSP adapter."""
 
+import asyncio
+import logging
 from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
 
 import pytest
 from contextmine_core.lsp.native_typescript import NativeTypeScriptLanguageServer
@@ -58,3 +62,126 @@ def test_native_server_requires_preinstalled_binary(tmp_path: Path) -> None:
             str(tmp_path),
             "typescript",
         )
+
+
+@pytest.mark.parametrize(
+    ("message_type", "expected_level"),
+    [
+        (1, logging.ERROR),
+        (2, logging.WARNING),
+        (3, logging.DEBUG),
+        (4, logging.DEBUG),
+    ],
+)
+def test_native_server_maps_log_severity(
+    tmp_path: Path, message_type: int, expected_level: int
+) -> None:
+    logger = MultilspyLogger()
+    logger.log = Mock()
+    server = NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"), logger, str(tmp_path), "typescript"
+    )
+    server._register_protocol_handlers()
+
+    asyncio.run(
+        server.server.on_notification_handlers["window/logMessage"](
+            {"type": message_type, "message": "ready"}
+        )
+    )
+
+    assert logger.log.call_args.args == (
+        f"LSP: window/logMessage type={message_type} "
+        "original_chars=5 truncated=false message=ready",
+        expected_level,
+    )
+
+
+def test_native_server_bounds_log_messages(tmp_path: Path) -> None:
+    logger = MultilspyLogger()
+    logger.log = Mock()
+    server = NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"), logger, str(tmp_path), "typescript"
+    )
+    server._register_protocol_handlers()
+    message = "a" * 8193 + "b" * 1024
+
+    asyncio.run(
+        server.server.on_notification_handlers["window/logMessage"]({"type": 3, "message": message})
+    )
+
+    logged = logger.log.call_args.args[0]
+    assert "original_chars=9217 truncated=true" in logged
+    assert f"message={'a' * 8192}...[truncated]...{'b' * 1024}" in logged
+
+
+def test_native_server_warns_for_invalid_log_payload(tmp_path: Path) -> None:
+    logger = MultilspyLogger()
+    logger.log = Mock()
+    server = NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"), logger, str(tmp_path), "typescript"
+    )
+    server._register_protocol_handlers()
+
+    asyncio.run(
+        server.server.on_notification_handlers["window/logMessage"](
+            {"type": 99, "message": "still useful", "extra": "must-not-be-logged"}
+        )
+    )
+
+    assert logger.log.call_args.args[1] == logging.WARNING
+    assert "invalid window/logMessage" in logger.log.call_args.args[0]
+    assert "message=still useful" in logger.log.call_args.args[0]
+    assert "must-not-be-logged" not in logger.log.call_args.args[0]
+
+
+def test_native_server_shutdown_omits_params(tmp_path: Path) -> None:
+    logger = MultilspyLogger()
+    server = NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"), logger, str(tmp_path), "typescript"
+    )
+    payloads: list[dict[str, Any]] = []
+
+    async def exercise() -> None:
+        async def send(payload: dict[str, Any]) -> None:
+            payloads.append(payload)
+            if payload["method"] == "shutdown":
+
+                async def respond() -> None:
+                    await asyncio.sleep(0)
+                    await server.server._response_handlers[payload["id"]].on_result(None)
+
+                asyncio.create_task(respond())
+
+        server.server._send_payload = send
+        await server._shutdown_server()
+
+    asyncio.run(exercise())
+
+    assert payloads == [
+        {"jsonrpc": "2.0", "id": 1, "method": "shutdown"},
+        {"jsonrpc": "2.0", "method": "exit"},
+    ]
+
+
+def test_native_server_shutdown_failure_is_bounded(tmp_path: Path) -> None:
+    logger = MultilspyLogger()
+    logger.log = Mock()
+    server = NativeTypeScriptLanguageServer(
+        make_config("/usr/local/bin/tsc"), logger, str(tmp_path), "typescript"
+    )
+    payloads: list[dict[str, Any]] = []
+
+    async def exercise() -> None:
+        async def send(payload: dict[str, Any]) -> None:
+            payloads.append(payload)
+            if payload["method"] == "shutdown":
+                raise RuntimeError("a" * 8193 + "b" * 1024)
+
+        server.server._send_payload = send
+        await server._shutdown_server()
+
+    asyncio.run(exercise())
+
+    assert payloads[-1] == {"jsonrpc": "2.0", "method": "exit"}
+    assert logger.log.call_args.args[1] == logging.WARNING
+    assert "original_chars=9217 truncated=true" in logger.log.call_args.args[0]


### PR DESCRIPTION
Closes #43

## Summary

- Remove recursive ownership changes over `/app` and `.venv`; create only the runtime data and cache directories that `appuser` needs to write.
- Map native TypeScript `window/logMessage` severities to Python log levels.
- Log only the message text, keeping the first 8192 and last 1024 characters when truncated; include the original character count and never serialize the full params object.
- Route TypeScript protocol logs through a dedicated logger; `LSP_PROTOCOL_LOG_LEVEL=DEBUG` enables bounded diagnostic chatter without enabling application-wide debug logging.
- Send `shutdown` and `exit` without `params`, matching the TypeScript 7 LSP contract.

## Build evidence

- API affected cold layer: 324.5s on `origin/main` -> 1.2s on this branch (-99.6%).
- Analyzer affected cold layer: 41.6s on `origin/main` -> 23.1s on this branch (-44.5%).
- Immediate warm API rebuild: cached, 0.1s export step.
- API, analyzer, and worker images run as non-root; `/app` and `.venv` remain read-only while data/cache paths are writable.

## Validation

- `uv run pytest packages/core/tests/test_native_typescript_lsp.py -q` (14 passed)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `scripts/smoke/model-free-system.sh` with the candidate images: 553 symbols, 691 chunks, no-op sync pass, 10 search results
- Direct Tree-sitter extraction inside the analyzer image

The full pytest suite is left to CI because the local checkout does not provide the CI PostgreSQL service.
