### PR TITLE
fix(api): let a source sync again after its flow run crashed

### DIFF
--- a/apps/api/app/routes/prefect.py
+++ b/apps/api/app/routes/prefect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -15,6 +16,8 @@ from prefect.exceptions import ObjectNotFound
 from prefect.states import Cancelling
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["prefect"])
 
@@ -71,6 +74,40 @@ async def start_source_sync(source_id: str, source_url: str, sync_run_id: str) -
         idempotency_key=sync_run_id,
     )
     return str(flow_run.id)
+
+
+# Prefect states from which a flow run never leaves. A sync run still marked
+# active behind one of these is stale and must not keep blocking the source.
+_TERMINAL_FLOW_RUN_STATES = frozenset({"COMPLETED", "FAILED", "CRASHED", "CANCELLED"})
+
+# Reported when Prefect no longer knows the flow run at all, e.g. after its
+# database was reset. The sync run behind it can never complete either.
+FLOW_RUN_MISSING = "MISSING"
+
+
+async def terminal_flow_run_state(flow_run_id: str) -> str | None:
+    """Return the flow run's state when Prefect considers it finished.
+
+    Returns None while the run may still be in flight - including when Prefect
+    cannot be reached - so callers keep waiting rather than releasing a sync
+    that is genuinely still running.
+    """
+    try:
+        run_uuid = uuid.UUID(flow_run_id)
+    except ValueError:
+        return FLOW_RUN_MISSING
+
+    try:
+        async with get_client() as client:
+            flow_run = await client.read_flow_run(run_uuid)
+    except ObjectNotFound:
+        return FLOW_RUN_MISSING
+    except Exception:
+        logger.warning("Could not read flow run %s from Prefect", flow_run_id, exc_info=True)
+        return None
+
+    state_type = getattr(flow_run.state_type, "value", None) or str(flow_run.state_type or "")
+    return state_type if state_type in _TERMINAL_FLOW_RUN_STATES else None
 
 
 async def _get_flow_run_progress(

--- a/apps/api/app/routes/sources.py
+++ b/apps/api/app/routes/sources.py
@@ -434,6 +434,51 @@ async def update_source(
         )
 
 
+_ACTIVE_SYNC_RUN_STATUSES = (SyncRunStatus.SCHEDULED, SyncRunStatus.RUNNING)
+
+# How a finished Prefect flow run maps onto the business sync run behind it.
+_FLOW_STATE_TO_SYNC_STATUS = {
+    "COMPLETED": SyncRunStatus.SUCCESS,
+    "CANCELLED": SyncRunStatus.CANCELLED,
+    "FAILED": SyncRunStatus.FAILED,
+    "CRASHED": SyncRunStatus.FAILED,
+}
+
+
+async def _release_finished_sync_run(sync_run_id: uuid.UUID, flow_run_id: str) -> bool:
+    """Close out a sync run whose Prefect flow run has already finished.
+
+    A crashed flow leaves its sync run on 'scheduled' forever, and since any
+    active run counts as a sync in flight, the source would never accept
+    another one. The in-flow stale recovery cannot help: it runs inside the
+    flow that failed to start, and only considers running rows.
+
+    Returns True when the run was closed out, so the caller can schedule a
+    replacement. Returns False while the flow may still be in flight - which
+    includes Prefect being unreachable, where waiting is the safe answer.
+    """
+    from app.routes.prefect import FLOW_RUN_MISSING, terminal_flow_run_state
+
+    flow_state = await terminal_flow_run_state(flow_run_id)
+    if flow_state is None:
+        return False
+
+    async with get_db_session() as db:
+        run = (
+            await db.execute(select(SyncRun).where(SyncRun.id == sync_run_id).with_for_update())
+        ).scalar_one_or_none()
+        if run is None or run.status not in _ACTIVE_SYNC_RUN_STATUSES:
+            # Someone else already reconciled it.
+            return False
+        run.status = _FLOW_STATE_TO_SYNC_STATUS.get(flow_state, SyncRunStatus.FAILED)
+        run.finished_at = datetime.now(UTC)
+        if run.status is not SyncRunStatus.SUCCESS:
+            ended_as = "an unknown run" if flow_state == FLOW_RUN_MISSING else flow_state
+            run.error = f"RECONCILED_WITH_PREFECT: flow run {flow_run_id} ended as {ended_as}"
+        await db.commit()
+    return True
+
+
 @router.post(
     "/sources/{source_id}/sync-now",
     responses={
@@ -485,11 +530,21 @@ async def sync_now(request: Request, source_id: str) -> dict[str, str]:
         await db.commit()
 
     if existing_flow_run_id:
-        return {
-            "status": "already_scheduled",
-            "sync_run_id": sync_run_id,
-            "flow_run_id": existing_flow_run_id,
-        }
+        # A finished flow run must not keep the source blocked forever.
+        if not await _release_finished_sync_run(sync_run_uuid, existing_flow_run_id):
+            return {
+                "status": "already_scheduled",
+                "sync_run_id": sync_run_id,
+                "flow_run_id": existing_flow_run_id,
+            }
+        async with get_db_session() as db:
+            replacement = SyncRun(source_id=src_uuid, status=SyncRunStatus.SCHEDULED)
+            db.add(replacement)
+            await db.flush()
+            sync_run_id = str(replacement.id)
+            sync_run_uuid = replacement.id
+            await db.commit()
+        created = True
 
     from app.routes.prefect import start_source_sync
 

--- a/apps/api/tests/test_routes_sources.py
+++ b/apps/api/tests/test_routes_sources.py
@@ -500,6 +500,8 @@ class TestSyncNow:
             ),
             patch("app.routes.sources._get_collection_with_access", new=AsyncMock()),
             patch("app.routes.prefect.start_source_sync", new=AsyncMock()) as start_sync,
+            # Prefect reports nothing terminal, i.e. the flow is still in flight.
+            patch("app.routes.prefect.terminal_flow_run_state", AsyncMock(return_value=None)),
         ):
             response = await client.post(f"/api/sources/{source_id}/sync-now")
 
@@ -507,6 +509,70 @@ class TestSyncNow:
         assert response.json()["status"] == "already_scheduled"
         assert response.json()["flow_run_id"] == flow_run_id
         start_sync.assert_not_awaited()
+
+    async def test_sync_now_replaces_a_run_whose_flow_already_crashed(
+        self, client: AsyncClient
+    ) -> None:
+        """A crashed flow must not block the source from syncing again."""
+        from contextmine_core import SyncRunStatus
+
+        source_id = uuid.uuid4()
+        dead_flow_run_id = str(uuid.uuid4())
+        new_flow_run_id = str(uuid.uuid4())
+        source = MagicMock(
+            id=source_id,
+            collection_id=uuid.uuid4(),
+            url="https://github.com/example/repository",
+            schedule_interval_minutes=60,
+        )
+        stale_run = MagicMock(
+            id=uuid.uuid4(),
+            flow_run_id=dead_flow_run_id,
+            status=SyncRunStatus.SCHEDULED,
+            finished_at=None,
+            error=None,
+        )
+        replacement_id = uuid.uuid4()
+
+        def add(row: Any) -> None:
+            row.id = replacement_id
+
+        mock_db = MagicMock()
+        mock_db.add = add
+        mock_db.flush = AsyncMock()
+        source_result = MagicMock()
+        source_result.scalar_one_or_none.return_value = source
+        active_result = MagicMock()
+        active_result.scalar_one_or_none.return_value = stale_run
+        run_result = MagicMock()
+        run_result.scalar_one_or_none.return_value = stale_run
+        mock_db.execute = AsyncMock(
+            side_effect=[source_result, active_result, run_result, run_result, run_result]
+        )
+
+        with (
+            patch("app.routes.sources.get_session", return_value={"user_id": str(uuid.uuid4())}),
+            patch(
+                "app.routes.sources.get_db_session",
+                side_effect=lambda: _mock_db_session(mock_db),
+            ),
+            patch("app.routes.sources._get_collection_with_access", new=AsyncMock()),
+            patch(
+                "app.routes.prefect.terminal_flow_run_state",
+                AsyncMock(return_value="CRASHED"),
+            ),
+            patch(
+                "app.routes.prefect.start_source_sync",
+                AsyncMock(return_value=new_flow_run_id),
+            ) as start_sync,
+        ):
+            response = await client.post(f"/api/sources/{source_id}/sync-now")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "sync_scheduled"
+        assert response.json()["flow_run_id"] == new_flow_run_id
+        start_sync.assert_awaited_once()
+        assert stale_run.status is SyncRunStatus.FAILED
 
     async def test_sync_now_prefect_outage_finishes_business_run(self, client: AsyncClient) -> None:
         source_id = uuid.uuid4()
@@ -1005,3 +1071,152 @@ class TestListSources:
         response = await client.delete(f"/api/sources/{source_id}")
         assert response.status_code == 200
         assert response.json()["status"] == "deleted"
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestTerminalFlowRunState:
+    """Tests for reading a flow run's terminal state from Prefect."""
+
+    @staticmethod
+    def _client_returning(flow_run: Any) -> Any:
+        @asynccontextmanager
+        async def factory():
+            client = MagicMock()
+            client.read_flow_run = AsyncMock(return_value=flow_run)
+            yield client
+
+        return factory
+
+    @pytest.mark.parametrize("state", ["COMPLETED", "FAILED", "CRASHED", "CANCELLED"])
+    async def test_reports_states_a_run_never_leaves(self, state: str) -> None:
+        from app.routes import prefect as prefect_routes
+
+        flow_run = MagicMock(state_type=MagicMock(value=state))
+        with patch.object(prefect_routes, "get_client", self._client_returning(flow_run)):
+            assert await prefect_routes.terminal_flow_run_state(str(uuid.uuid4())) == state
+
+    @pytest.mark.parametrize("state", ["RUNNING", "SCHEDULED", "PENDING", "PAUSED"])
+    async def test_reports_nothing_while_the_run_may_still_finish(self, state: str) -> None:
+        from app.routes import prefect as prefect_routes
+
+        flow_run = MagicMock(state_type=MagicMock(value=state))
+        with patch.object(prefect_routes, "get_client", self._client_returning(flow_run)):
+            assert await prefect_routes.terminal_flow_run_state(str(uuid.uuid4())) is None
+
+    async def test_treats_an_unknown_run_as_gone(self) -> None:
+        from app.routes import prefect as prefect_routes
+        from prefect.exceptions import ObjectNotFound
+
+        @asynccontextmanager
+        async def factory():
+            client = MagicMock()
+            client.read_flow_run = AsyncMock(
+                side_effect=ObjectNotFound(http_exc=Exception("404 flow run not found"))
+            )
+            yield client
+
+        with patch.object(prefect_routes, "get_client", factory):
+            result = await prefect_routes.terminal_flow_run_state(str(uuid.uuid4()))
+        assert result == prefect_routes.FLOW_RUN_MISSING
+
+    async def test_treats_a_malformed_id_as_gone(self) -> None:
+        from app.routes import prefect as prefect_routes
+
+        assert await prefect_routes.terminal_flow_run_state("not-a-uuid") == (
+            prefect_routes.FLOW_RUN_MISSING
+        )
+
+    async def test_stays_silent_when_prefect_is_unreachable(self) -> None:
+        """An unreachable server must not look like a finished run."""
+        from app.routes import prefect as prefect_routes
+
+        @asynccontextmanager
+        async def factory():
+            client = MagicMock()
+            client.read_flow_run = AsyncMock(side_effect=ConnectionError("boom"))
+            yield client
+
+        with patch.object(prefect_routes, "get_client", factory):
+            assert await prefect_routes.terminal_flow_run_state(str(uuid.uuid4())) is None
+
+
+@pytest.mark.anyio
+class TestReleaseFinishedSyncRun:
+    """A finished flow must not keep its source blocked from syncing again."""
+
+    @staticmethod
+    def _run() -> MagicMock:
+        from contextmine_core import SyncRunStatus
+
+        return MagicMock(
+            id=uuid.uuid4(),
+            status=SyncRunStatus.SCHEDULED,
+            finished_at=None,
+            error=None,
+        )
+
+    async def _release(self, run: MagicMock | None, flow_state: str | None) -> bool:
+        from app.routes import sources as sources_routes
+
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = run
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            patch.object(sources_routes, "get_db_session", lambda: _mock_db_session(mock_db)),
+            patch(
+                "app.routes.prefect.terminal_flow_run_state",
+                AsyncMock(return_value=flow_state),
+            ),
+        ):
+            return await sources_routes._release_finished_sync_run(
+                run.id if run else uuid.uuid4(), str(uuid.uuid4())
+            )
+
+    async def test_marks_a_crashed_run_failed(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, "CRASHED") is True
+        assert run.status is SyncRunStatus.FAILED
+        assert run.finished_at is not None
+        assert "RECONCILED_WITH_PREFECT" in run.error
+
+    async def test_marks_a_completed_run_successful_without_an_error(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, "COMPLETED") is True
+        assert run.status is SyncRunStatus.SUCCESS
+        assert run.error is None
+
+    async def test_keeps_waiting_while_the_flow_may_still_finish(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, None) is False
+        assert run.status is SyncRunStatus.SCHEDULED
+        assert run.finished_at is None
+
+    async def test_treats_a_vanished_flow_run_as_failed(self) -> None:
+        from app.routes import prefect as prefect_routes
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, prefect_routes.FLOW_RUN_MISSING) is True
+        assert run.status is SyncRunStatus.FAILED
+        assert "an unknown run" in run.error
+
+    async def test_does_not_reconcile_a_run_someone_else_already_closed(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        run.status = SyncRunStatus.FAILED
+        assert await self._release(run, "CRASHED") is False
+
+    async def test_does_nothing_when_the_run_is_gone(self) -> None:
+        assert await self._release(None, "CRASHED") is False


### PR DESCRIPTION
## Problem

`sync_now()` treats any sync run in `scheduled` or `running` as a sync in flight and returns `already_scheduled` — **without ever asking Prefect what actually happened to the flow run**.

A crashed flow therefore leaves its sync run on `scheduled` permanently, and the source never accepts another sync again.

Observed while bringing the stack up locally:

```
flow run 7dd93cc8-...  state: CRASHED
sync run bf6a551e-...  status: scheduled     <- still "active"
```

Every subsequent `sync-now` answered `already_scheduled`, pointing at a flow run that had died minutes earlier. It took a manual SQL update to get moving again.

## Why the existing recovery does not cover it

There is a stale-run recovery in `flows.py:4558` — but it cannot help here for two independent reasons:

1. It runs **inside the sync flow**, which is exactly the thing that failed to start.
2. It only considers rows in `RUNNING`, never `SCHEDULED`.

## Fix

When an active run already carries a `flow_run_id`, ask Prefect for its state:

- **Terminal** (`COMPLETED`, `FAILED`, `CRASHED`, `CANCELLED`) → close the run out with a matching status and schedule a replacement.
- **Anything else, or Prefect unreachable** → previous behaviour. Waiting is the safe answer when a sync may genuinely still be running; an unreachable server must never look like a finished run.

Prefect is queried **only when an active run is actually in the way**, so the common path costs no extra round trip.

A flow run Prefect no longer knows (`ObjectNotFound`, or an unparseable id) counts as finished as well — otherwise a reset Prefect database would block a source forever.

`COMPLETED` maps to `SUCCESS` without an error message; everything else to a failure state carrying `RECONCILED_WITH_PREFECT: flow run <id> ended as <state>`, so the reconciliation is visible in the run history rather than looking like a normal failure.

## Tests

11 new tests:

- `terminal_flow_run_state` across all four terminal states and four non-terminal ones, plus an unreachable server, a malformed id and a vanished run
- the reconcile helper: crashed → failed with message, completed → success without message, still-running → untouched, and the race where another request already closed the run
- an end-to-end route test asserting a crashed flow yields `sync_scheduled` with a fresh flow run id, and that the stale run ends up `FAILED`

One existing test was updated to state its assumption explicitly — it simulates an active run, which now means patching Prefect to report a non-terminal state instead of letting the client reach for a server.

**698 API tests pass**, `ruff` and `uvx ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)