### PR TITLE
fix(worker): skip embeddings deliberately when the provider key is missing

### DIFF
--- a/apps/worker/contextmine_worker/flows.py
+++ b/apps/worker/contextmine_worker/flows.py
@@ -12,6 +12,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
 
@@ -32,6 +33,7 @@ from contextmine_core import (
     get_session,
     get_settings,
 )
+from contextmine_core.embeddings import embedding_credential_available
 from git.exc import GitCommandError
 from prefect import flow, task
 from prefect.artifacts import create_progress_artifact, update_progress_artifact
@@ -815,6 +817,19 @@ async def get_embedding_model_for_collection(collection_id: str) -> str:
     return settings.default_embedding_model
 
 
+@lru_cache(maxsize=8)
+def _warn_missing_embedding_credential(provider: str, model_spec: str) -> None:
+    """Warn once per process rather than once per document."""
+    logger.warning(
+        "No API key configured for embedding provider %r (model spec %r); "
+        "skipping embeddings for this run. Configure the provider key, point "
+        "DEFAULT_EMBEDDING_MODEL at a provider you have a key for, or set "
+        "MODEL_CALLS_ENABLED=false to disable model calls entirely.",
+        provider,
+        model_spec,
+    )
+
+
 async def embed_document(document_id: str, collection_id: str | None = None) -> dict:
     """Embed all chunks for a document using the collection's or default embedding model.
 
@@ -845,6 +860,21 @@ async def embed_document(document_id: str, collection_id: str | None = None) -> 
         model_spec = settings.default_embedding_model
 
     provider, model_name = parse_embedding_model_spec(model_spec)
+
+    # Without the provider's key the embedder constructor raises, and the
+    # caller records that as a per-document processing failure. Skipping
+    # deliberately keeps the rest of the sync intact and reports one reason
+    # instead of one failure per document.
+    if not embedding_credential_available(provider):
+        provider_name = getattr(provider, "value", str(provider))
+        _warn_missing_embedding_credential(provider_name, model_spec)
+        return {
+            "chunks_embedded": 0,
+            "chunks_deduplicated": 0,
+            "tokens_used": 0,
+            "skipped": True,
+            "skip_reason": f"missing_api_key:{provider_name}",
+        }
 
     # Get embedder to determine dimension
     embedder = get_embedder(provider, model_name)

--- a/apps/worker/tests/test_flows_coverage.py
+++ b/apps/worker/tests/test_flows_coverage.py
@@ -389,6 +389,8 @@ class TestEmbedDocument:
             "parse_embedding_model_spec",
             lambda spec: ("openai", "text-embedding-3-small"),
         )
+        # This path only runs when the provider's key is configured.
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: True)
 
         mock_embedder = MagicMock()
         mock_embedder.dimension = 1536
@@ -424,6 +426,8 @@ class TestEmbedDocument:
             "parse_embedding_model_spec",
             lambda spec: ("openai", "text-embedding-3-small"),
         )
+        # This path only runs when the provider's key is configured.
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: True)
 
         mock_embedder = MagicMock()
         mock_embedder.dimension = 1536

--- a/apps/worker/tests/test_flows_unit.py
+++ b/apps/worker/tests/test_flows_unit.py
@@ -699,6 +699,60 @@ class TestGetEmbeddingModelForCollection:
 
 
 class TestEmbedDocument:
+    async def test_skips_when_the_provider_key_is_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing key must not surface as a per-document processing failure.
+
+        get_embedder() raises when its provider key is absent, and that call
+        sits outside the batch fallback, so every document was counted as a
+        processing failure with the same underlying cause.
+        """
+        monkeypatch.setattr(
+            flows,
+            "get_settings",
+            lambda: _make_settings(
+                model_calls_enabled=True,
+                default_embedding_model="openai:text-embedding-3-small",
+            ),
+        )
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: False)
+        embedder = MagicMock(side_effect=AssertionError("must not build an embedder"))
+        monkeypatch.setattr(flows, "get_embedder", embedder)
+        flows._warn_missing_embedding_credential.cache_clear()
+
+        result = await flows.embed_document(str(uuid.uuid4()))
+
+        assert result == {
+            "chunks_embedded": 0,
+            "chunks_deduplicated": 0,
+            "tokens_used": 0,
+            "skipped": True,
+            "skip_reason": "missing_api_key:openai",
+        }
+        embedder.assert_not_called()
+
+    async def test_warns_once_per_process_not_once_per_document(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(
+            flows,
+            "get_settings",
+            lambda: _make_settings(
+                model_calls_enabled=True,
+                default_embedding_model="openai:text-embedding-3-small",
+            ),
+        )
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: False)
+        flows._warn_missing_embedding_credential.cache_clear()
+
+        with caplog.at_level("WARNING"):
+            for _ in range(5):
+                await flows.embed_document(str(uuid.uuid4()))
+
+        warnings = [r for r in caplog.records if "No API key configured" in r.getMessage()]
+        assert len(warnings) == 1
+
     async def test_skips_when_model_calls_are_disabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -736,6 +790,8 @@ class TestEmbedDocument:
             "get_embedding_model_for_collection",
             AsyncMock(return_value="openai:text-embedding-3-small"),
         )
+        # This path only runs when the provider's key is configured.
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: True)
 
         mock_embedder = MagicMock()
         mock_embedder.dimension = 1536

--- a/packages/core/contextmine_core/__init__.py
+++ b/packages/core/contextmine_core/__init__.py
@@ -31,6 +31,7 @@ from contextmine_core.embeddings import (
     FakeEmbedder,
     GeminiEmbedder,
     OpenAIEmbedder,
+    embedding_credential_available,
     get_embedder,
     parse_embedding_model_spec,
 )
@@ -104,6 +105,7 @@ __all__ = [
     "ContextRequest",
     "ContextResponse",
     "Embedder",
+    "embedding_credential_available",
     "EmbeddingModel",
     "EmbeddingProvider",
     "EmbeddingResult",

--- a/packages/core/contextmine_core/embeddings.py
+++ b/packages/core/contextmine_core/embeddings.py
@@ -273,6 +273,27 @@ class GeminiEmbedder(Embedder):
         )
 
 
+def embedding_credential_available(provider: EmbeddingProvider | str) -> bool:
+    """Report whether the key this embedding provider needs is configured.
+
+    Constructing an embedder without its key raises, and callers that embed
+    document by document would hit that once per document. Asking up front
+    turns a storm of identical failures into one deliberate decision.
+    """
+    if isinstance(provider, str):
+        try:
+            provider = EmbeddingProvider(provider)
+        except ValueError:
+            return False
+
+    settings = get_settings()
+    if provider is EmbeddingProvider.OPENAI:
+        return bool(secret_value(settings.openai_api_key))
+    if provider is EmbeddingProvider.GEMINI:
+        return bool(secret_value(settings.gemini_api_key))
+    return False
+
+
 def get_embedder(
     provider: EmbeddingProvider | str,
     model_name: str | None = None,

--- a/packages/core/tests/test_embeddings_credentials.py
+++ b/packages/core/tests/test_embeddings_credentials.py
@@ -1,0 +1,46 @@
+"""Tests for detecting a missing embedding provider key up front."""
+
+from __future__ import annotations
+
+import pytest
+from contextmine_core.embeddings import embedding_credential_available
+from contextmine_core.models import EmbeddingProvider
+from contextmine_core.settings import Settings
+
+
+def _settings(**overrides) -> Settings:
+    return Settings(**overrides)
+
+
+class TestEmbeddingCredentialAvailable:
+    def test_reports_openai_key_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(openai_api_key="sk-test"),
+        )
+        assert embedding_credential_available(EmbeddingProvider.OPENAI) is True
+
+    def test_reports_openai_key_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(openai_api_key=None, gemini_api_key="g-test"),
+        )
+        # A Gemini key does not make the OpenAI embedder usable.
+        assert embedding_credential_available(EmbeddingProvider.OPENAI) is False
+
+    def test_reports_gemini_key_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(gemini_api_key="g-test"),
+        )
+        assert embedding_credential_available(EmbeddingProvider.GEMINI) is True
+
+    def test_accepts_a_provider_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(openai_api_key="sk-test"),
+        )
+        assert embedding_credential_available("openai") is True
+
+    def test_rejects_an_unknown_provider_name(self) -> None:
+        assert embedding_credential_available("no-such-provider") is False


### PR DESCRIPTION
## Problem

With `MODEL_CALLS_ENABLED=true` but no key for the configured embedding provider, **every document fails the same way**.

`OpenAIEmbedder.__init__` raises `ValueError: OpenAI API key required` (`embeddings.py:160`). That constructor is called at `flows.py:751` — **outside** the try block of `_embed_batch_with_fallback` (`flows.py:622`), so the `FakeEmbedder` fallback never applies. `_process_single_document` catches it at line 368, counts `docs_processing_failures`, and returns early.

The result is a sync reporting hundreds of processing failures that all share one cause, with nothing anywhere naming that cause.

This is not an exotic configuration. `DEFAULT_EMBEDDING_MODEL` defaults to `openai:text-embedding-3-small`, so any Anthropic-only or Gemini-only setup walks straight into it — verified in a running stack:

```
$ get_embedder(EmbeddingProvider.OPENAI, "text-embedding-3-small")
ValueError: OpenAI API key required
```

## Fix

`embed_document` now checks whether the provider's key is present before building anything, and if not returns the **same shape already used for disabled model calls**:

```python
{"chunks_embedded": 0, "chunks_deduplicated": 0, "tokens_used": 0,
 "skipped": True, "skip_reason": "missing_api_key:openai"}
```

Documents are still chunked, indexed and added to the knowledge graph — only the embedding step is skipped, and it surfaces as `embedding_documents_skipped` instead of failures.

The explanation is logged **once per process** rather than once per document, and names the three ways out: configure the key, point `DEFAULT_EMBEDDING_MODEL` at a provider you have a key for, or set `MODEL_CALLS_ENABLED=false`.

### Why skip rather than abort

A sync without embeddings still produces documents, symbols, the knowledge graph and the digital twin — full-text search keeps working. Aborting would throw all of that away over one missing optional capability. What was wrong was not continuing; it was continuing *silently*, disguised as N unrelated document failures.

## Tests

- 5 tests for `embedding_credential_available` — key present, key missing, a Gemini key not making the OpenAI embedder usable, a provider passed by name, and an unknown provider name.
- 2 tests for the flow: the skip result shape with an assertion that **no embedder is constructed**, and that the warning is emitted once across five documents rather than five times.

Three existing tests relied on an embedder being constructible without a key. They now state that precondition explicitly (`embedding_credential_available → True`), which also documents what those paths actually assume.

**3982 worker and core tests pass.** `ruff` and `uvx ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)