### PR TITLE
fix(codecharta): show exported edges and colour metrics in the right direction

### DIFF
--- a/apps/web/src/cockpit/hooks/useCockpitData.test.ts
+++ b/apps/web/src/cockpit/hooks/useCockpitData.test.ts
@@ -172,3 +172,4 @@ describe('parseApiErrorMessage', () => {
     expect(result).toBe('Validation error (422)')
   })
 })
+

--- a/apps/web/src/cockpit/hooks/useCockpitData.ts
+++ b/apps/web/src/cockpit/hooks/useCockpitData.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api, apiData, apiErrorMessage } from '../../api/client'
+import { buildCityEmbedUrl } from '../utils/cityEmbed'
 import type {
   Arc42DriftPayload,
   Arc42ViewPayload,
@@ -358,8 +359,7 @@ export function useCockpitData(args: UseCockpitDataArgs) {
         const exportId = created.id ?? created.exports?.[0]?.id
         if (!exportId) throw new Error('Missing export id from city export response')
         const rawPath = `/api/twin/scenarios/${scenarioId}/exports/${exportId}/raw`
-        const embed = new URLSearchParams({ file: rawPath, area: 'loc', height: 'coupling', color: 'complexity', mode: 'Single' })
-        return { cityEmbedUrl: `/codecharta/index.html?${embed.toString()}` }
+        return { cityEmbedUrl: buildCityEmbedUrl(rawPath) }
       }
 
       return {}

--- a/apps/web/src/cockpit/utils/cityEmbed.test.ts
+++ b/apps/web/src/cockpit/utils/cityEmbed.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCityEmbedUrl } from './cityEmbed'
+
+describe('buildCityEmbedUrl', () => {
+  it('asks the viewer to show the exported dependency edges', () => {
+    // Without an edge metric the embedded viewer leaves isEdgeMetricVisible
+    // off and never draws the edges the export carries.
+    const params = new URLSearchParams(
+      buildCityEmbedUrl('/api/twin/scenarios/s1/exports/e1/raw').split('?')[1],
+    )
+
+    expect(params.get('edge')).toBe('dependency_weight')
+    expect(params.get('file')).toBe('/api/twin/scenarios/s1/exports/e1/raw')
+    expect(params.get('area')).toBe('loc')
+    expect(params.get('height')).toBe('coupling')
+    expect(params.get('color')).toBe('complexity')
+    expect(params.get('mode')).toBe('Single')
+  })
+
+  it('points at the proxied viewer', () => {
+    expect(buildCityEmbedUrl('/raw')).toMatch(/^\/codecharta\/index\.html\?/)
+  })
+})

--- a/apps/web/src/cockpit/utils/cityEmbed.ts
+++ b/apps/web/src/cockpit/utils/cityEmbed.ts
@@ -1,0 +1,18 @@
+/**
+ * Query string for the embedded CodeCharta viewer.
+ *
+ * `edge` matters: without an edge metric the viewer never sets
+ * isEdgeMetricVisible, so the dependency edges carried in the export are
+ * never drawn.
+ */
+export function buildCityEmbedUrl(rawPath: string): string {
+  const embed = new URLSearchParams({
+    file: rawPath,
+    area: 'loc',
+    height: 'coupling',
+    color: 'complexity',
+    edge: 'dependency_weight',
+    mode: 'Single',
+  })
+  return `/codecharta/index.html?${embed.toString()}`
+}

--- a/packages/core/contextmine_core/exports/codecharta.py
+++ b/packages/core/contextmine_core/exports/codecharta.py
@@ -467,6 +467,33 @@ async def _build_arch_projection_leaf_items(
     return leaf_items
 
 
+# CodeCharta reverses its colour scale when a descriptor reports direction == 1,
+# so a metric where a high value is good must say so explicitly. Without these
+# descriptors every metric is treated as "higher is worse" and well-covered,
+# cohesive files are painted as if they were the problem.
+_HIGHER_IS_BETTER = 1
+_HIGHER_IS_WORSE = -1
+
+_ATTRIBUTE_DESCRIPTORS: dict[str, dict[str, object]] = {
+    "loc": {"title": "Lines of Code", "direction": _HIGHER_IS_WORSE},
+    "symbol_count": {"title": "Symbols", "direction": _HIGHER_IS_WORSE},
+    "coupling": {"title": "Coupling", "direction": _HIGHER_IS_WORSE},
+    "coverage": {"title": "Test coverage", "direction": _HIGHER_IS_BETTER},
+    "complexity": {"title": "Cyclomatic complexity", "direction": _HIGHER_IS_WORSE},
+    "cohesion": {"title": "Cohesion", "direction": _HIGHER_IS_BETTER},
+    "instability": {"title": "Instability", "direction": _HIGHER_IS_WORSE},
+    "fan_in": {"title": "Fan-in", "direction": _HIGHER_IS_WORSE},
+    "fan_out": {"title": "Fan-out", "direction": _HIGHER_IS_WORSE},
+    "cycle_participation": {"title": "Cycle participation", "direction": _HIGHER_IS_WORSE},
+    "cycle_size": {"title": "Cycle size", "direction": _HIGHER_IS_WORSE},
+    "duplication_ratio": {"title": "Duplication", "direction": _HIGHER_IS_WORSE},
+    "crap_score": {"title": "CRAP score", "direction": _HIGHER_IS_WORSE},
+    "change_frequency": {"title": "Change frequency", "direction": _HIGHER_IS_WORSE},
+    "churn": {"title": "Churn", "direction": _HIGHER_IS_WORSE},
+    "dependency_weight": {"title": "Dependency weight", "direction": _HIGHER_IS_WORSE},
+}
+
+
 async def export_codecharta_json(
     session: AsyncSession,
     scenario_id: UUID,
@@ -546,6 +573,7 @@ async def export_codecharta_json(
         "apiVersion": "1.5",
         "nodes": [root],
         "edges": cc_edges,
+        "attributeDescriptors": _ATTRIBUTE_DESCRIPTORS,
         "attributeTypes": {
             "nodes": {
                 "loc": "absolute",

--- a/packages/core/tests/test_codecharta_export.py
+++ b/packages/core/tests/test_codecharta_export.py
@@ -181,6 +181,21 @@ async def test_codecharta_file_projection_schema_and_edges(test_session: AsyncSe
     assert leaves["/root/apps/web/App.tsx"]["churn"] == pytest.approx(30.0)
     assert payload["attributeTypes"]["nodes"]["churn"] == "absolute"
 
+    # CodeCharta reverses its colour scale only when a descriptor says direction == 1.
+    # Without these, high coverage and high cohesion are painted as problems.
+    descriptors = payload["attributeDescriptors"]
+    assert descriptors["coverage"]["direction"] == 1
+    assert descriptors["cohesion"]["direction"] == 1
+    assert descriptors["complexity"]["direction"] == -1
+    assert descriptors["churn"]["direction"] == -1
+    assert descriptors["coverage"]["title"] == "Test coverage"
+    # Every exported node metric needs a descriptor, otherwise it silently
+    # falls back to "higher is worse".
+    for metric in payload["attributeTypes"]["nodes"]:
+        assert metric in descriptors, metric
+    for metric in payload["attributeTypes"]["edges"]:
+        assert metric in descriptors, metric
+
     assert len(payload["edges"]) == 1
     edge_payload = payload["edges"][0]
     assert edge_payload["fromNodeName"] == "/root/apps/api/main.py"


### PR DESCRIPTION
## Two defects, one embedded view

### 1. The exported edges were never drawn

`useCockpitData.ts` built the embed URL with `area`, `height` and `color` — but no `edge` metric. CodeCharta only turns on `isEdgeMetricVisible` when an edge metric is selected, so the `dependency_weight` edges the export carries were never rendered. The embedded view looked like a codebase without dependencies.

### 2. `coverage` and `cohesion` were coloured inverted

The export shipped `attributeTypes` but no `attributeDescriptors`. CodeCharta reverses its colour scale **only** when a descriptor reports `direction === 1`; without one, every metric is treated as *higher is worse*.

So well-tested, cohesive files were painted as the problem spots — and a green tile meant the opposite of what any reader assumes. That is worse than showing nothing, because it looks correct.

Verified in the CodeCharta sources rather than assumed:

- `updateMapColors.effect.ts:24` — `direction === 1` swaps the `positive` and `negative` colours
- `treeMapGenerator.ts:247` and `treeMapHelper.ts:129` — the same flag inverts area and height

## Fix

- `edge: 'dependency_weight'` added to the embed URL.
- `attributeDescriptors` exported for **every** node and edge metric, with `coverage` and `cohesion` as higher-is-better and the remainder as higher-is-worse, plus a readable `title` for the viewer's inspector.

The URL builder moved into `utils/cityEmbed.ts` so it can be tested directly. The existing hook tests deliberately avoid importing `useCockpitData.ts` — its header notes that rendering the 1600-line hook under jsdom causes memory pressure — so putting the helper in its own module respects that constraint instead of working around it.

## Tests

- `cityEmbed.test.ts` — asserts the edge metric is present and the viewer path is correct.
- `test_codecharta_export.py` — asserts the two higher-is-better directions, two higher-is-worse ones, and that **every** exported metric has a descriptor, so a newly added metric cannot silently fall back to the wrong direction.

466 web tests and the export tests pass. `ruff`, `uvx ty`, `tsc --noEmit` and `eslint --max-warnings=0` clean.

## Note on scope

This repairs the existing embedding. It does not depend on any decision about whether to keep embedding CodeCharta long-term.

🤖 Generated with [Claude Code](https://claude.com/claude-code)