### PR TITLE
fix(worker): pin the deployment working directory

### DIFF
--- a/apps/worker/contextmine_worker/main.py
+++ b/apps/worker/contextmine_worker/main.py
@@ -2,29 +2,45 @@
 
 import asyncio
 import logging
+from pathlib import Path
 
 from contextmine_core import get_settings
 from contextmine_core.lsp import shutdown_lsp_manager
 from contextmine_core.telemetry import init_telemetry
 from prefect.workers.process import ProcessWorker
 
+import contextmine_worker
 from contextmine_worker.flows import sync_due_sources, sync_single_source
 from contextmine_worker.init_prefect import init_prefect
 
 logger = logging.getLogger(__name__)
 
 
+def _deployment_working_dir() -> str:
+    """Return the directory the relative flow entrypoint resolves against.
+
+    Deployments register their entrypoint relative to the package parent
+    ("contextmine_worker/flows.py"). ProcessWorker opens flow run processes in a
+    temporary directory unless working_dir is set, so the entrypoint would not
+    be found there.
+    """
+    return str(Path(contextmine_worker.__file__).resolve().parent.parent)
+
+
 def configure_deployments() -> None:
     """Apply the two supported source-sync deployments."""
     settings = get_settings()
+    job_variables = {"working_dir": _deployment_working_dir()}
     sync_due_sources.to_deployment(
         name="default",
         interval=settings.prefect_due_interval_seconds,
         work_pool_name=settings.prefect_work_pool_name,
+        job_variables=job_variables,
     ).apply()
     sync_single_source.to_deployment(
         name="default",
         work_pool_name=settings.prefect_work_pool_name,
+        job_variables=job_variables,
     ).apply()
 
 

--- a/apps/worker/tests/test_worker_misc.py
+++ b/apps/worker/tests/test_worker_misc.py
@@ -202,9 +202,7 @@ class TestWorkerMain:
         from contextmine_worker import main
 
         with (
-            patch.object(
-                main.sync_due_sources, "to_deployment", return_value=MagicMock()
-            ) as due,
+            patch.object(main.sync_due_sources, "to_deployment", return_value=MagicMock()) as due,
             patch.object(
                 main.sync_single_source, "to_deployment", return_value=MagicMock()
             ) as single,

--- a/apps/worker/tests/test_worker_misc.py
+++ b/apps/worker/tests/test_worker_misc.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import contextmine_core.settings as settings_module
@@ -190,6 +191,32 @@ class TestWorkerMain:
 
         due_deployment.apply.assert_called_once()
         single_deployment.apply.assert_called_once()
+
+    def test_configure_deployments_pins_the_entrypoint_working_directory(self) -> None:
+        """ProcessWorker runs flows in a temp dir unless working_dir is set.
+
+        The deployments register a relative entrypoint
+        ("contextmine_worker/flows.py:..."), so without an explicit working_dir
+        the worker cannot find the flow script and every run crashes.
+        """
+        from contextmine_worker import main
+
+        with (
+            patch.object(
+                main.sync_due_sources, "to_deployment", return_value=MagicMock()
+            ) as due,
+            patch.object(
+                main.sync_single_source, "to_deployment", return_value=MagicMock()
+            ) as single,
+        ):
+            main.configure_deployments()
+
+        for call in (due, single):
+            job_variables = call.call_args.kwargs["job_variables"]
+            working_dir = Path(job_variables["working_dir"])
+            assert working_dir.is_absolute()
+            # The relative entrypoint must resolve against this directory.
+            assert (working_dir / "contextmine_worker" / "flows.py").is_file()
 
     def test_run_worker_uses_supported_process_worker(self) -> None:
         async def _inner() -> None:


### PR DESCRIPTION
## Problem

Every sync flow run crashes the moment the worker picks it up:

```
prefect.exceptions.ScriptError: Script at
'/tmp/tmp7bui_qdzprefect/contextmine_worker/flows.py' encountered an exception:
FileNotFoundError(2, 'No such file or directory')
```

The flow run ends as `CRASHED` with `Process exited with status code: 1`.

## Cause

`configure_deployments()` registers a **relative** entrypoint and no job variables:

```
$ curl -s -X POST localhost:4200/api/deployments/filter -d '{}'
entrypoint  : contextmine_worker/flows.py:sync_single_source
path        : .
pull_steps  : null
job_vars    : {}
```

Prefect's `ProcessWorker` opens flow run processes in a **temporary directory**
unless `working_dir` is set. The relative entrypoint does not resolve there, so the
worker cannot load the flow script.

`working_dir` is a documented variable of the process work pool's base job template
(default `null`) — the deployments simply never set it.

## Fix

Pass `job_variables={"working_dir": ...}` on both deployments, derived from
`contextmine_worker.__file__` so it stays correct regardless of the worker process's
own cwd (the container's `WORKDIR` is `/app/apps/worker`, but nothing guarantees that
for other deployments).

## Test

`test_configure_deployments_pins_the_entrypoint_working_directory` asserts both
deployments receive an absolute `working_dir` that actually contains
`contextmine_worker/flows.py` — i.e. that the relative entrypoint resolves against it.

Without the production change it fails with `KeyError: 'job_variables'`; with it, all
33 tests in the file pass. `ruff check apps/worker/` is clean.

## Verification

After applying it, the deployments carry the directory and a real sync runs to
completion instead of crashing:

```
contextmine_worker/flows.py:sync_due_sources    -> {'working_dir': '/app/apps/worker'}
contextmine_worker/flows.py:sync_single_source  -> {'working_dir': '/app/apps/worker'}
```

Found while bringing the stack up locally against the
`fastapi/full-stack-fastapi-template` fixture. Needs #47 to reach this code path at
all through the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F34wGYmJ2GQAtR9Q7eD28S