### PR TITLE
fix(llm): recover structured output whose arrays arrive JSON-encoded

### DIFF
--- a/packages/core/contextmine_core/research/llm/provider.py
+++ b/packages/core/contextmine_core/research/llm/provider.py
@@ -264,9 +264,7 @@ class LangChainProvider(LLMProvider):
             # Use default method - Anthropic uses tool calling, OpenAI uses json_schema.
             # include_raw keeps the tool-call arguments available so a response
             # that only fails schema validation can still be repaired below.
-            structured_model = self._model.with_structured_output(
-                output_schema, include_raw=True
-            )
+            structured_model = self._model.with_structured_output(output_schema, include_raw=True)
             configured_model = structured_model.bind(
                 **self._generation_parameters(
                     max_tokens=max_tokens,

--- a/packages/core/contextmine_core/research/llm/provider.py
+++ b/packages/core/contextmine_core/research/llm/provider.py
@@ -12,6 +12,10 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from contextmine_core.model_policy import ensure_model_calls_enabled
+from contextmine_core.research.llm.structured import (
+    coerce_json_string_fields,
+    repair_structured_payload,
+)
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.output_parsers import PydanticOutputParser
@@ -257,8 +261,12 @@ class LangChainProvider(LLMProvider):
 
         # Try using LangChain's built-in structured output first
         try:
-            # Use default method - Anthropic uses tool calling, OpenAI uses json_schema
-            structured_model = self._model.with_structured_output(output_schema)
+            # Use default method - Anthropic uses tool calling, OpenAI uses json_schema.
+            # include_raw keeps the tool-call arguments available so a response
+            # that only fails schema validation can still be repaired below.
+            structured_model = self._model.with_structured_output(
+                output_schema, include_raw=True
+            )
             configured_model = structured_model.bind(
                 **self._generation_parameters(
                     max_tokens=max_tokens,
@@ -271,9 +279,24 @@ class LangChainProvider(LLMProvider):
             if isinstance(result, output_schema):
                 return result
 
+            if isinstance(result, dict) and "parsed" in result:
+                parsed = result["parsed"]
+                if isinstance(parsed, output_schema):
+                    return parsed
+                repaired = repair_structured_payload(result.get("raw"), output_schema)
+                if repaired is not None:
+                    return repaired
+                parsing_error = result.get("parsing_error")
+                if parsing_error is not None:
+                    raise parsing_error
+                msg = f"Model returned no usable {output_schema.__name__}"
+                raise ValueError(msg)
+
             # If we got a dict, try to parse it
             if isinstance(result, dict):
-                return output_schema.model_validate(result)
+                return output_schema.model_validate(
+                    coerce_json_string_fields(result, output_schema)
+                )
 
             # Raise a ValueError that will be caught and retried
             msg = f"Expected {output_schema.__name__}, got {type(result).__name__}"

--- a/packages/core/contextmine_core/research/llm/structured.py
+++ b/packages/core/contextmine_core/research/llm/structured.py
@@ -1,0 +1,114 @@
+"""Repair structured LLM output that arrives with JSON-encoded fields.
+
+Anthropic's tool-calling transport occasionally serializes a nested array or
+object into a JSON *string* instead of returning it structurally. The value is
+well-formed JSON, just one encoding level too deep, and strict schema
+validation rejects it:
+
+    rules
+      Input should be a valid list [type=list_type,
+       input_value='[\\n  {\\n    "name": ...', input_type=str]
+
+Decoding such fields before validation keeps the extracted data instead of
+discarding the whole response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import types
+import typing
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "coerce_json_string_fields",
+    "field_expects_structure",
+    "repair_structured_payload",
+]
+
+
+def _unwrap_annotation(annotation: Any) -> list[Any]:
+    """Return the candidate types of an annotation, flattening unions."""
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):
+        return [arg for arg in typing.get_args(annotation) if arg is not type(None)]
+    return [annotation]
+
+
+def field_expects_structure(annotation: Any) -> bool:
+    """Report whether a field wants a list, dict or model rather than a string.
+
+    A field that legitimately accepts a string is never decoded, so a
+    ``reasoning`` field holding the text ``"[1, 2]"`` keeps its exact value.
+    """
+    for candidate in _unwrap_annotation(annotation):
+        if candidate is str:
+            return False
+
+        origin = typing.get_origin(candidate) or candidate
+        if origin in (list, tuple, set, frozenset, dict):
+            return True
+        if isinstance(origin, type) and issubclass(origin, BaseModel):
+            return True
+    return False
+
+
+def coerce_json_string_fields(data: Any, schema: type[BaseModel]) -> Any:
+    """Decode JSON strings sitting in fields that expect structured values.
+
+    Returns ``data`` unchanged when it is not a mapping. Fields are left alone
+    unless the schema wants a structure there *and* the string parses as JSON,
+    so malformed output still reaches validation and reports a real error.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    coerced: dict[str, Any] = dict(data)
+    for name, field in schema.model_fields.items():
+        for key in {name, field.alias} - {None}:
+            raw = coerced.get(key)
+            if not isinstance(raw, str) or not field_expects_structure(field.annotation):
+                continue
+            try:
+                decoded = json.loads(raw)
+            except (TypeError, ValueError):
+                # Not JSON after all - let validation report the real problem.
+                continue
+            if isinstance(decoded, str):
+                # A plain quoted string is not the structure we are looking for.
+                continue
+            coerced[key] = decoded
+    return coerced
+
+
+def repair_structured_payload[T: BaseModel](
+    raw: Any,
+    output_schema: type[T],
+) -> T | None:
+    """Rebuild a schema instance from the raw tool-call arguments of a response.
+
+    Used when the provider returned a complete answer that only failed schema
+    validation because a nested value was JSON-encoded. Returns None when the
+    payload needed no repair or cannot be salvaged, so the caller still reports
+    the original error instead of hiding it.
+    """
+    tool_calls = getattr(raw, "tool_calls", None) or []
+    for tool_call in tool_calls:
+        arguments = tool_call.get("args") if isinstance(tool_call, dict) else None
+        if not isinstance(arguments, dict):
+            continue
+        coerced = coerce_json_string_fields(arguments, output_schema)
+        if coerced == arguments:
+            continue
+        try:
+            repaired = output_schema.model_validate(coerced)
+        except ValidationError:
+            continue
+        logger.warning("Repaired JSON-encoded fields in %s response", output_schema.__name__)
+        return repaired
+    return None

--- a/packages/core/contextmine_core/research/llm/structured.py
+++ b/packages/core/contextmine_core/research/llm/structured.py
@@ -76,7 +76,7 @@ def coerce_json_string_fields(data: Any, schema: type[BaseModel]) -> Any:
                 continue
             try:
                 decoded = json.loads(raw)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 # Not JSON after all - let validation report the real problem.
                 continue
             if isinstance(decoded, str):

--- a/packages/core/tests/test_llm_structured_coercion.py
+++ b/packages/core/tests/test_llm_structured_coercion.py
@@ -1,0 +1,162 @@
+"""Tests for repairing JSON-encoded fields in structured LLM output."""
+
+from __future__ import annotations
+
+from contextmine_core.analyzer.extractors.rules import ExtractionOutput
+from contextmine_core.research.llm.structured import (
+    coerce_json_string_fields,
+    field_expects_structure,
+    repair_structured_payload,
+)
+from langchain_core.messages import AIMessage
+from pydantic import BaseModel, Field
+
+# The exact shape observed from Anthropic tool calling during a sync: the
+# `rules` array arrived as a JSON string, so validation rejected the response
+# and the extracted business rules were silently dropped.
+ANTHROPIC_STRING_ARRAY_PAYLOAD = {
+    "rules": (
+        '[\n  {\n    "name": "Legacy series must stay sorted",\n'
+        '    "description": "Series entries are ordered before rendering",\n'
+        '    "category": "invariant",\n'
+        '    "severity": "error",\n'
+        '    "natural_language": "Series must be sorted before rendering",\n'
+        '    "evidence_snippet": "if (!isSorted(series)) throw new Error()",\n'
+        '    "start_line": 1137,\n    "end_line": 1139\n  }\n]'
+    ),
+    "reasoning": "Analyzed the series helper for ordering guarantees.",
+}
+
+
+class TestCoerceJsonStringFields:
+    def test_decodes_json_string_array_into_list(self) -> None:
+        coerced = coerce_json_string_fields(ANTHROPIC_STRING_ARRAY_PAYLOAD, ExtractionOutput)
+        result = ExtractionOutput.model_validate(coerced)
+
+        assert len(result.rules) == 1
+        assert result.rules[0].name == "Legacy series must stay sorted"
+        assert result.rules[0].start_line == 1137
+        assert result.rules[0].end_line == 1139
+
+    def test_leaves_string_fields_untouched(self) -> None:
+        """A string field keeps its literal value even when it looks like JSON."""
+        payload = {"rules": [], "reasoning": '["not", "a", "list"]'}
+
+        coerced = coerce_json_string_fields(payload, ExtractionOutput)
+
+        assert coerced["reasoning"] == '["not", "a", "list"]'
+        assert ExtractionOutput.model_validate(coerced).reasoning == '["not", "a", "list"]'
+
+    def test_leaves_wellformed_payloads_unchanged(self) -> None:
+        payload = {
+            "rules": [
+                {
+                    "name": "n",
+                    "description": "d",
+                    "category": "validation",
+                    "severity": "error",
+                    "natural_language": "nl",
+                    "evidence_snippet": "s",
+                    "start_line": 1,
+                    "end_line": 2,
+                }
+            ],
+            "reasoning": "r",
+        }
+
+        assert coerce_json_string_fields(payload, ExtractionOutput) == payload
+
+    def test_leaves_malformed_json_for_validation_to_report(self) -> None:
+        """Broken output must still surface as a validation error, not be hidden."""
+        payload = {"rules": "[{unclosed", "reasoning": "r"}
+
+        coerced = coerce_json_string_fields(payload, ExtractionOutput)
+
+        assert coerced["rules"] == "[{unclosed"
+
+    def test_returns_non_mapping_input_unchanged(self) -> None:
+        assert coerce_json_string_fields(["a"], ExtractionOutput) == ["a"]
+        assert coerce_json_string_fields(None, ExtractionOutput) is None
+
+    def test_decodes_nested_model_and_dict_fields(self) -> None:
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            inner: Inner
+            mapping: dict[str, int]
+            label: str
+
+        payload = {"inner": '{"value": 5}', "mapping": '{"a": 1}', "label": "plain"}
+
+        result = Outer.model_validate(coerce_json_string_fields(payload, Outer))
+
+        assert result.inner.value == 5
+        assert result.mapping == {"a": 1}
+        assert result.label == "plain"
+
+    def test_decodes_optional_structured_field(self) -> None:
+        class WithOptional(BaseModel):
+            items: list[int] | None = Field(default=None)
+
+        coerced = coerce_json_string_fields({"items": "[1, 2, 3]"}, WithOptional)
+
+        assert WithOptional.model_validate(coerced).items == [1, 2, 3]
+
+
+class TestFieldExpectsStructure:
+    def test_recognises_structured_annotations(self) -> None:
+        assert field_expects_structure(list[int])
+        assert field_expects_structure(dict[str, int])
+        assert field_expects_structure(list[str] | None)
+
+    def test_rejects_plain_scalar_annotations(self) -> None:
+        assert not field_expects_structure(str)
+        assert not field_expects_structure(int)
+        assert not field_expects_structure(str | None)
+
+
+def _tool_call_message(arguments: dict) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "ExtractionOutput",
+                "args": arguments,
+                "id": "toolu_test",
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+class TestRepairStructuredPayload:
+    def test_recovers_response_whose_array_arrived_as_json_string(self) -> None:
+        repaired = repair_structured_payload(
+            _tool_call_message(ANTHROPIC_STRING_ARRAY_PAYLOAD), ExtractionOutput
+        )
+
+        assert repaired is not None
+        assert len(repaired.rules) == 1
+        assert repaired.rules[0].name == "Legacy series must stay sorted"
+
+    def test_returns_none_when_nothing_needed_repairing(self) -> None:
+        """A payload that was already fine is left to the normal error path."""
+        assert (
+            repair_structured_payload(
+                _tool_call_message({"rules": [], "reasoning": "r"}), ExtractionOutput
+            )
+            is None
+        )
+
+    def test_returns_none_for_unusable_payload(self) -> None:
+        assert (
+            repair_structured_payload(
+                _tool_call_message({"rules": "[{unclosed", "reasoning": "r"}), ExtractionOutput
+            )
+            is None
+        )
+
+    def test_returns_none_without_tool_calls(self) -> None:
+        assert repair_structured_payload(AIMessage(content=""), ExtractionOutput) is None
+        assert repair_structured_payload(None, ExtractionOutput) is None


### PR DESCRIPTION
## Problem

During a real sync against `fastapi/full-stack-fastapi-template` with `DEFAULT_LLM_PROVIDER=anthropic`, extracted business rules were silently discarded:

```
Failed to analyze superset-frontend/plugins/plugin-chart-echarts/test/utils/series.test.ts
lines 1001-1500: 1 validation error for ExtractionOutput
rules
  Input should be a valid list [type=list_type,
   input_value='[\n  {\n    "name": "Leg...end_line": 1139\n  }\n]', input_type=str]
```

The model had done the work — the payload contains a complete, well-formed rule — but it arrived as a JSON **string** instead of a list, so validation rejected it and `rules.py` logged a warning and moved on with an empty result.

## Cause

`generate_structured()` notes it itself: *"Anthropic uses tool calling, OpenAI uses json_schema."* Anthropic's tool-calling transport occasionally serializes a nested array or object into a JSON string rather than returning it structurally. The value is valid JSON, just encoded one level too deep.

Neither existing safety net catches it:
- `except NotImplementedError` only covers providers without structured-output support.
- The tenacity retry is limited to `ConnectionError`/`TimeoutError`.

A `ValidationError` falls through both, so the response is lost.

This affects **only the Anthropic path**; `json_schema` (OpenAI) does not exhibit it.

## Fix

Request the raw response alongside the parsed one (`include_raw=True`) and, when parsing failed, decode the JSON-encoded fields from the tool-call arguments and validate again.

The decoding is deliberately conservative — a field is only touched when **both** hold:
1. the schema wants a structure there (list/dict/model, never `str`), and
2. the string actually parses as JSON.

So a `str` field keeps the literal text `"[1, 2]"`, and genuinely malformed output still surfaces as a validation error instead of being silently swallowed. If nothing needed repair, the original error is re-raised unchanged.

The repair lives in a new `research/llm/structured.py` as pure functions, independent of the provider class, so it is directly testable and reusable across all 16 `output_schema=` call sites.

## Tests

13 new tests in `packages/core/tests/test_llm_structured_coercion.py`, built around the **exact payload shape observed in the failing sync**:

- decodes the JSON-string array into real `BusinessRuleDef` entries
- leaves a `str` field holding `'["not", "a", "list"]'` byte-identical
- leaves well-formed payloads untouched
- leaves malformed JSON alone so validation still reports it
- handles nested models, dicts and optional structured fields
- `repair_structured_payload` returns `None` when nothing needed repair, when the payload is unusable, and when there are no tool calls

Full suite: **3180 passed, 14 skipped**, `ruff check` clean, `uvx ty check` clean.

(`packages/core/tests/test_native_typescript_lsp.py` fails to collect with `ModuleNotFoundError: No module named 'multilspy'` — a pre-existing optional dependency issue, unrelated to this change.)

## Why CI does not catch this

The model-free smoke suite runs with `MODEL_CALLS_ENABLED=false` and therefore never exercises a real provider response. This class of bug is invisible to it by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)