### PR TITLE
fix(cockpit): make the graph views readable and stop relayout on every click

### DIFF
--- a/apps/web/src/cockpit/views/DeepDiveView.test.tsx
+++ b/apps/web/src/cockpit/views/DeepDiveView.test.tsx
@@ -3,20 +3,27 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { OverlayState, TwinGraphResponse } from '../types'
 
 vi.mock('cytoscape', () => ({
-  default: vi.fn().mockReturnValue({
+  default: vi.fn(() => ({
     on: vi.fn(),
     destroy: vi.fn(),
     fit: vi.fn(),
     layout: vi.fn().mockReturnValue({ run: vi.fn() }),
-  }),
+    batch: vi.fn((mutate: () => void) => mutate()),
+    getElementById: vi.fn(() => ({ empty: () => false, data: vi.fn() })),
+    nodes: vi.fn(() => ({ toggleClass: vi.fn() })),
+  })),
 }))
 
+import cytoscape from 'cytoscape'
+
 import DeepDiveView from './DeepDiveView'
+
+const cytoscapeMock = vi.mocked(cytoscape)
 
 const noOverlay: OverlayState = {
   mode: 'none',
@@ -200,5 +207,84 @@ describe('DeepDiveView rendering', () => {
     })} />)
     await userEvent.click(screen.getByText('Switch to Code / Controlflow'))
     expect(onSwitchToCodeLayer).toHaveBeenCalledOnce()
+  })
+})
+
+
+describe('DeepDiveView graph lifecycle', () => {
+  beforeEach(() => {
+    cytoscapeMock.mockClear()
+  })
+
+  it('does not rebuild the graph when the selection changes', () => {
+    // Rebuilding tears down the instance and re-runs the layout over every
+    // node - doing that on each click makes the view unusable.
+    const props = makeProps()
+    const { rerender } = render(<DeepDiveView {...props} />)
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+
+    rerender(<DeepDiveView {...props} selectedNodeId="n1" />)
+    rerender(<DeepDiveView {...props} selectedNodeId="n2" />)
+
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not rebuild the graph when the overlay or click handler changes', () => {
+    const props = makeProps()
+    const { rerender } = render(<DeepDiveView {...props} />)
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <DeepDiveView
+        {...props}
+        overlay={{ ...noOverlay, riskByNodeKey: { 'file:auth.py': { severity_score: 9 } } }}
+        onSelectNodeId={vi.fn()}
+      />,
+    )
+
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds the graph when the graph data itself changes', () => {
+    const props = makeProps()
+    const { rerender } = render(<DeepDiveView {...props} />)
+
+    rerender(<DeepDiveView {...props} graph={{ ...populatedGraph, total_nodes: 3 }} />)
+
+    expect(cytoscapeMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('overrides the cose defaults that produce the dense clump', () => {
+    render(<DeepDiveView {...makeProps({ density: 3000 })} />)
+
+    const options = cytoscapeMock.mock.calls[0][0] as { layout: Record<string, unknown> }
+    expect(options.layout.name).toBe('cose')
+    // Defaults are idealEdgeLength 32 and nodeRepulsion 2048 - far too tight here.
+    expect(options.layout.idealEdgeLength).toBe(80)
+    expect(options.layout.nodeRepulsion).toBe(8000)
+  })
+
+  it('enables the WebGL renderer and viewport optimisations', () => {
+    render(<DeepDiveView {...makeProps()} />)
+
+    const options = cytoscapeMock.mock.calls[0][0] as Record<string, unknown>
+    expect(options.renderer).toEqual({ name: 'canvas', webgl: true })
+    expect(options.textureOnViewport).toBe(true)
+    expect(options.hideEdgesOnViewport).toBe(true)
+  })
+
+  it('places labels beside nodes and stops drawing them when too small', () => {
+    render(<DeepDiveView {...makeProps()} />)
+
+    const options = cytoscapeMock.mock.calls[0][0] as {
+      style: Array<{ selector: string; style: Record<string, unknown> }>
+    }
+    const nodeStyle = options.style.find((rule) => rule.selector === 'node')?.style
+    // A 10px label does not fit inside a 20px circle.
+    expect(nodeStyle?.['text-halign']).toBe('right')
+    expect(nodeStyle?.['min-zoomed-font-size']).toBe(8)
+
+    const edgeStyle = options.style.find((rule) => rule.selector === 'edge')?.style
+    expect(edgeStyle?.['curve-style']).toBe('straight')
   })
 })

--- a/apps/web/src/cockpit/views/DeepDiveView.tsx
+++ b/apps/web/src/cockpit/views/DeepDiveView.tsx
@@ -21,8 +21,38 @@ interface DeepDiveViewProps {
   onRetry: () => void
 }
 
+/**
+ * cytoscape 3.31 added a WebGL renderer, but @types/cytoscape does not model the
+ * `renderer` option yet. Verified present in the installed build - cytoscape.esm.mjs
+ * contains webglTexSize, textureOnViewport and hideEdgesOnViewport.
+ */
+const WEBGL_RENDERER: Record<string, unknown> = {
+  renderer: { name: 'canvas', webgl: true },
+}
+
 function getLayoutName(density: number): 'cose' | 'breadthfirst' {
   return density > 5000 ? 'breadthfirst' : 'cose'
+}
+
+/**
+ * Cytoscape's cose defaults (idealEdgeLength 32, nodeRepulsion 2048) are tuned for
+ * small graphs. At the densities this view reaches - hundreds of nodes averaging
+ * several edges each - they pull everything into one unreadable clump.
+ */
+function layoutOptions(density: number) {
+  const name = getLayoutName(density)
+  if (name === 'breadthfirst') {
+    return { name, animate: false, spacingFactor: 1.4 }
+  }
+  return {
+    name,
+    animate: false,
+    idealEdgeLength: 80,
+    nodeRepulsion: 8000,
+    nodeOverlap: 20,
+    componentSpacing: 120,
+    nestingFactor: 1.2,
+  }
 }
 
 function humanizeSliceStrategy(strategy: string | undefined): string {
@@ -51,6 +81,13 @@ export default function DeepDiveView({
   const [showLabelsOverride, setShowLabelsOverride] = useState<boolean | null>(null)
   const showLabels = showLabelsOverride ?? density <= 5000
 
+  // Read through a ref so a caller that re-creates this handler on every render
+  // cannot invalidate the build effect and trigger a full relayout.
+  const selectHandlerRef = useRef(onSelectNodeId)
+  useEffect(() => {
+    selectHandlerRef.current = onSelectNodeId
+  }, [onSelectNodeId])
+
   useEffect(() => {
     if (!containerRef.current || state === 'loading' || graph.nodes.length === 0) {
       return
@@ -63,21 +100,23 @@ export default function DeepDiveView({
 
     const next = cytoscape({
       container: containerRef.current,
+      // Without the WebGL renderer cytoscape falls back to plain canvas and
+      // redraws every edge on each frame.
+      ...WEBGL_RENDERER,
+      textureOnViewport: true,
+      hideEdgesOnViewport: true,
+      motionBlur: true,
       elements: [
-        ...graph.nodes.map((node) => {
-          const runtime = overlay.runtimeByNodeKey[node.natural_key] || overlay.runtimeByNodeKey[node.name]
-          const risk = overlay.riskByNodeKey[node.natural_key] || overlay.riskByNodeKey[node.name]
-          return {
-            data: {
-              id: node.id,
-              label: node.name,
-              kind: node.kind,
-              selected: selectedNodeId === node.id ? 1 : 0,
-              runtime_error: Number(runtime?.error_rate || 0),
-              risk_score: Number(risk?.severity_score || 0),
-            },
-          }
-        }),
+        ...graph.nodes.map((node) => ({
+          data: {
+            id: node.id,
+            label: node.name,
+            kind: node.kind,
+            selected: 0,
+            runtime_error: 0,
+            risk_score: 0,
+          },
+        })),
         ...graph.edges.map((edge) => ({
           data: {
             id: edge.id,
@@ -93,14 +132,26 @@ export default function DeepDiveView({
           style: {
             'background-color': '#1d4ed8',
             color: '#0f172a',
-            label: showLabels ? 'data(label)' : '',
-            'font-size': 9,
+            label: 'data(label)',
+            'font-size': 10,
+            // Cytoscape's only built-in label LOD: stop drawing text that would
+            // be too small to read instead of painting hundreds of smudges.
+            'min-zoomed-font-size': 8,
             width: 20,
             height: 20,
             'text-valign': 'center',
-            'text-halign': 'center',
+            // A 10px label does not fit inside a 20px circle - place it beside.
+            'text-halign': 'right',
+            'text-margin-x': 4,
+            'text-events': 'no',
             'border-width': 1,
             'border-color': '#0f172a',
+          },
+        },
+        {
+          selector: 'node.cm-labels-hidden',
+          style: {
+            label: '',
           },
         },
         {
@@ -141,19 +192,15 @@ export default function DeepDiveView({
             'line-color': '#94a3b8',
             'target-arrow-color': '#94a3b8',
             'target-arrow-shape': 'triangle',
-            'curve-style': 'bezier',
+            'curve-style': 'straight',
           },
         },
       ],
-      layout: {
-        name: getLayoutName(density),
-        animate: false,
-      },
+      layout: layoutOptions(density),
     })
 
     next.on('tap', 'node', (event) => {
-      const id = String(event.target.id())
-      onSelectNodeId(id)
+      selectHandlerRef.current(String(event.target.id()))
     })
 
     graphRef.current = next
@@ -162,7 +209,31 @@ export default function DeepDiveView({
       next.destroy()
       graphRef.current = null
     }
-  }, [graph, state, showLabels, density, overlay, selectedNodeId, onSelectNodeId])
+  }, [graph, state, density])
+
+  // Selection and overlay are data updates. Rebuilding the instance for them
+  // would re-run the layout on every click.
+  useEffect(() => {
+    const cy = graphRef.current
+    if (!cy) return
+    cy.batch(() => {
+      for (const node of graph.nodes) {
+        const element = cy.getElementById(node.id)
+        if (element.empty()) continue
+        const runtime = overlay.runtimeByNodeKey[node.natural_key] || overlay.runtimeByNodeKey[node.name]
+        const risk = overlay.riskByNodeKey[node.natural_key] || overlay.riskByNodeKey[node.name]
+        element.data('selected', selectedNodeId === node.id ? 1 : 0)
+        element.data('runtime_error', Number(runtime?.error_rate || 0))
+        element.data('risk_score', Number(risk?.severity_score || 0))
+      }
+    })
+  }, [graph, overlay, selectedNodeId, state, density])
+
+  useEffect(() => {
+    const cy = graphRef.current
+    if (!cy) return
+    cy.nodes().toggleClass('cm-labels-hidden', !showLabels)
+  }, [showLabels, graph, state, density])
   const warnings = graph.warnings || []
   const provenanceNotes: string[] = []
   if (graph.provenance?.source === 'knowledge_recovery') {

--- a/apps/web/src/cockpit/views/TopologyView.test.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.test.tsx
@@ -191,7 +191,8 @@ describe('TopologyView rendering', () => {
   it('renders toolbar buttons', () => {
     render(<TopologyView {...makeProps()} />)
     expect(screen.getByText('Fit view')).toBeInTheDocument()
-    expect(screen.getByText('Show labels')).toBeInTheDocument()
+    // Labels are on by default, so the button offers to hide them.
+    expect(screen.getByText('Hide labels')).toBeInTheDocument()
     expect(screen.getByText('Display options')).toBeInTheDocument()
   })
 
@@ -205,10 +206,14 @@ describe('TopologyView rendering', () => {
     expect(screen.getByText(/cross-page edges are hidden/)).toBeInTheDocument()
   })
 
-  it('toggles show labels button text on click', async () => {
+  it('shows labels by default and toggles the button text on click', async () => {
     render(<TopologyView {...makeProps()} />)
-    const btn = screen.getByText('Show labels')
+    const btn = screen.getByText('Hide labels')
+
     await userEvent.click(btn)
+    expect(screen.getByText('Show labels')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Show labels'))
     expect(screen.getByText('Hide labels')).toBeInTheDocument()
   })
 

--- a/apps/web/src/cockpit/views/TopologyView.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.tsx
@@ -178,7 +178,9 @@ export default function TopologyView({
   onLayoutCompleted,
   onRetry,
 }: Readonly<TopologyViewProps>) {
-  const [showLabels, setShowLabels] = useState(false)
+  // Labels are what makes a topology readable; without them the nodes collapse
+  // to their minimum height and the view reads as unlabelled dots.
+  const [showLabels, setShowLabels] = useState(true)
   const [showMiniMap, setShowMiniMap] = useState(false)
   const [showDisplayOptions, setShowDisplayOptions] = useState(false)
   const [instance, setInstance] = useState<ReactFlowInstance | null>(null)


### PR DESCRIPTION
## Problem

The deep dive graph renders as a dense clump of unlabelled 20px circles and freezes on interaction. Measured against a real collection: 487 nodes, 2823 edges, average degree 11.6.

None of it is a library limit. Four separate causes:

## 1. Every click re-ran the layout

`DeepDiveView.tsx:164` had `selectedNodeId`, `overlay` and `onSelectNodeId` in the **build effect's** dependency array. Selecting a node therefore destroyed the cytoscape instance and re-ran `cose` over every node — all-pairs repulsion (`cose.mjs:746`), `numIter: 1000` (`cose.mjs:89`), on the main thread.

Selection and overlay are data updates. They now mutate through `cy.batch()`, and the click handler is read through a ref so a caller that re-creates it on every render cannot invalidate the build.

## 2. The clump was two default values

The layout was called with no parameters, so cytoscape's `cose` defaults applied: `idealEdgeLength: 32` and `nodeRepulsion: 2048`. Those are tuned for small graphs; at several edges per node they pull everything together. Now 80 and 8000, with explicit `nodeOverlap` and `componentSpacing`.

## 3. Labels were drawn inside the nodes

`font-size: 9` with `text-valign`/`text-halign: center` inside a 20px circle — structurally unreadable. Labels now sit beside the node and drop out below `min-zoomed-font-size`, which is cytoscape's only built-in label level-of-detail. Previously several hundred unreadable text blocks were painted per frame.

## 4. WebGL was available but never switched on

The installed cytoscape ships a WebGL renderer; `DeepDiveView.tsx:64` passed no `renderer` block, so it fell back to plain canvas. Every edge additionally used `curve-style: bezier`, the most expensive variant, recomputing control points on each redraw.

Now: WebGL on, edges straight, plus `textureOnViewport`, `hideEdgesOnViewport` and `motionBlur`. The published WebGL preview measures 1200 nodes / 16 000 edges going from 20 FPS to over 100 — comfortably above this graph.

The `renderer` option is cast to `Record<string, unknown>` because `@types/cytoscape` does not model it yet. Its presence in the installed build was verified directly in `node_modules/cytoscape/dist/cytoscape.esm.mjs` (`webglTexSize`, `textureOnViewport`, `hideEdgesOnViewport`).

## Topology: labels on by default

`TopologyView.tsx:181` defaulted `showLabels` to `false`. With labels off the nodes collapse to their minimum height — measured 105 × 11 px, which is the configured 210px width at zoom 0.5 — and the view reads as unlabelled dots.

## Tests

Six new tests in `DeepDiveView.test.tsx` covering the rebuild lifecycle, the layout parameters, the renderer options and the label placement. The two rebuild tests fail without the dependency-array change:

```
× does not rebuild the graph when the selection changes
× does not rebuild the graph when the overlay or click handler changes
```

Two existing topology tests asserted the old label default and were updated; the toggle test now covers both directions.

**470 web tests pass**, `tsc --noEmit` and `eslint --max-warnings=0` are clean.

## Scope

This is the configuration half of a larger problem. It does **not** address load time — the topology endpoint takes 127s for a 122KB response because the full scenario graph is loaded and paginated in Python. That is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)