### PR TITLE
fix(compose): give the api service its Prefect server URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,18 @@ services:
     environment:
       # Override DATABASE_URL for Docker network
       - DATABASE_URL=postgresql+asyncpg://contextmine:contextmine@postgres:5432/contextmine
+      # Prefect's run_deployment() reads the server from this environment
+      # variable, not from Settings.prefect_api_url. Without it the SDK falls
+      # back to an ephemeral local server and every sync-now fails to schedule.
+      - PREFECT_API_URL=http://prefect-server:4200/api
     volumes:
       # Mount source for development hot reload
       - ./packages:/app/packages:ro
       - ./apps/api:/app/apps/api:ro
     depends_on:
       postgres:
+        condition: service_healthy
+      prefect-server:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health/ready')"]


### PR DESCRIPTION
## Problem

Every `POST /api/sources/{id}/sync-now` against the compose stack returns 502:

```
{"detail":"Prefect scheduling failed"}
```

with this in the api container logs:

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) database is locked
[SQL: INSERT INTO configuration ("key", value, id, created, updated) VALUES (...)]
  parameters: {'key': 'TELEMETRY_SESSION', ...}
```

## Cause

`start_source_sync()` (`apps/api/app/routes/prefect.py:60`) calls Prefect's
`run_deployment()`. The Prefect SDK resolves its server from the **`PREFECT_API_URL`
environment variable** — not from `Settings.prefect_api_url`, which is what ContextMine
code reads everywhere else. That setting's default (`http://prefect-server:4200/api`)
is therefore never consulted on this path.

The `api` service never set the variable:

```
$ docker exec contextmine-api-1 printenv | grep -i prefect
(empty)
```

so the SDK fell back to an ephemeral local Prefect server *inside the api container*
— hence the SQLite writes. The `sync_single_source/default` deployment does not exist
in that throwaway database, so scheduling can never succeed.

## Fix

Set `PREFECT_API_URL` on the `api` service, and declare the `prefect-server` health
dependency the service actually has.

The `worker` service already sets this variable, and `scripts/smoke/docker-compose.yml`
sets it on its `api` service too — only the main compose file was missing it.

## Why CI does not catch this

The model-free smoke suite drives the sync by calling the flow directly from its
`smoke` service; it never asks the API to schedule one. The API's Prefect path is
therefore unexercised in CI.

## Verification

With the fix applied, `sync-now` schedules and the flow runs:

```
$ curl -X POST .../api/sources/<id>/sync-now
{"status":"sync_scheduled","sync_run_id":"...","flow_run_id":"..."}
```

`docker compose config` validates. Found while bringing the stack up locally against
the `fastapi/full-stack-fastapi-template` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F34wGYmJ2GQAtR9Q7eD28S