### PR TITLE
fix: cockpit rendering, sync reconciliation and provider robustness

### DIFF
--- a/apps/api/app/routes/prefect.py
+++ b/apps/api/app/routes/prefect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from typing import Any
 
@@ -15,6 +16,8 @@ from prefect.exceptions import ObjectNotFound
 from prefect.states import Cancelling
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["prefect"])
 
@@ -71,6 +74,40 @@ async def start_source_sync(source_id: str, source_url: str, sync_run_id: str) -
         idempotency_key=sync_run_id,
     )
     return str(flow_run.id)
+
+
+# Prefect states from which a flow run never leaves. A sync run still marked
+# active behind one of these is stale and must not keep blocking the source.
+_TERMINAL_FLOW_RUN_STATES = frozenset({"COMPLETED", "FAILED", "CRASHED", "CANCELLED"})
+
+# Reported when Prefect no longer knows the flow run at all, e.g. after its
+# database was reset. The sync run behind it can never complete either.
+FLOW_RUN_MISSING = "MISSING"
+
+
+async def terminal_flow_run_state(flow_run_id: str) -> str | None:
+    """Return the flow run's state when Prefect considers it finished.
+
+    Returns None while the run may still be in flight - including when Prefect
+    cannot be reached - so callers keep waiting rather than releasing a sync
+    that is genuinely still running.
+    """
+    try:
+        run_uuid = uuid.UUID(flow_run_id)
+    except ValueError:
+        return FLOW_RUN_MISSING
+
+    try:
+        async with get_client() as client:
+            flow_run = await client.read_flow_run(run_uuid)
+    except ObjectNotFound:
+        return FLOW_RUN_MISSING
+    except Exception:
+        logger.warning("Could not read flow run %s from Prefect", flow_run_id, exc_info=True)
+        return None
+
+    state_type = getattr(flow_run.state_type, "value", None) or str(flow_run.state_type or "")
+    return state_type if state_type in _TERMINAL_FLOW_RUN_STATES else None
 
 
 async def _get_flow_run_progress(

--- a/apps/api/app/routes/sources.py
+++ b/apps/api/app/routes/sources.py
@@ -434,6 +434,51 @@ async def update_source(
         )
 
 
+_ACTIVE_SYNC_RUN_STATUSES = (SyncRunStatus.SCHEDULED, SyncRunStatus.RUNNING)
+
+# How a finished Prefect flow run maps onto the business sync run behind it.
+_FLOW_STATE_TO_SYNC_STATUS = {
+    "COMPLETED": SyncRunStatus.SUCCESS,
+    "CANCELLED": SyncRunStatus.CANCELLED,
+    "FAILED": SyncRunStatus.FAILED,
+    "CRASHED": SyncRunStatus.FAILED,
+}
+
+
+async def _release_finished_sync_run(sync_run_id: uuid.UUID, flow_run_id: str) -> bool:
+    """Close out a sync run whose Prefect flow run has already finished.
+
+    A crashed flow leaves its sync run on 'scheduled' forever, and since any
+    active run counts as a sync in flight, the source would never accept
+    another one. The in-flow stale recovery cannot help: it runs inside the
+    flow that failed to start, and only considers running rows.
+
+    Returns True when the run was closed out, so the caller can schedule a
+    replacement. Returns False while the flow may still be in flight - which
+    includes Prefect being unreachable, where waiting is the safe answer.
+    """
+    from app.routes.prefect import FLOW_RUN_MISSING, terminal_flow_run_state
+
+    flow_state = await terminal_flow_run_state(flow_run_id)
+    if flow_state is None:
+        return False
+
+    async with get_db_session() as db:
+        run = (
+            await db.execute(select(SyncRun).where(SyncRun.id == sync_run_id).with_for_update())
+        ).scalar_one_or_none()
+        if run is None or run.status not in _ACTIVE_SYNC_RUN_STATUSES:
+            # Someone else already reconciled it.
+            return False
+        run.status = _FLOW_STATE_TO_SYNC_STATUS.get(flow_state, SyncRunStatus.FAILED)
+        run.finished_at = datetime.now(UTC)
+        if run.status is not SyncRunStatus.SUCCESS:
+            ended_as = "an unknown run" if flow_state == FLOW_RUN_MISSING else flow_state
+            run.error = f"RECONCILED_WITH_PREFECT: flow run {flow_run_id} ended as {ended_as}"
+        await db.commit()
+    return True
+
+
 @router.post(
     "/sources/{source_id}/sync-now",
     responses={
@@ -485,11 +530,21 @@ async def sync_now(request: Request, source_id: str) -> dict[str, str]:
         await db.commit()
 
     if existing_flow_run_id:
-        return {
-            "status": "already_scheduled",
-            "sync_run_id": sync_run_id,
-            "flow_run_id": existing_flow_run_id,
-        }
+        # A finished flow run must not keep the source blocked forever.
+        if not await _release_finished_sync_run(sync_run_uuid, existing_flow_run_id):
+            return {
+                "status": "already_scheduled",
+                "sync_run_id": sync_run_id,
+                "flow_run_id": existing_flow_run_id,
+            }
+        async with get_db_session() as db:
+            replacement = SyncRun(source_id=src_uuid, status=SyncRunStatus.SCHEDULED)
+            db.add(replacement)
+            await db.flush()
+            sync_run_id = str(replacement.id)
+            sync_run_uuid = replacement.id
+            await db.commit()
+        created = True
 
     from app.routes.prefect import start_source_sync
 

--- a/apps/api/tests/test_routes_sources.py
+++ b/apps/api/tests/test_routes_sources.py
@@ -500,6 +500,8 @@ class TestSyncNow:
             ),
             patch("app.routes.sources._get_collection_with_access", new=AsyncMock()),
             patch("app.routes.prefect.start_source_sync", new=AsyncMock()) as start_sync,
+            # Prefect reports nothing terminal, i.e. the flow is still in flight.
+            patch("app.routes.prefect.terminal_flow_run_state", AsyncMock(return_value=None)),
         ):
             response = await client.post(f"/api/sources/{source_id}/sync-now")
 
@@ -507,6 +509,70 @@ class TestSyncNow:
         assert response.json()["status"] == "already_scheduled"
         assert response.json()["flow_run_id"] == flow_run_id
         start_sync.assert_not_awaited()
+
+    async def test_sync_now_replaces_a_run_whose_flow_already_crashed(
+        self, client: AsyncClient
+    ) -> None:
+        """A crashed flow must not block the source from syncing again."""
+        from contextmine_core import SyncRunStatus
+
+        source_id = uuid.uuid4()
+        dead_flow_run_id = str(uuid.uuid4())
+        new_flow_run_id = str(uuid.uuid4())
+        source = MagicMock(
+            id=source_id,
+            collection_id=uuid.uuid4(),
+            url="https://github.com/example/repository",
+            schedule_interval_minutes=60,
+        )
+        stale_run = MagicMock(
+            id=uuid.uuid4(),
+            flow_run_id=dead_flow_run_id,
+            status=SyncRunStatus.SCHEDULED,
+            finished_at=None,
+            error=None,
+        )
+        replacement_id = uuid.uuid4()
+
+        def add(row: Any) -> None:
+            row.id = replacement_id
+
+        mock_db = MagicMock()
+        mock_db.add = add
+        mock_db.flush = AsyncMock()
+        source_result = MagicMock()
+        source_result.scalar_one_or_none.return_value = source
+        active_result = MagicMock()
+        active_result.scalar_one_or_none.return_value = stale_run
+        run_result = MagicMock()
+        run_result.scalar_one_or_none.return_value = stale_run
+        mock_db.execute = AsyncMock(
+            side_effect=[source_result, active_result, run_result, run_result, run_result]
+        )
+
+        with (
+            patch("app.routes.sources.get_session", return_value={"user_id": str(uuid.uuid4())}),
+            patch(
+                "app.routes.sources.get_db_session",
+                side_effect=lambda: _mock_db_session(mock_db),
+            ),
+            patch("app.routes.sources._get_collection_with_access", new=AsyncMock()),
+            patch(
+                "app.routes.prefect.terminal_flow_run_state",
+                AsyncMock(return_value="CRASHED"),
+            ),
+            patch(
+                "app.routes.prefect.start_source_sync",
+                AsyncMock(return_value=new_flow_run_id),
+            ) as start_sync,
+        ):
+            response = await client.post(f"/api/sources/{source_id}/sync-now")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "sync_scheduled"
+        assert response.json()["flow_run_id"] == new_flow_run_id
+        start_sync.assert_awaited_once()
+        assert stale_run.status is SyncRunStatus.FAILED
 
     async def test_sync_now_prefect_outage_finishes_business_run(self, client: AsyncClient) -> None:
         source_id = uuid.uuid4()
@@ -1005,3 +1071,152 @@ class TestListSources:
         response = await client.delete(f"/api/sources/{source_id}")
         assert response.status_code == 200
         assert response.json()["status"] == "deleted"
+
+
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+class TestTerminalFlowRunState:
+    """Tests for reading a flow run's terminal state from Prefect."""
+
+    @staticmethod
+    def _client_returning(flow_run: Any) -> Any:
+        @asynccontextmanager
+        async def factory():
+            client = MagicMock()
+            client.read_flow_run = AsyncMock(return_value=flow_run)
+            yield client
+
+        return factory
+
+    @pytest.mark.parametrize("state", ["COMPLETED", "FAILED", "CRASHED", "CANCELLED"])
+    async def test_reports_states_a_run_never_leaves(self, state: str) -> None:
+        from app.routes import prefect as prefect_routes
+
+        flow_run = MagicMock(state_type=MagicMock(value=state))
+        with patch.object(prefect_routes, "get_client", self._client_returning(flow_run)):
+            assert await prefect_routes.terminal_flow_run_state(str(uuid.uuid4())) == state
+
+    @pytest.mark.parametrize("state", ["RUNNING", "SCHEDULED", "PENDING", "PAUSED"])
+    async def test_reports_nothing_while_the_run_may_still_finish(self, state: str) -> None:
+        from app.routes import prefect as prefect_routes
+
+        flow_run = MagicMock(state_type=MagicMock(value=state))
+        with patch.object(prefect_routes, "get_client", self._client_returning(flow_run)):
+            assert await prefect_routes.terminal_flow_run_state(str(uuid.uuid4())) is None
+
+    async def test_treats_an_unknown_run_as_gone(self) -> None:
+        from app.routes import prefect as prefect_routes
+        from prefect.exceptions import ObjectNotFound
+
+        @asynccontextmanager
+        async def factory():
+            client = MagicMock()
+            client.read_flow_run = AsyncMock(
+                side_effect=ObjectNotFound(http_exc=Exception("404 flow run not found"))
+            )
+            yield client
+
+        with patch.object(prefect_routes, "get_client", factory):
+            result = await prefect_routes.terminal_flow_run_state(str(uuid.uuid4()))
+        assert result == prefect_routes.FLOW_RUN_MISSING
+
+    async def test_treats_a_malformed_id_as_gone(self) -> None:
+        from app.routes import prefect as prefect_routes
+
+        assert await prefect_routes.terminal_flow_run_state("not-a-uuid") == (
+            prefect_routes.FLOW_RUN_MISSING
+        )
+
+    async def test_stays_silent_when_prefect_is_unreachable(self) -> None:
+        """An unreachable server must not look like a finished run."""
+        from app.routes import prefect as prefect_routes
+
+        @asynccontextmanager
+        async def factory():
+            client = MagicMock()
+            client.read_flow_run = AsyncMock(side_effect=ConnectionError("boom"))
+            yield client
+
+        with patch.object(prefect_routes, "get_client", factory):
+            assert await prefect_routes.terminal_flow_run_state(str(uuid.uuid4())) is None
+
+
+@pytest.mark.anyio
+class TestReleaseFinishedSyncRun:
+    """A finished flow must not keep its source blocked from syncing again."""
+
+    @staticmethod
+    def _run() -> MagicMock:
+        from contextmine_core import SyncRunStatus
+
+        return MagicMock(
+            id=uuid.uuid4(),
+            status=SyncRunStatus.SCHEDULED,
+            finished_at=None,
+            error=None,
+        )
+
+    async def _release(self, run: MagicMock | None, flow_state: str | None) -> bool:
+        from app.routes import sources as sources_routes
+
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = run
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            patch.object(sources_routes, "get_db_session", lambda: _mock_db_session(mock_db)),
+            patch(
+                "app.routes.prefect.terminal_flow_run_state",
+                AsyncMock(return_value=flow_state),
+            ),
+        ):
+            return await sources_routes._release_finished_sync_run(
+                run.id if run else uuid.uuid4(), str(uuid.uuid4())
+            )
+
+    async def test_marks_a_crashed_run_failed(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, "CRASHED") is True
+        assert run.status is SyncRunStatus.FAILED
+        assert run.finished_at is not None
+        assert "RECONCILED_WITH_PREFECT" in run.error
+
+    async def test_marks_a_completed_run_successful_without_an_error(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, "COMPLETED") is True
+        assert run.status is SyncRunStatus.SUCCESS
+        assert run.error is None
+
+    async def test_keeps_waiting_while_the_flow_may_still_finish(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, None) is False
+        assert run.status is SyncRunStatus.SCHEDULED
+        assert run.finished_at is None
+
+    async def test_treats_a_vanished_flow_run_as_failed(self) -> None:
+        from app.routes import prefect as prefect_routes
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        assert await self._release(run, prefect_routes.FLOW_RUN_MISSING) is True
+        assert run.status is SyncRunStatus.FAILED
+        assert "an unknown run" in run.error
+
+    async def test_does_not_reconcile_a_run_someone_else_already_closed(self) -> None:
+        from contextmine_core import SyncRunStatus
+
+        run = self._run()
+        run.status = SyncRunStatus.FAILED
+        assert await self._release(run, "CRASHED") is False
+
+    async def test_does_nothing_when_the_run_is_gone(self) -> None:
+        assert await self._release(None, "CRASHED") is False

--- a/apps/web/src/cockpit/hooks/useCockpitData.test.ts
+++ b/apps/web/src/cockpit/hooks/useCockpitData.test.ts
@@ -172,3 +172,4 @@ describe('parseApiErrorMessage', () => {
     expect(result).toBe('Validation error (422)')
   })
 })
+

--- a/apps/web/src/cockpit/hooks/useCockpitData.ts
+++ b/apps/web/src/cockpit/hooks/useCockpitData.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 import { api, apiData, apiErrorMessage } from '../../api/client'
+import { buildCityEmbedUrl } from '../utils/cityEmbed'
 import type {
   Arc42DriftPayload,
   Arc42ViewPayload,
@@ -358,8 +359,7 @@ export function useCockpitData(args: UseCockpitDataArgs) {
         const exportId = created.id ?? created.exports?.[0]?.id
         if (!exportId) throw new Error('Missing export id from city export response')
         const rawPath = `/api/twin/scenarios/${scenarioId}/exports/${exportId}/raw`
-        const embed = new URLSearchParams({ file: rawPath, area: 'loc', height: 'coupling', color: 'complexity', mode: 'Single' })
-        return { cityEmbedUrl: `/codecharta/index.html?${embed.toString()}` }
+        return { cityEmbedUrl: buildCityEmbedUrl(rawPath) }
       }
 
       return {}

--- a/apps/web/src/cockpit/utils/cityEmbed.test.ts
+++ b/apps/web/src/cockpit/utils/cityEmbed.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCityEmbedUrl } from './cityEmbed'
+
+describe('buildCityEmbedUrl', () => {
+  it('asks the viewer to show the exported dependency edges', () => {
+    // Without an edge metric the embedded viewer leaves isEdgeMetricVisible
+    // off and never draws the edges the export carries.
+    const params = new URLSearchParams(
+      buildCityEmbedUrl('/api/twin/scenarios/s1/exports/e1/raw').split('?')[1],
+    )
+
+    expect(params.get('edge')).toBe('dependency_weight')
+    expect(params.get('file')).toBe('/api/twin/scenarios/s1/exports/e1/raw')
+    expect(params.get('area')).toBe('loc')
+    expect(params.get('height')).toBe('coupling')
+    expect(params.get('color')).toBe('complexity')
+    expect(params.get('mode')).toBe('Single')
+  })
+
+  it('points at the proxied viewer', () => {
+    expect(buildCityEmbedUrl('/raw')).toMatch(/^\/codecharta\/index\.html\?/)
+  })
+})

--- a/apps/web/src/cockpit/utils/cityEmbed.ts
+++ b/apps/web/src/cockpit/utils/cityEmbed.ts
@@ -1,0 +1,18 @@
+/**
+ * Query string for the embedded CodeCharta viewer.
+ *
+ * `edge` matters: without an edge metric the viewer never sets
+ * isEdgeMetricVisible, so the dependency edges carried in the export are
+ * never drawn.
+ */
+export function buildCityEmbedUrl(rawPath: string): string {
+  const embed = new URLSearchParams({
+    file: rawPath,
+    area: 'loc',
+    height: 'coupling',
+    color: 'complexity',
+    edge: 'dependency_weight',
+    mode: 'Single',
+  })
+  return `/codecharta/index.html?${embed.toString()}`
+}

--- a/apps/web/src/cockpit/views/DeepDiveView.test.tsx
+++ b/apps/web/src/cockpit/views/DeepDiveView.test.tsx
@@ -3,20 +3,27 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { OverlayState, TwinGraphResponse } from '../types'
 
 vi.mock('cytoscape', () => ({
-  default: vi.fn().mockReturnValue({
+  default: vi.fn(() => ({
     on: vi.fn(),
     destroy: vi.fn(),
     fit: vi.fn(),
     layout: vi.fn().mockReturnValue({ run: vi.fn() }),
-  }),
+    batch: vi.fn((mutate: () => void) => mutate()),
+    getElementById: vi.fn(() => ({ empty: () => false, data: vi.fn() })),
+    nodes: vi.fn(() => ({ toggleClass: vi.fn() })),
+  })),
 }))
 
+import cytoscape from 'cytoscape'
+
 import DeepDiveView from './DeepDiveView'
+
+const cytoscapeMock = vi.mocked(cytoscape)
 
 const noOverlay: OverlayState = {
   mode: 'none',
@@ -200,5 +207,84 @@ describe('DeepDiveView rendering', () => {
     })} />)
     await userEvent.click(screen.getByText('Switch to Code / Controlflow'))
     expect(onSwitchToCodeLayer).toHaveBeenCalledOnce()
+  })
+})
+
+
+describe('DeepDiveView graph lifecycle', () => {
+  beforeEach(() => {
+    cytoscapeMock.mockClear()
+  })
+
+  it('does not rebuild the graph when the selection changes', () => {
+    // Rebuilding tears down the instance and re-runs the layout over every
+    // node - doing that on each click makes the view unusable.
+    const props = makeProps()
+    const { rerender } = render(<DeepDiveView {...props} />)
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+
+    rerender(<DeepDiveView {...props} selectedNodeId="n1" />)
+    rerender(<DeepDiveView {...props} selectedNodeId="n2" />)
+
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not rebuild the graph when the overlay or click handler changes', () => {
+    const props = makeProps()
+    const { rerender } = render(<DeepDiveView {...props} />)
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <DeepDiveView
+        {...props}
+        overlay={{ ...noOverlay, riskByNodeKey: { 'file:auth.py': { severity_score: 9 } } }}
+        onSelectNodeId={vi.fn()}
+      />,
+    )
+
+    expect(cytoscapeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rebuilds the graph when the graph data itself changes', () => {
+    const props = makeProps()
+    const { rerender } = render(<DeepDiveView {...props} />)
+
+    rerender(<DeepDiveView {...props} graph={{ ...populatedGraph, total_nodes: 3 }} />)
+
+    expect(cytoscapeMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('overrides the cose defaults that produce the dense clump', () => {
+    render(<DeepDiveView {...makeProps({ density: 3000 })} />)
+
+    const options = cytoscapeMock.mock.calls[0][0] as { layout: Record<string, unknown> }
+    expect(options.layout.name).toBe('cose')
+    // Defaults are idealEdgeLength 32 and nodeRepulsion 2048 - far too tight here.
+    expect(options.layout.idealEdgeLength).toBe(80)
+    expect(options.layout.nodeRepulsion).toBe(8000)
+  })
+
+  it('enables the WebGL renderer and viewport optimisations', () => {
+    render(<DeepDiveView {...makeProps()} />)
+
+    const options = cytoscapeMock.mock.calls[0][0] as Record<string, unknown>
+    expect(options.renderer).toEqual({ name: 'canvas', webgl: true })
+    expect(options.textureOnViewport).toBe(true)
+    expect(options.hideEdgesOnViewport).toBe(true)
+  })
+
+  it('places labels beside nodes and stops drawing them when too small', () => {
+    render(<DeepDiveView {...makeProps()} />)
+
+    const options = cytoscapeMock.mock.calls[0][0] as {
+      style: Array<{ selector: string; style: Record<string, unknown> }>
+    }
+    const nodeStyle = options.style.find((rule) => rule.selector === 'node')?.style
+    // A 10px label does not fit inside a 20px circle.
+    expect(nodeStyle?.['text-halign']).toBe('right')
+    expect(nodeStyle?.['min-zoomed-font-size']).toBe(8)
+
+    const edgeStyle = options.style.find((rule) => rule.selector === 'edge')?.style
+    expect(edgeStyle?.['curve-style']).toBe('straight')
   })
 })

--- a/apps/web/src/cockpit/views/DeepDiveView.tsx
+++ b/apps/web/src/cockpit/views/DeepDiveView.tsx
@@ -21,8 +21,38 @@ interface DeepDiveViewProps {
   onRetry: () => void
 }
 
+/**
+ * cytoscape 3.31 added a WebGL renderer, but @types/cytoscape does not model the
+ * `renderer` option yet. Verified present in the installed build - cytoscape.esm.mjs
+ * contains webglTexSize, textureOnViewport and hideEdgesOnViewport.
+ */
+const WEBGL_RENDERER: Record<string, unknown> = {
+  renderer: { name: 'canvas', webgl: true },
+}
+
 function getLayoutName(density: number): 'cose' | 'breadthfirst' {
   return density > 5000 ? 'breadthfirst' : 'cose'
+}
+
+/**
+ * Cytoscape's cose defaults (idealEdgeLength 32, nodeRepulsion 2048) are tuned for
+ * small graphs. At the densities this view reaches - hundreds of nodes averaging
+ * several edges each - they pull everything into one unreadable clump.
+ */
+function layoutOptions(density: number) {
+  const name = getLayoutName(density)
+  if (name === 'breadthfirst') {
+    return { name, animate: false, spacingFactor: 1.4 }
+  }
+  return {
+    name,
+    animate: false,
+    idealEdgeLength: 80,
+    nodeRepulsion: 8000,
+    nodeOverlap: 20,
+    componentSpacing: 120,
+    nestingFactor: 1.2,
+  }
 }
 
 function humanizeSliceStrategy(strategy: string | undefined): string {
@@ -51,6 +81,13 @@ export default function DeepDiveView({
   const [showLabelsOverride, setShowLabelsOverride] = useState<boolean | null>(null)
   const showLabels = showLabelsOverride ?? density <= 5000
 
+  // Read through a ref so a caller that re-creates this handler on every render
+  // cannot invalidate the build effect and trigger a full relayout.
+  const selectHandlerRef = useRef(onSelectNodeId)
+  useEffect(() => {
+    selectHandlerRef.current = onSelectNodeId
+  }, [onSelectNodeId])
+
   useEffect(() => {
     if (!containerRef.current || state === 'loading' || graph.nodes.length === 0) {
       return
@@ -63,21 +100,23 @@ export default function DeepDiveView({
 
     const next = cytoscape({
       container: containerRef.current,
+      // Without the WebGL renderer cytoscape falls back to plain canvas and
+      // redraws every edge on each frame.
+      ...WEBGL_RENDERER,
+      textureOnViewport: true,
+      hideEdgesOnViewport: true,
+      motionBlur: true,
       elements: [
-        ...graph.nodes.map((node) => {
-          const runtime = overlay.runtimeByNodeKey[node.natural_key] || overlay.runtimeByNodeKey[node.name]
-          const risk = overlay.riskByNodeKey[node.natural_key] || overlay.riskByNodeKey[node.name]
-          return {
-            data: {
-              id: node.id,
-              label: node.name,
-              kind: node.kind,
-              selected: selectedNodeId === node.id ? 1 : 0,
-              runtime_error: Number(runtime?.error_rate || 0),
-              risk_score: Number(risk?.severity_score || 0),
-            },
-          }
-        }),
+        ...graph.nodes.map((node) => ({
+          data: {
+            id: node.id,
+            label: node.name,
+            kind: node.kind,
+            selected: 0,
+            runtime_error: 0,
+            risk_score: 0,
+          },
+        })),
         ...graph.edges.map((edge) => ({
           data: {
             id: edge.id,
@@ -93,14 +132,26 @@ export default function DeepDiveView({
           style: {
             'background-color': '#1d4ed8',
             color: '#0f172a',
-            label: showLabels ? 'data(label)' : '',
-            'font-size': 9,
+            label: 'data(label)',
+            'font-size': 10,
+            // Cytoscape's only built-in label LOD: stop drawing text that would
+            // be too small to read instead of painting hundreds of smudges.
+            'min-zoomed-font-size': 8,
             width: 20,
             height: 20,
             'text-valign': 'center',
-            'text-halign': 'center',
+            // A 10px label does not fit inside a 20px circle - place it beside.
+            'text-halign': 'right',
+            'text-margin-x': 4,
+            'text-events': 'no',
             'border-width': 1,
             'border-color': '#0f172a',
+          },
+        },
+        {
+          selector: 'node.cm-labels-hidden',
+          style: {
+            label: '',
           },
         },
         {
@@ -141,19 +192,15 @@ export default function DeepDiveView({
             'line-color': '#94a3b8',
             'target-arrow-color': '#94a3b8',
             'target-arrow-shape': 'triangle',
-            'curve-style': 'bezier',
+            'curve-style': 'straight',
           },
         },
       ],
-      layout: {
-        name: getLayoutName(density),
-        animate: false,
-      },
+      layout: layoutOptions(density),
     })
 
     next.on('tap', 'node', (event) => {
-      const id = String(event.target.id())
-      onSelectNodeId(id)
+      selectHandlerRef.current(String(event.target.id()))
     })
 
     graphRef.current = next
@@ -162,7 +209,31 @@ export default function DeepDiveView({
       next.destroy()
       graphRef.current = null
     }
-  }, [graph, state, showLabels, density, overlay, selectedNodeId, onSelectNodeId])
+  }, [graph, state, density])
+
+  // Selection and overlay are data updates. Rebuilding the instance for them
+  // would re-run the layout on every click.
+  useEffect(() => {
+    const cy = graphRef.current
+    if (!cy) return
+    cy.batch(() => {
+      for (const node of graph.nodes) {
+        const element = cy.getElementById(node.id)
+        if (element.empty()) continue
+        const runtime = overlay.runtimeByNodeKey[node.natural_key] || overlay.runtimeByNodeKey[node.name]
+        const risk = overlay.riskByNodeKey[node.natural_key] || overlay.riskByNodeKey[node.name]
+        element.data('selected', selectedNodeId === node.id ? 1 : 0)
+        element.data('runtime_error', Number(runtime?.error_rate || 0))
+        element.data('risk_score', Number(risk?.severity_score || 0))
+      }
+    })
+  }, [graph, overlay, selectedNodeId, state, density])
+
+  useEffect(() => {
+    const cy = graphRef.current
+    if (!cy) return
+    cy.nodes().toggleClass('cm-labels-hidden', !showLabels)
+  }, [showLabels, graph, state, density])
   const warnings = graph.warnings || []
   const provenanceNotes: string[] = []
   if (graph.provenance?.source === 'knowledge_recovery') {

--- a/apps/web/src/cockpit/views/TopologyView.test.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.test.tsx
@@ -191,7 +191,8 @@ describe('TopologyView rendering', () => {
   it('renders toolbar buttons', () => {
     render(<TopologyView {...makeProps()} />)
     expect(screen.getByText('Fit view')).toBeInTheDocument()
-    expect(screen.getByText('Show labels')).toBeInTheDocument()
+    // Labels are on by default, so the button offers to hide them.
+    expect(screen.getByText('Hide labels')).toBeInTheDocument()
     expect(screen.getByText('Display options')).toBeInTheDocument()
   })
 
@@ -205,10 +206,14 @@ describe('TopologyView rendering', () => {
     expect(screen.getByText(/cross-page edges are hidden/)).toBeInTheDocument()
   })
 
-  it('toggles show labels button text on click', async () => {
+  it('shows labels by default and toggles the button text on click', async () => {
     render(<TopologyView {...makeProps()} />)
-    const btn = screen.getByText('Show labels')
+    const btn = screen.getByText('Hide labels')
+
     await userEvent.click(btn)
+    expect(screen.getByText('Show labels')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('Show labels'))
     expect(screen.getByText('Hide labels')).toBeInTheDocument()
   })
 

--- a/apps/web/src/cockpit/views/TopologyView.test.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { OverlayState, TwinGraphResponse } from '../types'
 
@@ -293,5 +293,47 @@ describe('TopologyView rendering', () => {
     })} />)
     await userEvent.click(screen.getByText('Switch to Code / Controlflow'))
     expect(onSwitchToCodeLayer).toHaveBeenCalledOnce()
+  })
+})
+
+
+describe('TopologyView layout failures', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function architectureGraph(): TwinGraphResponse {
+    // ELK only runs for architecture projections of 100 nodes or more.
+    const nodes = Array.from({ length: 120 }, (_, index) => ({
+      id: `n${index}`,
+      natural_key: `file:module${index}.py`,
+      kind: 'FILE',
+      name: `module${index}.py`,
+      meta: {},
+    }))
+    return { nodes, edges: [], page: 0, limit: 5000, total_nodes: nodes.length, projection: 'architecture' }
+  }
+
+  it('reports a failed layout instead of claiming it finished', async () => {
+    // A swallowed error used to leave the grid placeholder on screen while the
+    // view reported a refined layout, with nothing to diagnose from.
+    const { runElkLayout } = await import('../layout/layoutCore')
+    vi.mocked(runElkLayout).mockRejectedValueOnce(new Error('elk failed'))
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(<TopologyView {...makeProps({ graph: architectureGraph(), layoutEngine: 'elk_layered' })} />)
+
+    expect(await screen.findByText(/Layout failed, showing grid placeholder/)).toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('does not report a failure when the layout succeeds', async () => {
+    const { runElkLayout } = await import('../layout/layoutCore')
+    vi.mocked(runElkLayout).mockResolvedValueOnce({})
+
+    render(<TopologyView {...makeProps({ graph: architectureGraph(), layoutEngine: 'elk_layered' })} />)
+
+    await screen.findByTestId('reactflow')
+    expect(screen.queryByText(/Layout failed/)).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/cockpit/views/TopologyView.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.tsx
@@ -178,7 +178,9 @@ export default function TopologyView({
   onLayoutCompleted,
   onRetry,
 }: Readonly<TopologyViewProps>) {
-  const [showLabels, setShowLabels] = useState(false)
+  // Labels are what makes a topology readable; without them the nodes collapse
+  // to their minimum height and the view reads as unlabelled dots.
+  const [showLabels, setShowLabels] = useState(true)
   const [showMiniMap, setShowMiniMap] = useState(false)
   const [showDisplayOptions, setShowDisplayOptions] = useState(false)
   const [instance, setInstance] = useState<ReactFlowInstance | null>(null)

--- a/apps/web/src/cockpit/views/TopologyView.tsx
+++ b/apps/web/src/cockpit/views/TopologyView.tsx
@@ -21,22 +21,33 @@ interface ElkLayoutParams {
   onPositions: (positions: Record<string, { x: number; y: number }>) => void
   onCompleted: (engine: LayoutEngine, durationMs: number, nodeCount: number) => void
   onFinish: () => void
+  onError: (reason: unknown) => void
 }
 
 /** Run ELK layout (in-thread or via worker), calling back with positions on completion. */
 async function applyElkLayout(params: Readonly<ElkLayoutParams>): Promise<void> {
-  const { nodes, edges, engine, columns, cancelled, startedAt, onPositions, onCompleted, onFinish } = params
+  const { nodes, edges, engine, columns, cancelled, startedAt, onPositions, onCompleted, onFinish, onError } = params
   try {
     if (nodes.length > 1000) {
       const worker = new Worker(new URL('../layout/layoutWorker.ts', import.meta.url), {
         type: 'module',
       })
-      worker.onmessage = (event: MessageEvent<{ ok: boolean; positions?: Record<string, { x: number; y: number }>; durationMs: number }>) => {
+      worker.onmessage = (event: MessageEvent<{ ok: boolean; positions?: Record<string, { x: number; y: number }>; durationMs: number; error?: string }>) => {
         worker.terminate()
-        if (cancelled.current || !event.data.ok || !event.data.positions) return
+        if (cancelled.current) return
+        if (!event.data.ok || !event.data.positions) {
+          onError(event.data.error ?? 'layout worker returned no positions')
+          return
+        }
         onPositions(event.data.positions)
         onFinish()
         onCompleted(engine, event.data.durationMs, nodes.length)
+      }
+      // Without this the worker failing leaves the status stuck on 'coarse'.
+      worker.onerror = (event) => {
+        worker.terminate()
+        if (cancelled.current) return
+        onError(event.message || 'layout worker failed')
       }
       worker.postMessage({ nodes, edges, engine, columns })
       return
@@ -47,9 +58,11 @@ async function applyElkLayout(params: Readonly<ElkLayoutParams>): Promise<void> 
     onPositions(positions)
     onFinish()
     onCompleted(engine, durationMs, nodes.length)
-  } catch {
+  } catch (reason) {
     if (cancelled.current) return
-    onFinish()
+    // Swallowing this used to leave the grid placeholder on screen while the
+    // view reported a finished layout, with nothing to diagnose from.
+    onError(reason)
   }
 }
 import { layerLabel } from '../types'
@@ -184,7 +197,7 @@ export default function TopologyView({
   const [showMiniMap, setShowMiniMap] = useState(false)
   const [showDisplayOptions, setShowDisplayOptions] = useState(false)
   const [instance, setInstance] = useState<ReactFlowInstance | null>(null)
-  const [layoutStatus, setLayoutStatus] = useState<'idle' | 'coarse' | 'refined'>('idle')
+  const [layoutStatus, setLayoutStatus] = useState<'idle' | 'coarse' | 'refined' | 'degraded'>('idle')
   const [layoutPositions, setLayoutPositions] = useState<Record<string, { x: number; y: number }>>({})
 
   const densityToColumns: Record<number, number> = { 800: 4, 1200: 6 }
@@ -220,6 +233,10 @@ export default function TopologyView({
         onPositions: setLayoutPositions,
         onCompleted: onLayoutCompleted,
         onFinish: () => setLayoutStatus('refined'),
+        onError: (reason) => {
+          console.error('[cockpit] %s layout failed, showing grid placeholder', preferredEngine, reason)
+          setLayoutStatus('degraded')
+        },
       })
     }, 0)
     return () => {
@@ -280,6 +297,7 @@ export default function TopologyView({
           Nodes: {graph.visible_nodes ?? graph.nodes.length} / Total: {graph.candidate_nodes ?? graph.total_nodes} • Edges: {graph.visible_edges ?? graph.edges.length}
           {graph.slice_strategy ? ` • Slice: ${humanizeSliceStrategy(graph.slice_strategy)}` : ''}
           {layoutStatus === 'coarse' ? ' • Refining layout…' : ''}
+          {layoutStatus === 'degraded' ? ' • Layout failed, showing grid placeholder' : ''}
         </p>
       </div>
 

--- a/apps/worker/contextmine_worker/flows.py
+++ b/apps/worker/contextmine_worker/flows.py
@@ -12,6 +12,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
 
@@ -32,6 +33,7 @@ from contextmine_core import (
     get_session,
     get_settings,
 )
+from contextmine_core.embeddings import embedding_credential_available
 from git.exc import GitCommandError
 from prefect import flow, task
 from prefect.artifacts import create_progress_artifact, update_progress_artifact
@@ -815,6 +817,19 @@ async def get_embedding_model_for_collection(collection_id: str) -> str:
     return settings.default_embedding_model
 
 
+@lru_cache(maxsize=8)
+def _warn_missing_embedding_credential(provider: str, model_spec: str) -> None:
+    """Warn once per process rather than once per document."""
+    logger.warning(
+        "No API key configured for embedding provider %r (model spec %r); "
+        "skipping embeddings for this run. Configure the provider key, point "
+        "DEFAULT_EMBEDDING_MODEL at a provider you have a key for, or set "
+        "MODEL_CALLS_ENABLED=false to disable model calls entirely.",
+        provider,
+        model_spec,
+    )
+
+
 async def embed_document(document_id: str, collection_id: str | None = None) -> dict:
     """Embed all chunks for a document using the collection's or default embedding model.
 
@@ -845,6 +860,21 @@ async def embed_document(document_id: str, collection_id: str | None = None) -> 
         model_spec = settings.default_embedding_model
 
     provider, model_name = parse_embedding_model_spec(model_spec)
+
+    # Without the provider's key the embedder constructor raises, and the
+    # caller records that as a per-document processing failure. Skipping
+    # deliberately keeps the rest of the sync intact and reports one reason
+    # instead of one failure per document.
+    if not embedding_credential_available(provider):
+        provider_name = getattr(provider, "value", str(provider))
+        _warn_missing_embedding_credential(provider_name, model_spec)
+        return {
+            "chunks_embedded": 0,
+            "chunks_deduplicated": 0,
+            "tokens_used": 0,
+            "skipped": True,
+            "skip_reason": f"missing_api_key:{provider_name}",
+        }
 
     # Get embedder to determine dimension
     embedder = get_embedder(provider, model_name)

--- a/apps/worker/tests/test_flows_coverage.py
+++ b/apps/worker/tests/test_flows_coverage.py
@@ -389,6 +389,8 @@ class TestEmbedDocument:
             "parse_embedding_model_spec",
             lambda spec: ("openai", "text-embedding-3-small"),
         )
+        # This path only runs when the provider's key is configured.
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: True)
 
         mock_embedder = MagicMock()
         mock_embedder.dimension = 1536
@@ -424,6 +426,8 @@ class TestEmbedDocument:
             "parse_embedding_model_spec",
             lambda spec: ("openai", "text-embedding-3-small"),
         )
+        # This path only runs when the provider's key is configured.
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: True)
 
         mock_embedder = MagicMock()
         mock_embedder.dimension = 1536

--- a/apps/worker/tests/test_flows_unit.py
+++ b/apps/worker/tests/test_flows_unit.py
@@ -699,6 +699,60 @@ class TestGetEmbeddingModelForCollection:
 
 
 class TestEmbedDocument:
+    async def test_skips_when_the_provider_key_is_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing key must not surface as a per-document processing failure.
+
+        get_embedder() raises when its provider key is absent, and that call
+        sits outside the batch fallback, so every document was counted as a
+        processing failure with the same underlying cause.
+        """
+        monkeypatch.setattr(
+            flows,
+            "get_settings",
+            lambda: _make_settings(
+                model_calls_enabled=True,
+                default_embedding_model="openai:text-embedding-3-small",
+            ),
+        )
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: False)
+        embedder = MagicMock(side_effect=AssertionError("must not build an embedder"))
+        monkeypatch.setattr(flows, "get_embedder", embedder)
+        flows._warn_missing_embedding_credential.cache_clear()
+
+        result = await flows.embed_document(str(uuid.uuid4()))
+
+        assert result == {
+            "chunks_embedded": 0,
+            "chunks_deduplicated": 0,
+            "tokens_used": 0,
+            "skipped": True,
+            "skip_reason": "missing_api_key:openai",
+        }
+        embedder.assert_not_called()
+
+    async def test_warns_once_per_process_not_once_per_document(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setattr(
+            flows,
+            "get_settings",
+            lambda: _make_settings(
+                model_calls_enabled=True,
+                default_embedding_model="openai:text-embedding-3-small",
+            ),
+        )
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: False)
+        flows._warn_missing_embedding_credential.cache_clear()
+
+        with caplog.at_level("WARNING"):
+            for _ in range(5):
+                await flows.embed_document(str(uuid.uuid4()))
+
+        warnings = [r for r in caplog.records if "No API key configured" in r.getMessage()]
+        assert len(warnings) == 1
+
     async def test_skips_when_model_calls_are_disabled(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -736,6 +790,8 @@ class TestEmbedDocument:
             "get_embedding_model_for_collection",
             AsyncMock(return_value="openai:text-embedding-3-small"),
         )
+        # This path only runs when the provider's key is configured.
+        monkeypatch.setattr(flows, "embedding_credential_available", lambda _provider: True)
 
         mock_embedder = MagicMock()
         mock_embedder.dimension = 1536

--- a/packages/core/contextmine_core/__init__.py
+++ b/packages/core/contextmine_core/__init__.py
@@ -31,6 +31,7 @@ from contextmine_core.embeddings import (
     FakeEmbedder,
     GeminiEmbedder,
     OpenAIEmbedder,
+    embedding_credential_available,
     get_embedder,
     parse_embedding_model_spec,
 )
@@ -104,6 +105,7 @@ __all__ = [
     "ContextRequest",
     "ContextResponse",
     "Embedder",
+    "embedding_credential_available",
     "EmbeddingModel",
     "EmbeddingProvider",
     "EmbeddingResult",

--- a/packages/core/contextmine_core/embeddings.py
+++ b/packages/core/contextmine_core/embeddings.py
@@ -273,6 +273,27 @@ class GeminiEmbedder(Embedder):
         )
 
 
+def embedding_credential_available(provider: EmbeddingProvider | str) -> bool:
+    """Report whether the key this embedding provider needs is configured.
+
+    Constructing an embedder without its key raises, and callers that embed
+    document by document would hit that once per document. Asking up front
+    turns a storm of identical failures into one deliberate decision.
+    """
+    if isinstance(provider, str):
+        try:
+            provider = EmbeddingProvider(provider)
+        except ValueError:
+            return False
+
+    settings = get_settings()
+    if provider is EmbeddingProvider.OPENAI:
+        return bool(secret_value(settings.openai_api_key))
+    if provider is EmbeddingProvider.GEMINI:
+        return bool(secret_value(settings.gemini_api_key))
+    return False
+
+
 def get_embedder(
     provider: EmbeddingProvider | str,
     model_name: str | None = None,

--- a/packages/core/contextmine_core/exports/codecharta.py
+++ b/packages/core/contextmine_core/exports/codecharta.py
@@ -467,6 +467,33 @@ async def _build_arch_projection_leaf_items(
     return leaf_items
 
 
+# CodeCharta reverses its colour scale when a descriptor reports direction == 1,
+# so a metric where a high value is good must say so explicitly. Without these
+# descriptors every metric is treated as "higher is worse" and well-covered,
+# cohesive files are painted as if they were the problem.
+_HIGHER_IS_BETTER = 1
+_HIGHER_IS_WORSE = -1
+
+_ATTRIBUTE_DESCRIPTORS: dict[str, dict[str, object]] = {
+    "loc": {"title": "Lines of Code", "direction": _HIGHER_IS_WORSE},
+    "symbol_count": {"title": "Symbols", "direction": _HIGHER_IS_WORSE},
+    "coupling": {"title": "Coupling", "direction": _HIGHER_IS_WORSE},
+    "coverage": {"title": "Test coverage", "direction": _HIGHER_IS_BETTER},
+    "complexity": {"title": "Cyclomatic complexity", "direction": _HIGHER_IS_WORSE},
+    "cohesion": {"title": "Cohesion", "direction": _HIGHER_IS_BETTER},
+    "instability": {"title": "Instability", "direction": _HIGHER_IS_WORSE},
+    "fan_in": {"title": "Fan-in", "direction": _HIGHER_IS_WORSE},
+    "fan_out": {"title": "Fan-out", "direction": _HIGHER_IS_WORSE},
+    "cycle_participation": {"title": "Cycle participation", "direction": _HIGHER_IS_WORSE},
+    "cycle_size": {"title": "Cycle size", "direction": _HIGHER_IS_WORSE},
+    "duplication_ratio": {"title": "Duplication", "direction": _HIGHER_IS_WORSE},
+    "crap_score": {"title": "CRAP score", "direction": _HIGHER_IS_WORSE},
+    "change_frequency": {"title": "Change frequency", "direction": _HIGHER_IS_WORSE},
+    "churn": {"title": "Churn", "direction": _HIGHER_IS_WORSE},
+    "dependency_weight": {"title": "Dependency weight", "direction": _HIGHER_IS_WORSE},
+}
+
+
 async def export_codecharta_json(
     session: AsyncSession,
     scenario_id: UUID,
@@ -546,6 +573,7 @@ async def export_codecharta_json(
         "apiVersion": "1.5",
         "nodes": [root],
         "edges": cc_edges,
+        "attributeDescriptors": _ATTRIBUTE_DESCRIPTORS,
         "attributeTypes": {
             "nodes": {
                 "loc": "absolute",

--- a/packages/core/contextmine_core/research/llm/provider.py
+++ b/packages/core/contextmine_core/research/llm/provider.py
@@ -12,6 +12,10 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from contextmine_core.model_policy import ensure_model_calls_enabled
+from contextmine_core.research.llm.structured import (
+    coerce_json_string_fields,
+    repair_structured_payload,
+)
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.output_parsers import PydanticOutputParser
@@ -257,8 +261,10 @@ class LangChainProvider(LLMProvider):
 
         # Try using LangChain's built-in structured output first
         try:
-            # Use default method - Anthropic uses tool calling, OpenAI uses json_schema
-            structured_model = self._model.with_structured_output(output_schema)
+            # Use default method - Anthropic uses tool calling, OpenAI uses json_schema.
+            # include_raw keeps the tool-call arguments available so a response
+            # that only fails schema validation can still be repaired below.
+            structured_model = self._model.with_structured_output(output_schema, include_raw=True)
             configured_model = structured_model.bind(
                 **self._generation_parameters(
                     max_tokens=max_tokens,
@@ -271,9 +277,24 @@ class LangChainProvider(LLMProvider):
             if isinstance(result, output_schema):
                 return result
 
+            if isinstance(result, dict) and "parsed" in result:
+                parsed = result["parsed"]
+                if isinstance(parsed, output_schema):
+                    return parsed
+                repaired = repair_structured_payload(result.get("raw"), output_schema)
+                if repaired is not None:
+                    return repaired
+                parsing_error = result.get("parsing_error")
+                if parsing_error is not None:
+                    raise parsing_error
+                msg = f"Model returned no usable {output_schema.__name__}"
+                raise ValueError(msg)
+
             # If we got a dict, try to parse it
             if isinstance(result, dict):
-                return output_schema.model_validate(result)
+                return output_schema.model_validate(
+                    coerce_json_string_fields(result, output_schema)
+                )
 
             # Raise a ValueError that will be caught and retried
             msg = f"Expected {output_schema.__name__}, got {type(result).__name__}"

--- a/packages/core/contextmine_core/research/llm/structured.py
+++ b/packages/core/contextmine_core/research/llm/structured.py
@@ -1,0 +1,114 @@
+"""Repair structured LLM output that arrives with JSON-encoded fields.
+
+Anthropic's tool-calling transport occasionally serializes a nested array or
+object into a JSON *string* instead of returning it structurally. The value is
+well-formed JSON, just one encoding level too deep, and strict schema
+validation rejects it:
+
+    rules
+      Input should be a valid list [type=list_type,
+       input_value='[\\n  {\\n    "name": ...', input_type=str]
+
+Decoding such fields before validation keeps the extracted data instead of
+discarding the whole response.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import types
+import typing
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "coerce_json_string_fields",
+    "field_expects_structure",
+    "repair_structured_payload",
+]
+
+
+def _unwrap_annotation(annotation: Any) -> list[Any]:
+    """Return the candidate types of an annotation, flattening unions."""
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):
+        return [arg for arg in typing.get_args(annotation) if arg is not type(None)]
+    return [annotation]
+
+
+def field_expects_structure(annotation: Any) -> bool:
+    """Report whether a field wants a list, dict or model rather than a string.
+
+    A field that legitimately accepts a string is never decoded, so a
+    ``reasoning`` field holding the text ``"[1, 2]"`` keeps its exact value.
+    """
+    for candidate in _unwrap_annotation(annotation):
+        if candidate is str:
+            return False
+
+        origin = typing.get_origin(candidate) or candidate
+        if origin in (list, tuple, set, frozenset, dict):
+            return True
+        if isinstance(origin, type) and issubclass(origin, BaseModel):
+            return True
+    return False
+
+
+def coerce_json_string_fields(data: Any, schema: type[BaseModel]) -> Any:
+    """Decode JSON strings sitting in fields that expect structured values.
+
+    Returns ``data`` unchanged when it is not a mapping. Fields are left alone
+    unless the schema wants a structure there *and* the string parses as JSON,
+    so malformed output still reaches validation and reports a real error.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    coerced: dict[str, Any] = dict(data)
+    for name, field in schema.model_fields.items():
+        for key in {name, field.alias} - {None}:
+            raw = coerced.get(key)
+            if not isinstance(raw, str) or not field_expects_structure(field.annotation):
+                continue
+            try:
+                decoded = json.loads(raw)
+            except TypeError, ValueError:
+                # Not JSON after all - let validation report the real problem.
+                continue
+            if isinstance(decoded, str):
+                # A plain quoted string is not the structure we are looking for.
+                continue
+            coerced[key] = decoded
+    return coerced
+
+
+def repair_structured_payload[T: BaseModel](
+    raw: Any,
+    output_schema: type[T],
+) -> T | None:
+    """Rebuild a schema instance from the raw tool-call arguments of a response.
+
+    Used when the provider returned a complete answer that only failed schema
+    validation because a nested value was JSON-encoded. Returns None when the
+    payload needed no repair or cannot be salvaged, so the caller still reports
+    the original error instead of hiding it.
+    """
+    tool_calls = getattr(raw, "tool_calls", None) or []
+    for tool_call in tool_calls:
+        arguments = tool_call.get("args") if isinstance(tool_call, dict) else None
+        if not isinstance(arguments, dict):
+            continue
+        coerced = coerce_json_string_fields(arguments, output_schema)
+        if coerced == arguments:
+            continue
+        try:
+            repaired = output_schema.model_validate(coerced)
+        except ValidationError:
+            continue
+        logger.warning("Repaired JSON-encoded fields in %s response", output_schema.__name__)
+        return repaired
+    return None

--- a/packages/core/tests/test_codecharta_export.py
+++ b/packages/core/tests/test_codecharta_export.py
@@ -181,6 +181,21 @@ async def test_codecharta_file_projection_schema_and_edges(test_session: AsyncSe
     assert leaves["/root/apps/web/App.tsx"]["churn"] == pytest.approx(30.0)
     assert payload["attributeTypes"]["nodes"]["churn"] == "absolute"
 
+    # CodeCharta reverses its colour scale only when a descriptor says direction == 1.
+    # Without these, high coverage and high cohesion are painted as problems.
+    descriptors = payload["attributeDescriptors"]
+    assert descriptors["coverage"]["direction"] == 1
+    assert descriptors["cohesion"]["direction"] == 1
+    assert descriptors["complexity"]["direction"] == -1
+    assert descriptors["churn"]["direction"] == -1
+    assert descriptors["coverage"]["title"] == "Test coverage"
+    # Every exported node metric needs a descriptor, otherwise it silently
+    # falls back to "higher is worse".
+    for metric in payload["attributeTypes"]["nodes"]:
+        assert metric in descriptors, metric
+    for metric in payload["attributeTypes"]["edges"]:
+        assert metric in descriptors, metric
+
     assert len(payload["edges"]) == 1
     edge_payload = payload["edges"][0]
     assert edge_payload["fromNodeName"] == "/root/apps/api/main.py"

--- a/packages/core/tests/test_embeddings_credentials.py
+++ b/packages/core/tests/test_embeddings_credentials.py
@@ -1,0 +1,46 @@
+"""Tests for detecting a missing embedding provider key up front."""
+
+from __future__ import annotations
+
+import pytest
+from contextmine_core.embeddings import embedding_credential_available
+from contextmine_core.models import EmbeddingProvider
+from contextmine_core.settings import Settings
+
+
+def _settings(**overrides) -> Settings:
+    return Settings(**overrides)
+
+
+class TestEmbeddingCredentialAvailable:
+    def test_reports_openai_key_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(openai_api_key="sk-test"),
+        )
+        assert embedding_credential_available(EmbeddingProvider.OPENAI) is True
+
+    def test_reports_openai_key_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(openai_api_key=None, gemini_api_key="g-test"),
+        )
+        # A Gemini key does not make the OpenAI embedder usable.
+        assert embedding_credential_available(EmbeddingProvider.OPENAI) is False
+
+    def test_reports_gemini_key_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(gemini_api_key="g-test"),
+        )
+        assert embedding_credential_available(EmbeddingProvider.GEMINI) is True
+
+    def test_accepts_a_provider_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "contextmine_core.embeddings.get_settings",
+            lambda: _settings(openai_api_key="sk-test"),
+        )
+        assert embedding_credential_available("openai") is True
+
+    def test_rejects_an_unknown_provider_name(self) -> None:
+        assert embedding_credential_available("no-such-provider") is False

--- a/packages/core/tests/test_llm_structured_coercion.py
+++ b/packages/core/tests/test_llm_structured_coercion.py
@@ -1,0 +1,162 @@
+"""Tests for repairing JSON-encoded fields in structured LLM output."""
+
+from __future__ import annotations
+
+from contextmine_core.analyzer.extractors.rules import ExtractionOutput
+from contextmine_core.research.llm.structured import (
+    coerce_json_string_fields,
+    field_expects_structure,
+    repair_structured_payload,
+)
+from langchain_core.messages import AIMessage
+from pydantic import BaseModel, Field
+
+# The exact shape observed from Anthropic tool calling during a sync: the
+# `rules` array arrived as a JSON string, so validation rejected the response
+# and the extracted business rules were silently dropped.
+ANTHROPIC_STRING_ARRAY_PAYLOAD = {
+    "rules": (
+        '[\n  {\n    "name": "Legacy series must stay sorted",\n'
+        '    "description": "Series entries are ordered before rendering",\n'
+        '    "category": "invariant",\n'
+        '    "severity": "error",\n'
+        '    "natural_language": "Series must be sorted before rendering",\n'
+        '    "evidence_snippet": "if (!isSorted(series)) throw new Error()",\n'
+        '    "start_line": 1137,\n    "end_line": 1139\n  }\n]'
+    ),
+    "reasoning": "Analyzed the series helper for ordering guarantees.",
+}
+
+
+class TestCoerceJsonStringFields:
+    def test_decodes_json_string_array_into_list(self) -> None:
+        coerced = coerce_json_string_fields(ANTHROPIC_STRING_ARRAY_PAYLOAD, ExtractionOutput)
+        result = ExtractionOutput.model_validate(coerced)
+
+        assert len(result.rules) == 1
+        assert result.rules[0].name == "Legacy series must stay sorted"
+        assert result.rules[0].start_line == 1137
+        assert result.rules[0].end_line == 1139
+
+    def test_leaves_string_fields_untouched(self) -> None:
+        """A string field keeps its literal value even when it looks like JSON."""
+        payload = {"rules": [], "reasoning": '["not", "a", "list"]'}
+
+        coerced = coerce_json_string_fields(payload, ExtractionOutput)
+
+        assert coerced["reasoning"] == '["not", "a", "list"]'
+        assert ExtractionOutput.model_validate(coerced).reasoning == '["not", "a", "list"]'
+
+    def test_leaves_wellformed_payloads_unchanged(self) -> None:
+        payload = {
+            "rules": [
+                {
+                    "name": "n",
+                    "description": "d",
+                    "category": "validation",
+                    "severity": "error",
+                    "natural_language": "nl",
+                    "evidence_snippet": "s",
+                    "start_line": 1,
+                    "end_line": 2,
+                }
+            ],
+            "reasoning": "r",
+        }
+
+        assert coerce_json_string_fields(payload, ExtractionOutput) == payload
+
+    def test_leaves_malformed_json_for_validation_to_report(self) -> None:
+        """Broken output must still surface as a validation error, not be hidden."""
+        payload = {"rules": "[{unclosed", "reasoning": "r"}
+
+        coerced = coerce_json_string_fields(payload, ExtractionOutput)
+
+        assert coerced["rules"] == "[{unclosed"
+
+    def test_returns_non_mapping_input_unchanged(self) -> None:
+        assert coerce_json_string_fields(["a"], ExtractionOutput) == ["a"]
+        assert coerce_json_string_fields(None, ExtractionOutput) is None
+
+    def test_decodes_nested_model_and_dict_fields(self) -> None:
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            inner: Inner
+            mapping: dict[str, int]
+            label: str
+
+        payload = {"inner": '{"value": 5}', "mapping": '{"a": 1}', "label": "plain"}
+
+        result = Outer.model_validate(coerce_json_string_fields(payload, Outer))
+
+        assert result.inner.value == 5
+        assert result.mapping == {"a": 1}
+        assert result.label == "plain"
+
+    def test_decodes_optional_structured_field(self) -> None:
+        class WithOptional(BaseModel):
+            items: list[int] | None = Field(default=None)
+
+        coerced = coerce_json_string_fields({"items": "[1, 2, 3]"}, WithOptional)
+
+        assert WithOptional.model_validate(coerced).items == [1, 2, 3]
+
+
+class TestFieldExpectsStructure:
+    def test_recognises_structured_annotations(self) -> None:
+        assert field_expects_structure(list[int])
+        assert field_expects_structure(dict[str, int])
+        assert field_expects_structure(list[str] | None)
+
+    def test_rejects_plain_scalar_annotations(self) -> None:
+        assert not field_expects_structure(str)
+        assert not field_expects_structure(int)
+        assert not field_expects_structure(str | None)
+
+
+def _tool_call_message(arguments: dict) -> AIMessage:
+    return AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "ExtractionOutput",
+                "args": arguments,
+                "id": "toolu_test",
+                "type": "tool_call",
+            }
+        ],
+    )
+
+
+class TestRepairStructuredPayload:
+    def test_recovers_response_whose_array_arrived_as_json_string(self) -> None:
+        repaired = repair_structured_payload(
+            _tool_call_message(ANTHROPIC_STRING_ARRAY_PAYLOAD), ExtractionOutput
+        )
+
+        assert repaired is not None
+        assert len(repaired.rules) == 1
+        assert repaired.rules[0].name == "Legacy series must stay sorted"
+
+    def test_returns_none_when_nothing_needed_repairing(self) -> None:
+        """A payload that was already fine is left to the normal error path."""
+        assert (
+            repair_structured_payload(
+                _tool_call_message({"rules": [], "reasoning": "r"}), ExtractionOutput
+            )
+            is None
+        )
+
+    def test_returns_none_for_unusable_payload(self) -> None:
+        assert (
+            repair_structured_payload(
+                _tool_call_message({"rules": "[{unclosed", "reasoning": "r"}), ExtractionOutput
+            )
+            is None
+        )
+
+    def test_returns_none_without_tool_calls(self) -> None:
+        assert repair_structured_payload(AIMessage(content=""), ExtractionOutput) is None
+        assert repair_structured_payload(None, ExtractionOutput) is None


### PR DESCRIPTION
Bundles the six remaining fixes from #49–#54 into one CI run. **Each PR is preserved as its own commit** — the individual PRs stay open for reading and are closed once this merges.

Branch protection requires branches to be up to date, so merging seven PRs individually meant seven full CI runs at ~10 minutes each, almost entirely the system smoke. This is one run instead.

## The six commits

| Commit | Problem it fixes |
|---|---|
| `fix(api): let a source sync again after its flow run crashed` | A CRASHED flow left its sync run on `scheduled` forever; the source never accepted another sync ([#53](https://github.com/mayflower/contextmine/pull/53)) |
| `fix(worker): skip embeddings deliberately when the provider key is missing` | A missing key surfaced as N identical per-document processing failures ([#54](https://github.com/mayflower/contextmine/pull/54)) |
| `fix(llm): recover structured output whose arrays arrive JSON-encoded` | Anthropic tool calling returns arrays as JSON strings; extracted business rules were silently discarded ([#49](https://github.com/mayflower/contextmine/pull/49)) |
| `fix(cockpit): make the graph views readable and stop relayout on every click` | Every node click destroyed the cytoscape instance and re-ran the layout; labels sat inside 20px circles; WebGL was never enabled ([#50](https://github.com/mayflower/contextmine/pull/50)) |
| `fix(cockpit): report layout failures instead of swallowing them` | An empty catch hid ELK failures while reporting a finished layout ([#51](https://github.com/mayflower/contextmine/pull/51)) |
| `fix(codecharta): show exported edges and colour metrics in the right direction` | Exported edges were never drawn, and `coverage`/`cohesion` were coloured inverted ([#52](https://github.com/mayflower/contextmine/pull/52)) |

Full rationale, measurements and test descriptions are in the individual PRs.

## Verification on the combined branch

Not just per-PR — the combination was checked as a whole, since #50 and #51 both touch `TopologyView.tsx`:

```
4694 passed, 17 skipped     (apps + packages/core)
 474 passed                 (web)
```

`ruff check`, `ruff format --check`, `tsc --noEmit` and `eslint --max-warnings=0` all clean. The two cockpit commits merged without conflict and their tests pass together.

`packages/core/tests/test_native_typescript_lsp.py` is excluded locally — it needs the optional `multilspy` dependency. It is unaffected by these changes and runs in CI.

## Every fix has a test that fails without it

Not added as an afterthought — each was written to reproduce the observed failure first, including the exact Anthropic payload from a real sync and the crashed-flow/stale-run pair from the running stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)