### PR TITLE
ci: split the live web check out of the model-free system smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
     outputs:
       model_free: ${{ steps.classify.outputs.model_free }}
       otel: ${{ steps.classify.outputs.otel }}
+      live_web: ${{ steps.classify.outputs.live_web }}
     steps:
       - name: Check out pull request history
         if: github.event_name == 'pull_request'
@@ -217,7 +218,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
-            printf 'model_free=false\notel=false\n' >>"${GITHUB_OUTPUT}"
+            printf 'model_free=false\notel=false\nlive_web=false\n' >>"${GITHUB_OUTPUT}"
             echo "System smokes are selected by the ${GITHUB_EVENT_NAME} schedule, not changed files."
             exit 0
           fi
@@ -241,7 +242,6 @@ jobs:
     timeout-minutes: 60
     env:
       CONTEXTMINE_SMOKE_API_IMAGE: contextmine-smoke-api:${{ github.sha }}
-      CONTEXTMINE_SMOKE_WEB_IMAGE: contextmine-smoke-web:${{ github.sha }}
       CONTEXTMINE_SMOKE_WORKER_IMAGE: contextmine-smoke-analyzer:${{ github.sha }}
       CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES: "true"
       RUN_SYSTEM_SMOKE: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft && needs.smoke-changes.outputs.model_free == 'true') }}
@@ -275,18 +275,6 @@ jobs:
           cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-api' }}
           cache-to: type=gha,scope=contextmine-api,mode=max
 
-      - name: Build cached web smoke image
-        if: env.RUN_SYSTEM_SMOKE == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ./apps/web
-          file: apps/web/Dockerfile
-          load: true
-          tags: ${{ env.CONTEXTMINE_SMOKE_WEB_IMAGE }}
-          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
-          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-web' }}
-          cache-to: type=gha,scope=contextmine-web,mode=max
-
       - name: Build cached analyzer smoke image
         if: env.RUN_SYSTEM_SMOKE == 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -303,6 +291,63 @@ jobs:
       - name: Run pinned repository sync gate
         if: env.RUN_SYSTEM_SMOKE == 'true'
         run: ./scripts/smoke/model-free-system.sh
+
+  live-web-smoke:
+    name: Live Web Smoke
+    needs: [smoke-changes]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CONTEXTMINE_SMOKE_API_IMAGE: contextmine-smoke-api:${{ github.sha }}
+      CONTEXTMINE_SMOKE_WEB_IMAGE: contextmine-smoke-web:${{ github.sha }}
+      CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES: "true"
+      RUN_LIVE_WEB_SMOKE: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !github.event.pull_request.draft && needs.smoke-changes.outputs.live_web == 'true') }}
+    steps:
+      - name: Require successful change classification
+        if: needs.smoke-changes.result != 'success'
+        run: |
+          echo "System smoke change classification did not succeed" >&2
+          exit 1
+
+      - name: Record intentional skip
+        if: env.RUN_LIVE_WEB_SMOKE != 'true'
+        run: echo "Live web smoke is not required for this event and change set."
+
+      - if: env.RUN_LIVE_WEB_SMOKE == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Docker Buildx
+        if: env.RUN_LIVE_WEB_SMOKE == 'true'
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+
+      - name: Build cached API smoke image
+        if: env.RUN_LIVE_WEB_SMOKE == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          load: true
+          tags: ${{ env.CONTEXTMINE_SMOKE_API_IMAGE }}
+          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
+          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-api' }}
+          cache-to: type=gha,scope=contextmine-api,mode=max
+
+      - name: Build cached web smoke image
+        if: env.RUN_LIVE_WEB_SMOKE == 'true'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./apps/web
+          file: apps/web/Dockerfile
+          load: true
+          tags: ${{ env.CONTEXTMINE_SMOKE_WEB_IMAGE }}
+          no-cache: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' }}
+          cache-from: ${{ env.CONTEXTMINE_SMOKE_COLD_BUILD == 'true' && '' || 'type=gha,scope=contextmine-web' }}
+          cache-to: type=gha,scope=contextmine-web,mode=max
+
+      - name: Drive the web UI in a real browser
+        if: env.RUN_LIVE_WEB_SMOKE == 'true'
+        run: ./scripts/smoke/live-web-smoke.sh
 
   otel-enabled-smoke:
     name: OpenTelemetry Enabled Smoke

--- a/scripts/ci/classify-system-smoke-changes.sh
+++ b/scripts/ci/classify-system-smoke-changes.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 model_free="false"
 otel="false"
+live_web="false"
 
 while IFS= read -r path || [[ -n "${path}" ]]; do
   [[ -z "${path}" ]] && continue
@@ -14,7 +15,8 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       docker-compose.yml | \
       pyproject.toml | \
       uv.lock | \
-      apps/* | \
+      apps/api/* | \
+      apps/worker/* | \
       packages/* | \
       rust/* | \
       scripts/ci/* | \
@@ -43,7 +45,24 @@ while IFS= read -r path || [[ -n "${path}" ]]; do
       otel="true"
       ;;
   esac
+
+  case "${path}" in
+    .dockerignore | \
+      .github/workflows/ci.yml | \
+      docker-compose.yml | \
+      pyproject.toml | \
+      uv.lock | \
+      apps/web/* | \
+      apps/api/* | \
+      packages/* | \
+      scripts/ci/* | \
+      scripts/docker/* | \
+      scripts/smoke/*)
+      live_web="true"
+      ;;
+  esac
 done
 
 printf 'model_free=%s\n' "${model_free}"
 printf 'otel=%s\n' "${otel}"
+printf 'live_web=%s\n' "${live_web}"

--- a/scripts/ci/test-classify-system-smoke-changes.sh
+++ b/scripts/ci/test-classify-system-smoke-changes.sh
@@ -9,11 +9,13 @@ assert_classification() {
   local name="$1"
   local expected_model_free="$2"
   local expected_otel="$3"
-  shift 3
+  local expected_live_web="$4"
+  shift 4
 
   local expected
   local actual
-  expected="$(printf 'model_free=%s\notel=%s' "${expected_model_free}" "${expected_otel}")"
+  expected="$(printf 'model_free=%s\notel=%s\nlive_web=%s' \
+    "${expected_model_free}" "${expected_otel}" "${expected_live_web}")"
   actual="$(printf '%s\n' "$@" | "${classifier}")"
 
   if [[ "${actual}" != "${expected}" ]]; then
@@ -23,19 +25,32 @@ assert_classification() {
   fi
 }
 
-assert_classification "documentation only" false false \
+assert_classification "documentation only" false false false \
   README.md docs/operations.md
-assert_classification "web application" true false \
+
+# A frontend change needs the browser check, not the indexing run.
+assert_classification "web application" false false true \
   apps/web/src/App.tsx
-assert_classification "shared Python package" true true \
+
+# The API sits behind the UI, so it needs both.
+assert_classification "api application" true true true \
+  apps/api/app/main.py
+
+# Indexing is backend only - no reason to build the web image.
+assert_classification "worker application" true true false \
+  apps/worker/contextmine_worker/flows.py
+
+assert_classification "shared Python package" true true true \
   packages/core/contextmine_core/config.py
-assert_classification "OpenTelemetry smoke" true true \
+assert_classification "OpenTelemetry smoke" true true true \
   scripts/smoke/otel_enabled.py
-assert_classification "CI policy" true true \
+assert_classification "CI policy" true true true \
   .github/workflows/ci.yml
-assert_classification "deployment only" false false \
+assert_classification "deployment only" false false false \
   deploy/helm/contextmine/values.yaml
-assert_classification "combined changes" true true \
-  README.md apps/web/src/App.tsx apps/api/contextmine_api/main.py
+assert_classification "rust crawler" true true false \
+  rust/spider_md/src/main.rs
+assert_classification "combined changes" true true true \
+  README.md apps/web/src/App.tsx apps/api/app/main.py
 
 echo "System smoke change classifier tests passed"

--- a/scripts/smoke/live-web-smoke.sh
+++ b/scripts/smoke/live-web-smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Drive the web UI in a real browser against a live API.
+#
+# Split out of model-free-system.sh: that gate additionally indexes a pinned
+# repository, which needs the analyzer image and takes minutes. A frontend
+# change needs the browser check, not the indexing run.
+
+set -euo pipefail
+
+repository_root="$(git rev-parse --show-toplevel)"
+compose_file="${repository_root}/scripts/smoke/docker-compose.yml"
+compose_project="contextmine-live-web-${BASHPID}"
+compose_up_build_args=(--build)
+compose_run_build_args=(--build)
+
+if [[ "${CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES:-false}" == "true" ]]; then
+  compose_up_build_args=(--no-build)
+  compose_run_build_args=()
+
+  for image in \
+    "${CONTEXTMINE_SMOKE_API_IMAGE:?prebuilt API image is required}" \
+    "${CONTEXTMINE_SMOKE_WEB_IMAGE:?prebuilt web image is required}"; do
+    if ! docker image inspect "${image}" >/dev/null; then
+      echo "Required prebuilt smoke image is unavailable: ${image}" >&2
+      exit 1
+    fi
+  done
+fi
+
+cleanup() {
+  docker compose \
+    --project-name "${compose_project}" \
+    --file "${compose_file}" \
+    down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# The compose file demands these for the analyzer service, which this smoke
+# never starts. Compose still interpolates them, so give them inert values.
+export CONTEXTMINE_SMOKE_FIXTURE_DIR="${CONTEXTMINE_SMOKE_FIXTURE_DIR:-${repository_root}}"
+export CONTEXTMINE_SMOKE_FIXTURE_REVISION="${CONTEXTMINE_SMOKE_FIXTURE_REVISION:-unused}"
+export CONTEXTMINE_SMOKE_WORKER_TARGET="${CONTEXTMINE_SMOKE_WORKER_TARGET:-analyzer}"
+
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  up "${compose_up_build_args[@]}" --detach --wait --wait-timeout 300 \
+  postgres prefect-server api web browser
+
+docker compose \
+  --project-name "${compose_project}" \
+  --file "${compose_file}" \
+  run "${compose_run_build_args[@]}" --rm --no-deps \
+  --env CONTEXTMINE_SMOKE_WEB_URL=http://web:5173 \
+  --env CONTEXTMINE_SMOKE_BROWSER_URL=http://browser:9222 \
+  --volume "${repository_root}/scripts/smoke/live_web.mjs:/app/live_web.mjs:ro" \
+  web node /app/live_web.mjs

--- a/scripts/smoke/model-free-system.sh
+++ b/scripts/smoke/model-free-system.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# Index a pinned repository end to end and assert the resulting counts.
+#
+# The browser check against the web UI lives in live-web-smoke.sh, so that a
+# frontend change need not wait for an indexing run and an indexing change
+# need not build the web image.
+
 set -euo pipefail
 
 readonly FIXTURE_REPOSITORY="https://github.com/fastapi/full-stack-fastapi-template.git"
@@ -20,7 +26,6 @@ if [[ "${CONTEXTMINE_SMOKE_USE_PREBUILT_IMAGES:-false}" == "true" ]]; then
 
   for image in \
     "${CONTEXTMINE_SMOKE_API_IMAGE:?prebuilt API image is required}" \
-    "${CONTEXTMINE_SMOKE_WEB_IMAGE:?prebuilt web image is required}" \
     "${CONTEXTMINE_SMOKE_WORKER_IMAGE:?prebuilt analyzer image is required}"; do
     if ! docker image inspect "${image}" >/dev/null; then
       echo "Required prebuilt smoke image is unavailable: ${image}" >&2
@@ -57,7 +62,7 @@ docker compose \
   --project-name "${compose_project}" \
   --file "${compose_file}" \
   up "${compose_up_build_args[@]}" --detach --wait --wait-timeout 300 \
-  postgres prefect-server api web browser
+  postgres prefect-server api
 
 prefect_server_version="$(
   docker compose \
@@ -69,15 +74,6 @@ if [[ -z "${prefect_server_version}" ]]; then
   echo "Prefect server version could not be determined" >&2
   exit 1
 fi
-
-docker compose \
-  --project-name "${compose_project}" \
-  --file "${compose_file}" \
-  run --rm --no-deps \
-  --env CONTEXTMINE_SMOKE_WEB_URL=http://web:5173 \
-  --env CONTEXTMINE_SMOKE_BROWSER_URL=http://browser:9222 \
-  --volume "${repository_root}/scripts/smoke/live_web.mjs:/app/live_web.mjs:ro" \
-  web node /app/live_web.mjs
 
 docker compose \
   --project-name "${compose_project}" \


### PR DESCRIPTION
## Problem

One job did two unrelated things:

1. **Index a pinned repository end to end** — needs the analyzer image, takes minutes
2. **Drive the web UI in a real browser** against a live API — needs api + web + browser

And because the change classifier matched `apps/*` for that job, a **frontend-only change triggered the whole thing**: building the analyzer image and running a full indexing pass to reach a browser check that needs neither. Measured on a recent run:

```
10min  Model-free System & Live Web Smoke
 3min  OpenTelemetry Enabled Smoke
 2min  Rust Format, Clippy & Test
 1min  Web Lint, Test & Build
```

## Fix

| Job | Triggers on | Builds | Does |
|---|---|---|---|
| `model-free-system-smoke` | `apps/api`, `apps/worker`, `packages`, `rust` | api + analyzer | indexes the fixture |
| `live-web-smoke` *(new)* | `apps/web`, `apps/api`, `packages` | api + web | drives the browser |

Each builds only the images it needs — so the split also removes the web image build from the indexing gate and the analyzer build from the browser check.

The classifier gained a `live_web` output alongside `model_free` and `otel`, and `model_free` narrowed from `apps/*` to `apps/api/*` + `apps/worker/*` — which is exactly what the `otel` branch immediately below it already did. That asymmetry looks like copy-paste history rather than intent.

## ⚠️ Action required after merge

**Add `Live Web Smoke` to the required status checks on `main`.**

Until that happens, a frontend-only PR satisfies the required smoke check *by skipping it*, and the browser check runs without blocking — a weaker gate than today. I can make that change if you want it done together with the merge.

The existing job deliberately **keeps its name** `Model-free System & Live Web Smoke`, even though it no longer runs the browser check. That name is a required status check; renaming it in this change would block every open PR until protection is updated. The rename belongs in a follow-up, once protection lists the new job.

## Tests

The classifier already had a test script. Extended from 7 to 10 cases, all now asserting **all three** outputs:

```
web application       model_free=false  otel=false  live_web=true
worker application    model_free=true   otel=true   live_web=false
api application       model_free=true   otel=true   live_web=true
rust crawler          model_free=true   otel=true   live_web=false
```

The first two are the point of the change: a frontend change no longer triggers indexing, and a worker change no longer builds the web image.

`./scripts/ci/test-classify-system-smoke-changes.sh` passes; both shell scripts pass `bash -n`; the workflow parses as valid YAML with all 11 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)