### PR TITLE
ci: drop the live web part from the model-free smoke job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
           printf '%s\n' "${classification}" >>"${GITHUB_OUTPUT}"
 
   model-free-system-smoke:
-    name: Model-free System & Live Web Smoke
+    name: Model-free System Smoke
     needs: [smoke-changes]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Cosmetic follow-up to #56. The job stopped running the browser check there but kept its old name:

```
- name: Model-free System & Live Web Smoke
+ name: Model-free System Smoke
```

## Why it could not be part of #56

The old name is a **required status check** on `main`. Renaming the job in the same change would have meant no workflow produces that check any more — blocking every open pull request until branch protection caught up.

## Why it is safe now

`Live Web Smoke` is its own required check since #56 merged, so the browser test is independently enforced. The sequence for this PR avoids any unprotected window:

1. This PR runs CI and produces the **new** check name
2. Branch protection swaps old name → new name in a single PATCH, once that check is green
3. This PR then satisfies the new requirement and merges

At no point is a required check unproduced, and at no point is the smoke gate absent. There are currently no other open PRs, so nothing else is affected by the swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)