### PR TITLE
fix(cockpit): report layout failures instead of swallowing them

### DIFF
--- a/apps/web/src/cockpit/views/TopologyView.test.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { OverlayState, TwinGraphResponse } from '../types'
 
@@ -288,5 +288,47 @@ describe('TopologyView rendering', () => {
     })} />)
     await userEvent.click(screen.getByText('Switch to Code / Controlflow'))
     expect(onSwitchToCodeLayer).toHaveBeenCalledOnce()
+  })
+})
+
+
+describe('TopologyView layout failures', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function architectureGraph(): TwinGraphResponse {
+    // ELK only runs for architecture projections of 100 nodes or more.
+    const nodes = Array.from({ length: 120 }, (_, index) => ({
+      id: `n${index}`,
+      natural_key: `file:module${index}.py`,
+      kind: 'FILE',
+      name: `module${index}.py`,
+      meta: {},
+    }))
+    return { nodes, edges: [], page: 0, limit: 5000, total_nodes: nodes.length, projection: 'architecture' }
+  }
+
+  it('reports a failed layout instead of claiming it finished', async () => {
+    // A swallowed error used to leave the grid placeholder on screen while the
+    // view reported a refined layout, with nothing to diagnose from.
+    const { runElkLayout } = await import('../layout/layoutCore')
+    vi.mocked(runElkLayout).mockRejectedValueOnce(new Error('elk failed'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<TopologyView {...makeProps({ graph: architectureGraph(), layoutEngine: 'elk_layered' })} />)
+
+    expect(await screen.findByText(/Layout failed, showing grid placeholder/)).toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('does not report a failure when the layout succeeds', async () => {
+    const { runElkLayout } = await import('../layout/layoutCore')
+    vi.mocked(runElkLayout).mockResolvedValueOnce({})
+
+    render(<TopologyView {...makeProps({ graph: architectureGraph(), layoutEngine: 'elk_layered' })} />)
+
+    await screen.findByTestId('reactflow')
+    expect(screen.queryByText(/Layout failed/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/cockpit/views/TopologyView.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.tsx
@@ -21,22 +21,33 @@ interface ElkLayoutParams {
   onPositions: (positions: Record<string, { x: number; y: number }>) => void
   onCompleted: (engine: LayoutEngine, durationMs: number, nodeCount: number) => void
   onFinish: () => void
+  onError: (reason: unknown) => void
 }
 
 /** Run ELK layout (in-thread or via worker), calling back with positions on completion. */
 async function applyElkLayout(params: Readonly<ElkLayoutParams>): Promise<void> {
-  const { nodes, edges, engine, columns, cancelled, startedAt, onPositions, onCompleted, onFinish } = params
+  const { nodes, edges, engine, columns, cancelled, startedAt, onPositions, onCompleted, onFinish, onError } = params
   try {
     if (nodes.length > 1000) {
       const worker = new Worker(new URL('../layout/layoutWorker.ts', import.meta.url), {
         type: 'module',
       })
-      worker.onmessage = (event: MessageEvent<{ ok: boolean; positions?: Record<string, { x: number; y: number }>; durationMs: number }>) => {
+      worker.onmessage = (event: MessageEvent<{ ok: boolean; positions?: Record<string, { x: number; y: number }>; durationMs: number; error?: string }>) => {
         worker.terminate()
-        if (cancelled.current || !event.data.ok || !event.data.positions) return
+        if (cancelled.current) return
+        if (!event.data.ok || !event.data.positions) {
+          onError(event.data.error ?? 'layout worker returned no positions')
+          return
+        }
         onPositions(event.data.positions)
         onFinish()
         onCompleted(engine, event.data.durationMs, nodes.length)
+      }
+      // Without this the worker failing leaves the status stuck on 'coarse'.
+      worker.onerror = (event) => {
+        worker.terminate()
+        if (cancelled.current) return
+        onError(event.message || 'layout worker failed')
       }
       worker.postMessage({ nodes, edges, engine, columns })
       return
@@ -47,9 +58,11 @@ async function applyElkLayout(params: Readonly<ElkLayoutParams>): Promise<void> 
     onPositions(positions)
     onFinish()
     onCompleted(engine, durationMs, nodes.length)
-  } catch {
+  } catch (reason) {
     if (cancelled.current) return
-    onFinish()
+    // Swallowing this used to leave the grid placeholder on screen while the
+    // view reported a finished layout, with nothing to diagnose from.
+    onError(reason)
   }
 }
 import { layerLabel } from '../types'
@@ -182,7 +195,7 @@ export default function TopologyView({
   const [showMiniMap, setShowMiniMap] = useState(false)
   const [showDisplayOptions, setShowDisplayOptions] = useState(false)
   const [instance, setInstance] = useState<ReactFlowInstance | null>(null)
-  const [layoutStatus, setLayoutStatus] = useState<'idle' | 'coarse' | 'refined'>('idle')
+  const [layoutStatus, setLayoutStatus] = useState<'idle' | 'coarse' | 'refined' | 'degraded'>('idle')
   const [layoutPositions, setLayoutPositions] = useState<Record<string, { x: number; y: number }>>({})
 
   const densityToColumns: Record<number, number> = { 800: 4, 1200: 6 }
@@ -218,6 +231,10 @@ export default function TopologyView({
         onPositions: setLayoutPositions,
         onCompleted: onLayoutCompleted,
         onFinish: () => setLayoutStatus('refined'),
+        onError: (reason) => {
+          console.error('[cockpit] %s layout failed, showing grid placeholder', preferredEngine, reason)
+          setLayoutStatus('degraded')
+        },
       })
     }, 0)
     return () => {
@@ -278,6 +295,7 @@ export default function TopologyView({
           Nodes: {graph.visible_nodes ?? graph.nodes.length} / Total: {graph.candidate_nodes ?? graph.total_nodes} • Edges: {graph.visible_edges ?? graph.edges.length}
           {graph.slice_strategy ? ` • Slice: ${humanizeSliceStrategy(graph.slice_strategy)}` : ''}
           {layoutStatus === 'coarse' ? ' • Refining layout…' : ''}
+          {layoutStatus === 'degraded' ? ' • Layout failed, showing grid placeholder' : ''}
         </p>
       </div>
 


### PR DESCRIPTION
## Problem

`TopologyView.tsx:51` ended in an empty catch:

```ts
} catch {
  if (cancelled.current) return
  onFinish()
}
```

A failed ELK run therefore left the grid placeholder on screen **while the view reported a finished layout** — no log, no message, nothing to diagnose from.

This is not hypothetical. Observed against a real collection: the default engine is `elk_layered` (`CockpitPage.tsx:174`) and all three conditions at `TopologyView.tsx:191` were met — `projection === 'architecture'`, 487 nodes ≥ 100, flag enabled. The rendered positions were nevertheless a plain 120px grid, six nodes on identical `y`. Because the error was discarded there was no way to tell whether ELK had thrown, never started, or silently produced nothing.

## Fix

Failures now surface three ways:

- the reason is logged together with the engine that failed
- the panel reports `Layout failed, showing grid placeholder` instead of staying silent
- a new `degraded` layout status distinguishes that state from a finished layout

Two paths that previously could not report at all are also handled:

- **The worker already returns an `error` field on failure** (`layoutWorker.ts:25`) — it was ignored. It is now read and passed on.
- **The worker had no `onerror` handler.** A worker that failed outright left the status stuck on `coarse` forever.

## What this does not do

It does not fix the underlying ELK failure — it makes it diagnosable. Layout performance is ruled out as the cause: elkjs `layered` with `ORTHOGONAL` routing lays out this graph in **389 ms** measured in node (50 nodes → 89 ms, 200 → 134 ms, 487/2823 → 389 ms). Dangling edges are ruled out too — 0 dangling, 0 self-loops in the payload.

## Tests

Two new tests. The failure test fails without this change:

```
× reports a failed layout instead of claiming it finished
```

The companion test asserts no failure is reported when the layout succeeds, so the message cannot become sticky.

**466 web tests pass**, `tsc --noEmit` and `eslint --max-warnings=0` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)