### PR TITLE
perf(twin): aggregate scenario graph projections in the database

### DIFF
--- a/packages/core/contextmine_core/twin/projections.py
+++ b/packages/core/contextmine_core/twin/projections.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
@@ -48,10 +49,11 @@ class ArchitectureProjectionEdge:
 
 _canonical_file_path = canonical_file_path_from_node
 
+# (domain, container, component, grouping strategy, confidence)
+ArchGroup = tuple[str, str, str, str, float]
 
-def _derive_group(
-    path: str | None, meta: dict[str, Any]
-) -> tuple[str, str, str, str, float] | None:
+
+def derive_group_with_strategy(path: str | None, meta: dict[str, Any]) -> ArchGroup | None:
     """Thin wrapper adding strategy/confidence to the shared grouping logic."""
     payload = meta or {}
     architecture_meta = payload.get("architecture")
@@ -68,6 +70,9 @@ def _derive_group(
     if is_explicit:
         return domain, container, component, "explicit", 1.0
     return domain, container, component, "heuristic", 0.6
+
+
+_derive_group = derive_group_with_strategy
 
 
 def _kind_allowed(
@@ -103,11 +108,9 @@ def _group_nodes_by_arch(
     nodes: list[dict[str, Any]],
     include_kinds: set[str] | None,
     exclude_kinds: set[str] | None,
-) -> tuple[dict[str, tuple[str, str, str, str, float]], int, int]:
-    """Assign each node to its architecture group. Return (mapping, explicit_count, heuristic_count)."""
-    group_by_node_id: dict[str, tuple[str, str, str, str, float]] = {}
-    explicit_count = 0
-    heuristic_count = 0
+) -> dict[str, ArchGroup]:
+    """Assign each allowed node to its architecture group, keyed by node id."""
+    group_by_node_id: dict[str, ArchGroup] = {}
     for node in nodes:
         kind = str(node.get("kind") or "")
         if not _kind_allowed(kind, include_kinds, exclude_kinds):
@@ -117,25 +120,18 @@ def _group_nodes_by_arch(
         if not group:
             continue
         group_by_node_id[str(node["id"])] = group
-        if group[3] == "explicit":
-            explicit_count += 1
-        else:
-            heuristic_count += 1
-    return group_by_node_id, explicit_count, heuristic_count
+    return group_by_node_id
 
 
 def _aggregate_arch_edges(
-    edges: list[dict[str, Any]],
-    group_by_node_id: dict[str, tuple[str, str, str, str, float]],
+    edge_groups: Iterable[tuple[ArchGroup, ArchGroup, str, int]],
     key_to_node_id: dict[str, str],
     level: str,
 ) -> list[dict[str, Any]]:
-    """Aggregate raw edges into architecture-level projected edges."""
+    """Fold grouped raw edges into architecture-level projected edges."""
     edge_stats: dict[tuple[str, str], dict[str, Any]] = {}
-    for edge in edges:
-        src = group_by_node_id.get(str(edge.get("source_node_id")))
-        dst = group_by_node_id.get(str(edge.get("target_node_id")))
-        if not src or not dst:
+    for src, dst, kind, count in edge_groups:
+        if count <= 0:
             continue
         src_key = "|".join(_make_level_key(level, src))
         dst_key = "|".join(_make_level_key(level, dst))
@@ -149,9 +145,9 @@ def _aggregate_arch_edges(
             (src_node_id, dst_node_id),
             {"weight": 0, "sample_edge_kinds": set(), "raw_edge_count": 0},
         )
-        bucket["weight"] += 1
-        bucket["raw_edge_count"] += 1
-        bucket["sample_edge_kinds"].add(str(edge.get("kind") or "depends_on"))
+        bucket["weight"] += count
+        bucket["raw_edge_count"] += count
+        bucket["sample_edge_kinds"].add(kind or "depends_on")
 
     projected_edges: list[dict[str, Any]] = []
     for idx, ((src, dst), stat) in enumerate(sorted(edge_stats.items()), start=1):
@@ -171,24 +167,39 @@ def _aggregate_arch_edges(
     return projected_edges
 
 
-def build_architecture_projection(
-    nodes: list[dict[str, Any]],
-    edges: list[dict[str, Any]],
-    entity_level: str,
-    include_kinds: set[str] | None = None,
-    exclude_kinds: set[str] | None = None,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str]:
-    """Aggregate raw nodes/edges into architecture entities."""
+def normalize_architecture_level(entity_level: str | None) -> str:
+    """Clamp a requested architecture level to the supported set."""
     level = (entity_level or "container").lower()
     if level not in {"domain", "container", "component"}:
-        level = "container"
+        return "container"
+    return level
 
-    group_by_node_id, explicit_count, heuristic_count = _group_nodes_by_arch(
-        nodes, include_kinds, exclude_kinds
-    )
+
+def assemble_architecture_projection(
+    member_groups: Iterable[tuple[ArchGroup, int]],
+    edge_groups: Iterable[tuple[ArchGroup, ArchGroup, str, int]],
+    entity_level: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str]:
+    """Build architecture entities from pre-grouped, counted members and edges.
+
+    ``member_groups`` carries one entry per (group, member count); ``edge_groups``
+    one per (source group, target group, raw edge kind, raw edge count). Feeding
+    counts instead of individual nodes lets the database do the grouping while
+    the projected output stays byte-identical to the in-memory builder.
+    """
+    level = normalize_architecture_level(entity_level)
 
     node_stats: dict[str, dict[str, Any]] = {}
-    for group in group_by_node_id.values():
+    explicit_count = 0
+    heuristic_count = 0
+    for group, count in member_groups:
+        if count <= 0:
+            continue
+        strategy = group[3]
+        if strategy == "explicit":
+            explicit_count += count
+        else:
+            heuristic_count += count
         key = _make_level_key(level, group)
         stat = node_stats.setdefault(
             "|".join(key),
@@ -204,13 +215,13 @@ def build_architecture_projection(
                 "heuristic_member_count": 0,
             },
         )
-        stat["member_count"] += 1
-        stat["confidence_sum"] += float(group[4])
-        stat["derived_from"].add(group[3])
-        if group[3] == "explicit":
-            stat["explicit_member_count"] += 1
+        stat["member_count"] += count
+        stat["confidence_sum"] += float(group[4]) * count
+        stat["derived_from"].add(strategy)
+        if strategy == "explicit":
+            stat["explicit_member_count"] += count
         else:
-            stat["heuristic_member_count"] += 1
+            stat["heuristic_member_count"] += count
 
     projected_nodes: list[dict[str, Any]] = []
     key_to_node_id: dict[str, str] = {}
@@ -249,7 +260,7 @@ def build_architecture_projection(
             ).__dict__
         )
 
-    projected_edges = _aggregate_arch_edges(edges, group_by_node_id, key_to_node_id, level)
+    projected_edges = _aggregate_arch_edges(edge_groups, key_to_node_id, level)
 
     if explicit_count and heuristic_count:
         grouping_strategy = "mixed"
@@ -259,6 +270,31 @@ def build_architecture_projection(
         grouping_strategy = "heuristic"
 
     return projected_nodes, projected_edges, grouping_strategy
+
+
+def build_architecture_projection(
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    entity_level: str,
+    include_kinds: set[str] | None = None,
+    exclude_kinds: set[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str]:
+    """Aggregate raw in-memory nodes/edges into architecture entities."""
+    group_by_node_id = _group_nodes_by_arch(nodes, include_kinds, exclude_kinds)
+
+    def _edge_groups() -> Iterable[tuple[ArchGroup, ArchGroup, str, int]]:
+        for edge in edges:
+            src = group_by_node_id.get(str(edge.get("source_node_id")))
+            dst = group_by_node_id.get(str(edge.get("target_node_id")))
+            if not src or not dst:
+                continue
+            yield src, dst, str(edge.get("kind") or "depends_on"), 1
+
+    return assemble_architecture_projection(
+        ((group, 1) for group in group_by_node_id.values()),
+        _edge_groups(),
+        entity_level,
+    )
 
 
 def _evidence_summary(evidence: tuple[EvidenceRef, ...]) -> list[str]:
@@ -475,85 +511,70 @@ def build_inferred_architecture_projection(
     }
 
 
-def _resolve_file_edge_endpoints(
-    edge: dict[str, Any],
-    node_by_id: dict[str, dict[str, Any]],
-    file_id_by_path: dict[str, str],
-) -> tuple[str, str] | None:
-    """Resolve an edge to source/target file IDs, returning None if ineligible."""
-    src_node = node_by_id.get(str(edge.get("source_node_id")))
-    dst_node = node_by_id.get(str(edge.get("target_node_id")))
-    if not src_node or not dst_node:
-        return None
-    src_path = _canonical_file_path(src_node)
-    dst_path = _canonical_file_path(dst_node)
-    if not src_path or not dst_path:
-        return None
-    src_file_id = file_id_by_path.get(src_path)
-    dst_file_id = file_id_by_path.get(dst_path)
-    if not src_file_id or not dst_file_id or src_file_id == dst_file_id:
-        return None
-    return src_file_id, dst_file_id
+FILE_DEFINES_SYMBOL_EDGE_KIND = "file_defines_symbol"
 
 
 def _classify_file_nodes(
     nodes: list[dict[str, Any]],
-) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]], dict[str, int]]:
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
     """Separate file nodes from symbol nodes and count symbols per path."""
     file_nodes: list[dict[str, Any]] = []
-    file_by_path: dict[str, dict[str, Any]] = {}
     symbol_count_by_path: dict[str, int] = defaultdict(int)
     for node in nodes:
         kind = str(node.get("kind") or "").lower()
         path = _canonical_file_path(node)
         if kind == "file" and path:
             file_nodes.append(node)
-            file_by_path[path] = node
         elif path:
             symbol_count_by_path[path] += 1
-    return file_nodes, file_by_path, symbol_count_by_path
+    return file_nodes, symbol_count_by_path
 
 
-def _bucket_file_edges(
+def _file_edge_groups(
     edges: list[dict[str, Any]],
     node_by_id: dict[str, dict[str, Any]],
-    file_id_by_path: dict[str, str],
     include_edge_kinds: set[str] | None,
-) -> dict[tuple[str, str], dict[str, Any]]:
-    """Bucket edges by (source_file, target_file) for file projection."""
-    edge_buckets: dict[tuple[str, str], dict[str, Any]] = {}
+) -> Iterable[tuple[str, str, str, int]]:
+    """Yield (source path, target path, edge kind, 1) for every eligible raw edge."""
     for edge in edges:
         edge_kind = str(edge.get("kind") or "")
-        if edge_kind == "file_defines_symbol":
+        if edge_kind == FILE_DEFINES_SYMBOL_EDGE_KIND:
             continue
         if include_edge_kinds and edge_kind.lower() not in include_edge_kinds:
             continue
-        endpoints = _resolve_file_edge_endpoints(edge, node_by_id, file_id_by_path)
-        if not endpoints:
+        src_node = node_by_id.get(str(edge.get("source_node_id")))
+        dst_node = node_by_id.get(str(edge.get("target_node_id")))
+        if not src_node or not dst_node:
             continue
-        src_file_id, dst_file_id = endpoints
-        bucket = edge_buckets.setdefault(
-            (src_file_id, dst_file_id),
-            {"weight": 0, "sample_edge_kinds": set(), "raw_edge_count": 0},
-        )
-        bucket["weight"] += 1
-        bucket["raw_edge_count"] += 1
-        bucket["sample_edge_kinds"].add(edge_kind)
-    return edge_buckets
+        src_path = _canonical_file_path(src_node)
+        dst_path = _canonical_file_path(dst_node)
+        if not src_path or not dst_path or src_path == dst_path:
+            continue
+        yield src_path, dst_path, edge_kind, 1
 
 
-def build_code_file_projection(
-    nodes: list[dict[str, Any]],
-    edges: list[dict[str, Any]],
-    include_edge_kinds: set[str] | None = None,
+def assemble_code_file_projection(
+    file_nodes: list[dict[str, Any]],
+    symbol_count_by_path: Mapping[str, int],
+    edge_groups: Iterable[tuple[str, str, str, int]],
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Project raw graph to file dependency graph."""
-    node_by_id = {str(node["id"]): node for node in nodes}
-    file_nodes, file_by_path, symbol_count_by_path = _classify_file_nodes(nodes)
+    """Build the file dependency graph from file nodes and path-grouped edges.
+
+    ``edge_groups`` carries (source path, target path, raw edge kind, raw edge
+    count) rows; edges touching a path without a file node are dropped, exactly
+    as the in-memory builder does.
+    """
+    file_by_path: dict[str, dict[str, Any]] = {}
+    for node in file_nodes:
+        path = _canonical_file_path(node)
+        if path:
+            file_by_path[path] = node
 
     projected_nodes: list[dict[str, Any]] = []
     for node in file_nodes:
-        path = _canonical_file_path(node) or str(node.get("name") or "")
+        path = _canonical_file_path(node)
+        if not path:
+            continue  # a file node without a path cannot anchor edges or counts
         meta = dict(node.get("meta") or {})
         meta["symbol_count"] = int(symbol_count_by_path.get(path, 0))
         projected_nodes.append(
@@ -567,7 +588,21 @@ def build_code_file_projection(
         )
 
     file_id_by_path = {path: str(node["id"]) for path, node in file_by_path.items()}
-    edge_buckets = _bucket_file_edges(edges, node_by_id, file_id_by_path, include_edge_kinds)
+    edge_buckets: dict[tuple[str, str], dict[str, Any]] = {}
+    for src_path, dst_path, edge_kind, count in edge_groups:
+        if count <= 0:
+            continue
+        src_file_id = file_id_by_path.get(src_path)
+        dst_file_id = file_id_by_path.get(dst_path)
+        if not src_file_id or not dst_file_id or src_file_id == dst_file_id:
+            continue
+        bucket = edge_buckets.setdefault(
+            (src_file_id, dst_file_id),
+            {"weight": 0, "sample_edge_kinds": set(), "raw_edge_count": 0},
+        )
+        bucket["weight"] += count
+        bucket["raw_edge_count"] += count
+        bucket["sample_edge_kinds"].add(edge_kind)
 
     projected_edges: list[dict[str, Any]] = []
     for idx, ((src, dst), bucket) in enumerate(sorted(edge_buckets.items()), start=1):
@@ -586,6 +621,21 @@ def build_code_file_projection(
         )
 
     return projected_nodes, projected_edges
+
+
+def build_code_file_projection(
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    include_edge_kinds: set[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Project an in-memory raw graph to a file dependency graph."""
+    node_by_id = {str(node["id"]): node for node in nodes}
+    file_nodes, symbol_count_by_path = _classify_file_nodes(nodes)
+    return assemble_code_file_projection(
+        file_nodes,
+        symbol_count_by_path,
+        _file_edge_groups(edges, node_by_id, include_edge_kinds),
+    )
 
 
 def build_code_symbol_projection(

--- a/packages/core/contextmine_core/twin/service.py
+++ b/packages/core/contextmine_core/twin/service.py
@@ -993,12 +993,19 @@ def _edge_aware_node_order(
     ordered: list[str] = []
     queue: deque[str] = deque()
     queued: set[str] = set()
+    # Every node before this index has already been ordered, so the search for
+    # the next BFS anchor never rescans the list. Scanning from the start on
+    # every component made sparse graphs quadratic: a symbol graph with 200k
+    # mostly isolated nodes took minutes to page.
+    anchor_index = 0
 
     while remaining:
         if not queue:
-            next_anchor = next((node_id for node_id in node_ids if node_id in remaining), None)
-            if next_anchor is None:
+            while anchor_index < len(node_ids) and node_ids[anchor_index] not in remaining:
+                anchor_index += 1
+            if anchor_index >= len(node_ids):
                 break
+            next_anchor = node_ids[anchor_index]
             queue.append(next_anchor)
             queued.add(next_anchor)
 

--- a/packages/core/contextmine_core/twin/service.py
+++ b/packages/core/contextmine_core/twin/service.py
@@ -44,12 +44,18 @@ from contextmine_core.models import (
 from contextmine_core.pathing import canonicalize_repo_relative_path
 from contextmine_core.semantic_snapshot.models import RelationKind, Snapshot, SymbolKind
 from contextmine_core.twin.projections import (
+    FILE_DEFINES_SYMBOL_EDGE_KIND,
+    ArchGroup,
     GraphProjection,
+    assemble_architecture_projection,
+    assemble_code_file_projection,
     build_architecture_projection,
     build_code_file_projection,
     build_code_symbol_projection,
+    derive_group_with_strategy,
+    normalize_architecture_level,
 )
-from sqlalchemy import delete, or_, select
+from sqlalchemy import ColumnElement, and_, case, delete, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -1100,65 +1106,48 @@ async def get_full_scenario_graph(
     exclude_kinds: set[str] | None = None,
     include_edge_kinds: set[str] | None = None,
 ) -> dict[str, Any]:
-    """Get full (unpaged) graph view with optional projection."""
-    node_stmt = select(TwinNode).where(TwinNode.scenario_id == scenario_id)
-    if layer is not None:
-        node_stmt = node_stmt.join(TwinNodeLayer, TwinNodeLayer.node_id == TwinNode.id).where(
-            TwinNodeLayer.layer == layer
+    """Get full (unpaged) graph view with optional projection.
+
+    Filtering and grouping happen in the database wherever the projection allows
+    it: the architecture and file projections only ever need per-path counts, so
+    the raw symbol rows never leave PostgreSQL. The symbol projection still loads
+    rows, but only the kinds the caller asked for and as plain column tuples
+    rather than ORM instances.
+    """
+    include_kinds_norm = _normalize_kinds(include_kinds)
+    exclude_kinds_norm = _normalize_kinds(exclude_kinds)
+    include_edge_kinds_norm = _normalize_kinds(include_edge_kinds)
+
+    if projection == GraphProjection.ARCHITECTURE:
+        return await _load_architecture_projection(
+            session,
+            scenario_id,
+            layer,
+            entity_level,
+            include_kinds_norm,
+            exclude_kinds_norm,
+        )
+    if projection == GraphProjection.CODE_FILE:
+        return await _load_code_file_projection(
+            session,
+            scenario_id,
+            layer,
+            entity_level,
+            exclude_kinds_norm,
+            include_edge_kinds_norm,
         )
 
-    raw_nodes = (await session.execute(node_stmt)).scalars().all()
-    if not raw_nodes:
-        raw_edges = []
-    elif layer is None:
-        # Scenario edges already reference nodes within the same scenario, so avoid
-        # building a giant IN (...) filter that can exceed PostgreSQL parameter limits.
-        edge_stmt = select(TwinEdge).where(TwinEdge.scenario_id == scenario_id)
-        raw_edges = (await session.execute(edge_stmt)).scalars().all()
-    else:
-        src_layer = aliased(TwinNodeLayer)
-        dst_layer = aliased(TwinNodeLayer)
-        edge_stmt = (
-            select(TwinEdge)
-            .join(src_layer, src_layer.node_id == TwinEdge.source_node_id)
-            .join(dst_layer, dst_layer.node_id == TwinEdge.target_node_id)
-            .where(
-                TwinEdge.scenario_id == scenario_id,
-                src_layer.layer == layer,
-                dst_layer.layer == layer,
-            )
-            .distinct()
-        )
-        raw_edges = (await session.execute(edge_stmt)).scalars().all()
-
-    nodes = [
-        {
-            "id": str(n.id),
-            "natural_key": n.natural_key,
-            "kind": n.kind,
-            "name": n.name,
-            "meta": n.meta or {},
-        }
-        for n in raw_nodes
-    ]
-    edges = [
-        {
-            "id": str(e.id),
-            "source_node_id": str(e.source_node_id),
-            "target_node_id": str(e.target_node_id),
-            "kind": e.kind,
-            "meta": e.meta or {},
-        }
-        for e in raw_edges
-    ]
-
-    include_kinds_norm = {kind.lower() for kind in include_kinds} if include_kinds else None
-    exclude_kinds_norm = {kind.lower() for kind in exclude_kinds} if exclude_kinds else None
-    include_edge_kinds_norm = (
-        {kind.lower() for kind in include_edge_kinds} if include_edge_kinds else None
+    # Symbol projection: the builder hides ``file`` nodes on top of the caller's
+    # filters, so push the same predicate into SQL and let it see only survivors.
+    nodes, edges = await _load_graph_rows(
+        session,
+        scenario_id,
+        layer,
+        include_kinds=include_kinds_norm,
+        exclude_kinds=(exclude_kinds_norm or set()) | {"file"},
+        include_edge_kinds=include_edge_kinds_norm,
     )
-
-    result = _apply_graph_projection(
+    return _apply_graph_projection(
         nodes,
         edges,
         projection,
@@ -1167,7 +1156,346 @@ async def get_full_scenario_graph(
         exclude_kinds_norm,
         include_edge_kinds_norm,
     )
-    return result
+
+
+# ── Database-side loading helpers ────────────────────────────────────────
+
+
+def _normalize_kinds(kinds: set[str] | None) -> set[str] | None:
+    """Lower-case a kind filter; empty filters mean "no filter"."""
+    if not kinds:
+        return None
+    return {kind.lower() for kind in kinds} or None
+
+
+def _node_kind_filters(
+    node: Any,
+    include_kinds: set[str] | None,
+    exclude_kinds: set[str] | None,
+) -> list[ColumnElement[bool]]:
+    """SQL counterpart of projections._kind_allowed for a TwinNode (or alias)."""
+    clauses: list[ColumnElement[bool]] = []
+    if include_kinds:
+        clauses.append(func.lower(node.kind).in_(sorted(include_kinds)))
+    if exclude_kinds:
+        clauses.append(func.lower(node.kind).not_in(sorted(exclude_kinds)))
+    return clauses
+
+
+def _node_path_expression(node: Any) -> ColumnElement[str | None]:
+    """SQL counterpart of grouping.canonical_file_path_from_node.
+
+    File nodes take their path from the ``file:`` natural key; every other kind
+    falls back to ``meta.file_path``. Empty values become NULL.
+    """
+    key_path = func.nullif(func.trim(func.substr(node.natural_key, len("file:") + 1)), "")
+    meta_path = func.nullif(func.trim(node.meta["file_path"].as_string()), "")
+    return case(
+        (and_(func.lower(node.kind) == "file", node.natural_key.like("file:%")), key_path),
+        else_=meta_path,
+    )
+
+
+def _node_arch_meta_expressions(node: Any) -> tuple[ColumnElement[Any], ...]:
+    """Explicit ``meta.architecture`` fields, as consumed by derive_arch_group."""
+    architecture = node.meta["architecture"]
+    return (
+        architecture["domain"].as_string(),
+        architecture["container"].as_string(),
+        architecture["component"].as_string(),
+    )
+
+
+def _with_layer(stmt: Select, node: Any, layer: TwinLayer | None) -> Select:
+    """Restrict ``node`` rows to one layer through the membership table."""
+    if layer is None:
+        return stmt
+    membership = aliased(TwinNodeLayer)
+    return stmt.join(membership, membership.node_id == node.id).where(membership.layer == layer)
+
+
+def _edge_with_endpoints(
+    scenario_id: UUID,
+    layer: TwinLayer | None,
+    *columns: ColumnElement[Any],
+) -> tuple[Select, Any, Any]:
+    """Select ``columns`` from scenario edges joined to their endpoint nodes."""
+    source = aliased(TwinNode)
+    target = aliased(TwinNode)
+    stmt = (
+        select(*columns)
+        .select_from(TwinEdge)
+        .join(source, source.id == TwinEdge.source_node_id)
+        .join(target, target.id == TwinEdge.target_node_id)
+        .where(TwinEdge.scenario_id == scenario_id)
+    )
+    stmt = _with_layer(stmt, source, layer)
+    stmt = _with_layer(stmt, target, layer)
+    return stmt, source, target
+
+
+def _derive_group_cached(
+    cache: dict[tuple[Any, ...], ArchGroup | None],
+    path: str | None,
+    domain: str | None,
+    container: str | None,
+    component: str | None,
+) -> ArchGroup | None:
+    """Derive the architecture group for one grouped row, memoised per path."""
+    key = (path, domain, container, component)
+    if key not in cache:
+        meta: dict[str, Any] = {}
+        if domain is not None or container is not None or component is not None:
+            meta["architecture"] = {
+                "domain": domain,
+                "container": container,
+                "component": component,
+            }
+        cache[key] = derive_group_with_strategy(path, meta)
+    return cache[key]
+
+
+async def _load_architecture_projection(
+    session: AsyncSession,
+    scenario_id: UUID,
+    layer: TwinLayer | None,
+    entity_level: str | None,
+    include_kinds: set[str] | None,
+    exclude_kinds: set[str] | None,
+) -> dict[str, Any]:
+    """Architecture projection with grouping pushed into SQL.
+
+    Nodes and edges are grouped by (path, explicit architecture meta) in the
+    database; the heuristic domain/container derivation then runs once per
+    distinct path instead of once per node.
+    """
+    effective_entity_level = normalize_architecture_level(entity_level)
+    effective_excluded = set(exclude_kinds or set()) | _ARCHITECTURE_DEFAULT_HIDDEN_KINDS
+
+    node = TwinNode
+    node_columns = (_node_path_expression(node), *_node_arch_meta_expressions(node))
+    node_stmt = (
+        select(*node_columns, func.count())
+        .where(
+            TwinNode.scenario_id == scenario_id,
+            *_node_kind_filters(node, include_kinds, effective_excluded),
+        )
+        .group_by(*node_columns)
+    )
+    node_stmt = _with_layer(node_stmt, node, layer)
+
+    cache: dict[tuple[Any, ...], ArchGroup | None] = {}
+    member_groups: list[tuple[ArchGroup, int]] = []
+    for path, domain, container, component, count in (await session.execute(node_stmt)).all():
+        group = _derive_group_cached(cache, path, domain, container, component)
+        if group is not None:
+            member_groups.append((group, int(count)))
+
+    edge_groups: list[tuple[ArchGroup, ArchGroup, str, int]] = []
+    if member_groups:
+        edge_stmt, source, target = _edge_with_endpoints(scenario_id, layer)
+        source_columns = (_node_path_expression(source), *_node_arch_meta_expressions(source))
+        target_columns = (_node_path_expression(target), *_node_arch_meta_expressions(target))
+        edge_stmt = (
+            edge_stmt.add_columns(*source_columns, *target_columns, TwinEdge.kind, func.count())
+            .where(
+                *_node_kind_filters(source, include_kinds, effective_excluded),
+                *_node_kind_filters(target, include_kinds, effective_excluded),
+            )
+            .group_by(*source_columns, *target_columns, TwinEdge.kind)
+        )
+        for row in (await session.execute(edge_stmt)).all():
+            src = _derive_group_cached(cache, *row[0:4])
+            dst = _derive_group_cached(cache, *row[4:8])
+            if src is None or dst is None:
+                continue
+            edge_groups.append((src, dst, str(row[8] or "depends_on"), int(row[9])))
+
+    projected_nodes, projected_edges, grouping_strategy = assemble_architecture_projection(
+        member_groups, edge_groups, effective_entity_level
+    )
+    return _architecture_result(
+        projected_nodes,
+        projected_edges,
+        grouping_strategy,
+        effective_entity_level,
+        effective_excluded,
+    )
+
+
+async def _load_code_file_projection(
+    session: AsyncSession,
+    scenario_id: UUID,
+    layer: TwinLayer | None,
+    entity_level: str | None,
+    exclude_kinds: set[str] | None,
+    include_edge_kinds: set[str] | None,
+) -> dict[str, Any]:
+    """File dependency projection with symbol counts and edge folding in SQL.
+
+    ``exclude_kinds`` is only echoed back in the response: the file projection
+    never applied it, and the in-memory builder reports it the same way.
+    """
+    file_stmt = (
+        select(TwinNode.id, TwinNode.natural_key, TwinNode.kind, TwinNode.name, TwinNode.meta)
+        .where(
+            TwinNode.scenario_id == scenario_id,
+            func.lower(TwinNode.kind) == "file",
+            _node_path_expression(TwinNode).is_not(None),
+        )
+        .order_by(TwinNode.natural_key, TwinNode.id)
+    )
+    file_stmt = _with_layer(file_stmt, TwinNode, layer)
+    file_nodes = [_node_row_to_dict(row) for row in (await session.execute(file_stmt)).all()]
+
+    symbol_count_by_path: dict[str, int] = {}
+    edge_groups: list[tuple[str, str, str, int]] = []
+    if file_nodes:
+        path = _node_path_expression(TwinNode)
+        count_stmt = (
+            select(path, func.count())
+            .where(
+                TwinNode.scenario_id == scenario_id,
+                func.lower(TwinNode.kind) != "file",
+                path.is_not(None),
+            )
+            .group_by(path)
+        )
+        count_stmt = _with_layer(count_stmt, TwinNode, layer)
+        symbol_count_by_path = {
+            str(row_path): int(count)
+            for row_path, count in (await session.execute(count_stmt)).all()
+        }
+
+        edge_stmt, source, target = _edge_with_endpoints(scenario_id, layer)
+        source_path = _node_path_expression(source)
+        target_path = _node_path_expression(target)
+        edge_stmt = (
+            edge_stmt.add_columns(source_path, target_path, TwinEdge.kind, func.count())
+            .where(
+                TwinEdge.kind != FILE_DEFINES_SYMBOL_EDGE_KIND,
+                source_path.is_not(None),
+                target_path.is_not(None),
+                source_path != target_path,
+            )
+            .group_by(source_path, target_path, TwinEdge.kind)
+        )
+        if include_edge_kinds:
+            edge_stmt = edge_stmt.where(func.lower(TwinEdge.kind).in_(sorted(include_edge_kinds)))
+        edge_groups = [
+            (str(src), str(dst), str(kind or ""), int(count))
+            for src, dst, kind, count in (await session.execute(edge_stmt)).all()
+        ]
+
+    projected_nodes, projected_edges = assemble_code_file_projection(
+        file_nodes, symbol_count_by_path, edge_groups
+    )
+    return _projection_result(
+        projected_nodes,
+        projected_edges,
+        GraphProjection.CODE_FILE,
+        (entity_level or "file").lower(),
+        excluded_kinds=sorted(exclude_kinds or set()),
+    )
+
+
+def _node_row_to_dict(row: Any) -> dict[str, Any]:
+    return {
+        "id": str(row.id),
+        "natural_key": row.natural_key,
+        "kind": row.kind,
+        "name": row.name,
+        "meta": row.meta or {},
+    }
+
+
+async def _load_graph_rows(
+    session: AsyncSession,
+    scenario_id: UUID,
+    layer: TwinLayer | None,
+    *,
+    include_kinds: set[str] | None = None,
+    exclude_kinds: set[str] | None = None,
+    include_edge_kinds: set[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Load raw nodes and edges as dicts, filtering kinds in the database.
+
+    Edges are restricted to the surviving nodes through the same kind filters on
+    both endpoints rather than an ``IN (...)`` list, which would exceed
+    PostgreSQL's parameter limit on large scenarios.
+    """
+    node_stmt = (
+        select(TwinNode.id, TwinNode.natural_key, TwinNode.kind, TwinNode.name, TwinNode.meta)
+        .where(TwinNode.scenario_id == scenario_id)
+        .where(*_node_kind_filters(TwinNode, include_kinds, exclude_kinds))
+    )
+    node_stmt = _with_layer(node_stmt, TwinNode, layer)
+    nodes = [_node_row_to_dict(row) for row in (await session.execute(node_stmt)).all()]
+    if not nodes:
+        return [], []
+
+    if layer is None and not include_kinds and not exclude_kinds:
+        # Scenario edges already reference nodes within the same scenario.
+        edge_stmt: Select = select(
+            TwinEdge.id,
+            TwinEdge.source_node_id,
+            TwinEdge.target_node_id,
+            TwinEdge.kind,
+            TwinEdge.meta,
+        ).where(TwinEdge.scenario_id == scenario_id)
+    else:
+        edge_stmt, source, target = _edge_with_endpoints(
+            scenario_id,
+            layer,
+            TwinEdge.id,
+            TwinEdge.source_node_id,
+            TwinEdge.target_node_id,
+            TwinEdge.kind,
+            TwinEdge.meta,
+        )
+        edge_stmt = edge_stmt.where(
+            *_node_kind_filters(source, include_kinds, exclude_kinds),
+            *_node_kind_filters(target, include_kinds, exclude_kinds),
+        )
+    if include_edge_kinds:
+        edge_stmt = edge_stmt.where(func.lower(TwinEdge.kind).in_(sorted(include_edge_kinds)))
+
+    edges = [
+        {
+            "id": str(row.id),
+            "source_node_id": str(row.source_node_id),
+            "target_node_id": str(row.target_node_id),
+            "kind": row.kind,
+            "meta": row.meta or {},
+        }
+        for row in (await session.execute(edge_stmt)).all()
+    ]
+    return nodes, edges
+
+
+def _projection_result(
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    projection: GraphProjection,
+    entity_level: str,
+    *,
+    excluded_kinds: list[str],
+) -> dict[str, Any]:
+    """Wrap projected nodes/edges in the graph response dict."""
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "total_nodes": len(nodes),
+        "projection": projection.value,
+        "entity_level": entity_level,
+        "grouping_strategy": "heuristic",
+        "excluded_kinds": excluded_kinds,
+        "warnings": [],
+        "provenance": {
+            "source": "scenario_graph",
+            "projection": projection.value,
+        },
+    }
 
 
 def _apply_graph_projection(
@@ -1179,10 +1507,7 @@ def _apply_graph_projection(
     exclude_kinds_norm: set[str] | None,
     include_edge_kinds_norm: set[str] | None,
 ) -> dict[str, Any]:
-    """Apply the selected projection and return a graph response dict."""
-    grouping_strategy = "heuristic"
-    effective_excluded_kinds = sorted(exclude_kinds_norm or set())
-
+    """Apply the selected projection to an in-memory graph."""
     if projection == GraphProjection.ARCHITECTURE:
         return _project_architecture(
             nodes,
@@ -1192,36 +1517,38 @@ def _apply_graph_projection(
             exclude_kinds_norm,
         )
     if projection == GraphProjection.CODE_FILE:
-        effective_entity_level = (entity_level or "file").lower()
         projected_nodes, projected_edges = build_code_file_projection(
             nodes=nodes,
             edges=edges,
             include_edge_kinds=include_edge_kinds_norm,
         )
-    else:
-        effective_entity_level = (entity_level or "symbol").lower()
-        projected_nodes, projected_edges = build_code_symbol_projection(
-            nodes=nodes,
-            edges=edges,
-            include_kinds=include_kinds_norm,
-            exclude_kinds=exclude_kinds_norm,
-            include_edge_kinds=include_edge_kinds_norm,
+        return _projection_result(
+            projected_nodes,
+            projected_edges,
+            projection,
+            (entity_level or "file").lower(),
+            excluded_kinds=sorted(exclude_kinds_norm or set()),
         )
 
-    return {
-        "nodes": projected_nodes,
-        "edges": projected_edges,
-        "total_nodes": len(projected_nodes),
-        "projection": projection.value,
-        "entity_level": effective_entity_level,
-        "grouping_strategy": grouping_strategy,
-        "excluded_kinds": effective_excluded_kinds,
-        "warnings": [],
-        "provenance": {
-            "source": "scenario_graph",
-            "projection": projection.value,
-        },
-    }
+    projected_nodes, projected_edges = build_code_symbol_projection(
+        nodes=nodes,
+        edges=edges,
+        include_kinds=include_kinds_norm,
+        exclude_kinds=exclude_kinds_norm,
+        include_edge_kinds=include_edge_kinds_norm,
+    )
+    return _projection_result(
+        projected_nodes,
+        projected_edges,
+        projection,
+        (entity_level or "symbol").lower(),
+        excluded_kinds=sorted(exclude_kinds_norm or set()),
+    )
+
+
+_ARCHITECTURE_DEFAULT_HIDDEN_KINDS = frozenset(
+    {"class", "method", "function", "property", "parameter", "variable", "constant"}
+)
 
 
 def _project_architecture(
@@ -1231,18 +1558,9 @@ def _project_architecture(
     include_kinds_norm: set[str] | None,
     exclude_kinds_norm: set[str] | None,
 ) -> dict[str, Any]:
-    """Apply architecture projection with default hidden kinds."""
-    effective_entity_level = (entity_level or "container").lower()
-    default_hidden = {
-        "class",
-        "method",
-        "function",
-        "property",
-        "parameter",
-        "variable",
-        "constant",
-    }
-    effective_excluded = set(exclude_kinds_norm or set()) | default_hidden
+    """Apply architecture projection to an in-memory graph with default hidden kinds."""
+    effective_entity_level = normalize_architecture_level(entity_level)
+    effective_excluded = set(exclude_kinds_norm or set()) | _ARCHITECTURE_DEFAULT_HIDDEN_KINDS
     projected_nodes, projected_edges, grouping_strategy = build_architecture_projection(
         nodes=nodes,
         edges=edges,
@@ -1250,6 +1568,23 @@ def _project_architecture(
         include_kinds=include_kinds_norm,
         exclude_kinds=effective_excluded,
     )
+    return _architecture_result(
+        projected_nodes,
+        projected_edges,
+        grouping_strategy,
+        effective_entity_level,
+        effective_excluded,
+    )
+
+
+def _architecture_result(
+    projected_nodes: list[dict[str, Any]],
+    projected_edges: list[dict[str, Any]],
+    grouping_strategy: str,
+    entity_level: str,
+    excluded_kinds: set[str],
+) -> dict[str, Any]:
+    """Wrap an architecture projection in the graph response dict."""
     explicit_assignment_count = sum(
         int((node.get("meta") or {}).get("explicit_member_count") or 0) for node in projected_nodes
     )
@@ -1270,9 +1605,9 @@ def _project_architecture(
         "edges": projected_edges,
         "total_nodes": len(projected_nodes),
         "projection": GraphProjection.ARCHITECTURE.value,
-        "entity_level": effective_entity_level,
+        "entity_level": entity_level,
         "grouping_strategy": grouping_strategy,
-        "excluded_kinds": sorted(effective_excluded),
+        "excluded_kinds": sorted(excluded_kinds),
         "warnings": warnings,
         "provenance": {
             "source": "scenario_graph",

--- a/packages/core/tests/test_twin_graph_sql_projection.py
+++ b/packages/core/tests/test_twin_graph_sql_projection.py
@@ -1,0 +1,383 @@
+"""Database-side graph projections must match the in-memory builders exactly.
+
+``get_full_scenario_graph`` groups the architecture and file projections in SQL
+and pushes kind filters down for the symbol projection. These tests seed a
+scenario through the ORM, run every projection through the SQL path and
+compare it with ``_apply_graph_projection`` over the naively loaded rows, which
+is the reference the cockpit views were built against.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from contextmine_core.database import Base
+from contextmine_core.models import (
+    Collection,
+    CollectionVisibility,
+    TwinEdge,
+    TwinLayer,
+    TwinNode,
+    TwinNodeLayer,
+    TwinScenario,
+    User,
+)
+from contextmine_core.twin.projections import GraphProjection
+from contextmine_core.twin.service import (
+    _apply_graph_projection,
+    _load_graph_rows,
+    get_full_scenario_graph,
+)
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+async def test_session() -> AsyncGenerator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with async_session_maker() as session:
+        yield session
+
+    await engine.dispose()
+
+
+_FILES = [
+    # (path, explicit architecture meta, layers)
+    ("services/billing/api/invoice.py", None, [TwinLayer.CODE_CONTROLFLOW]),
+    ("services/billing/api/tax.py", None, [TwinLayer.CODE_CONTROLFLOW]),
+    (
+        "services/payments/core/charge.py",
+        {"domain": "payments", "container": "core", "component": "charging"},
+        [TwinLayer.CODE_CONTROLFLOW, TwinLayer.PORTFOLIO_SYSTEM],
+    ),
+    ("apps/web/src/App.tsx", None, [TwinLayer.CODE_CONTROLFLOW]),
+    ("README.md", None, []),  # too shallow for a heuristic group
+    ("  ", None, []),  # blank path: never projected
+]
+
+
+async def _seed_graph(session: AsyncSession) -> uuid.UUID:
+    """A small scenario exercising every branch the SQL path has to mirror."""
+    user = User(id=uuid.uuid4(), github_user_id=1, github_login="architect")
+    collection = Collection(
+        id=uuid.uuid4(),
+        slug="sql-projection",
+        name="SQL projection",
+        visibility=CollectionVisibility.PRIVATE,
+        owner_user_id=user.id,
+    )
+    scenario = TwinScenario(
+        id=uuid.uuid4(),
+        collection_id=collection.id,
+        name="AS-IS",
+        is_as_is=True,
+        version=1,
+        meta={},
+    )
+    session.add_all([user, collection, scenario])
+    await session.flush()
+
+    nodes: list[TwinNode] = []
+    layers: list[TwinNodeLayer] = []
+    file_by_path: dict[str, TwinNode] = {}
+    symbols_by_path: dict[str, list[TwinNode]] = {}
+
+    def add(node: TwinNode, node_layers: list[TwinLayer]) -> TwinNode:
+        nodes.append(node)
+        layers.extend(TwinNodeLayer(node_id=node.id, layer=layer) for layer in node_layers)
+        return node
+
+    for index, (path, architecture, file_layers) in enumerate(_FILES):
+        meta: dict[str, Any] = {"file_path": path, "loc": 10 * (index + 1)}
+        if architecture:
+            meta["architecture"] = architecture
+        file_by_path[path] = add(
+            TwinNode(
+                id=uuid.uuid4(),
+                scenario_id=scenario.id,
+                natural_key=f"file:{path}",
+                kind="File" if index % 2 else "file",  # kinds compare case-insensitively
+                name=path.rsplit("/", 1)[-1],
+                meta=meta,
+            ),
+            file_layers,
+        )
+        symbols_by_path[path] = []
+        for symbol_index in range(3 if index < 3 else 1):
+            symbol_meta: dict[str, Any] = {"file_path": path, "symbol_kind": "function"}
+            if architecture:
+                symbol_meta["architecture"] = architecture
+            symbols_by_path[path].append(
+                add(
+                    TwinNode(
+                        id=uuid.uuid4(),
+                        scenario_id=scenario.id,
+                        natural_key=f"symbol:{path}:{symbol_index}",
+                        kind="symbol" if symbol_index else "class",
+                        name=f"sym_{index}_{symbol_index}",
+                        meta=symbol_meta,
+                    ),
+                    file_layers,
+                )
+            )
+
+    # A node whose meta.file_path is missing and a job pointing at a file.
+    detached = add(
+        TwinNode(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            natural_key="symbol:detached",
+            kind="symbol",
+            name="detached",
+            meta={},
+        ),
+        [TwinLayer.CODE_CONTROLFLOW],
+    )
+    job = add(
+        TwinNode(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            natural_key="job:nightly",
+            kind="job",
+            name="nightly",
+            meta={"file_path": "services/billing/api/invoice.py"},
+        ),
+        [TwinLayer.PORTFOLIO_SYSTEM],
+    )
+    session.add_all(nodes)
+    await session.flush()
+    session.add_all(layers)
+
+    billing = symbols_by_path["services/billing/api/invoice.py"]
+    tax = symbols_by_path["services/billing/api/tax.py"]
+    payments = symbols_by_path["services/payments/core/charge.py"]
+    web = symbols_by_path["apps/web/src/App.tsx"]
+    readme = symbols_by_path["README.md"]
+
+    edges = [
+        # file_defines_symbol is ignored by the file projection but folds away
+        # in the architecture projection (same group on both ends).
+        *(
+            TwinEdge(
+                id=uuid.uuid4(),
+                scenario_id=scenario.id,
+                source_node_id=file_by_path[path].id,
+                target_node_id=symbol.id,
+                kind="file_defines_symbol",
+                meta={},
+            )
+            for path, symbols in symbols_by_path.items()
+            for symbol in symbols
+        ),
+        # Cross-container calls, several per pair so counts matter.
+        *(
+            TwinEdge(
+                id=uuid.uuid4(),
+                scenario_id=scenario.id,
+                source_node_id=src.id,
+                target_node_id=dst.id,
+                kind="symbol_calls_symbol",
+                meta={"weight": 2},
+            )
+            for src in billing
+            for dst in payments
+        ),
+        TwinEdge(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            source_node_id=billing[1].id,
+            target_node_id=payments[1].id,
+            kind="symbol_references_symbol",
+            meta={},
+        ),
+        # Same container, different files: file edge yes, arch edge no.
+        TwinEdge(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            source_node_id=tax[0].id,
+            target_node_id=billing[1].id,
+            kind="symbol_imports_symbol",
+            meta={},
+        ),
+        # Same file: dropped by both projections.
+        TwinEdge(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            source_node_id=billing[0].id,
+            target_node_id=billing[2].id,
+            kind="symbol_contains_symbol",
+            meta={},
+        ),
+        # Upper-case kind: edge kind filters compare lower-cased.
+        TwinEdge(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            source_node_id=web[0].id,
+            target_node_id=payments[1].id,
+            kind="Symbol_Calls_Symbol",
+            meta={},
+        ),
+        # Endpoint without a path and endpoint outside any group.
+        TwinEdge(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            source_node_id=detached.id,
+            target_node_id=payments[0].id,
+            kind="symbol_calls_symbol",
+            meta={},
+        ),
+        TwinEdge(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            source_node_id=readme[0].id,
+            target_node_id=billing[0].id,
+            kind="symbol_references_symbol",
+            meta={},
+        ),
+        # Job → file edge crosses containers through meta.file_path.
+        TwinEdge(
+            id=uuid.uuid4(),
+            scenario_id=scenario.id,
+            source_node_id=job.id,
+            target_node_id=file_by_path["services/payments/core/charge.py"].id,
+            kind="job_touches_file",
+            meta={},
+        ),
+    ]
+    session.add_all(edges)
+    await session.commit()
+    return scenario.id
+
+
+def _canonical(graph: dict[str, Any]) -> dict[str, Any]:
+    """Order-insensitive view of a projection result."""
+    return {
+        **{key: value for key, value in graph.items() if key not in {"nodes", "edges"}},
+        "nodes": sorted(graph["nodes"], key=lambda node: node["id"]),
+        "edges": sorted(
+            graph["edges"],
+            key=lambda edge: (edge["source_node_id"], edge["target_node_id"], edge["id"]),
+        ),
+    }
+
+
+def _norm(kinds: set[str] | None) -> set[str] | None:
+    return {kind.lower() for kind in kinds} if kinds else None
+
+
+_CASES: list[dict[str, Any]] = [
+    {"projection": GraphProjection.ARCHITECTURE, "entity_level": "container"},
+    {"projection": GraphProjection.ARCHITECTURE, "entity_level": "domain"},
+    {"projection": GraphProjection.ARCHITECTURE, "entity_level": "component"},
+    {"projection": GraphProjection.ARCHITECTURE, "entity_level": "bogus"},
+    {"projection": GraphProjection.ARCHITECTURE, "include_kinds": {"FILE", "job"}},
+    {"projection": GraphProjection.ARCHITECTURE, "exclude_kinds": {"symbol"}},
+    {"projection": GraphProjection.ARCHITECTURE, "layer": TwinLayer.CODE_CONTROLFLOW},
+    {"projection": GraphProjection.ARCHITECTURE, "layer": TwinLayer.PORTFOLIO_SYSTEM},
+    {"projection": GraphProjection.CODE_FILE},
+    {"projection": GraphProjection.CODE_FILE, "exclude_kinds": {"class"}},
+    {"projection": GraphProjection.CODE_FILE, "include_edge_kinds": {"symbol_calls_symbol"}},
+    {"projection": GraphProjection.CODE_FILE, "layer": TwinLayer.CODE_CONTROLFLOW},
+    {"projection": GraphProjection.CODE_FILE, "layer": TwinLayer.PORTFOLIO_SYSTEM},
+    {"projection": GraphProjection.CODE_SYMBOL},
+    {"projection": GraphProjection.CODE_SYMBOL, "include_kinds": {"Symbol"}},
+    {"projection": GraphProjection.CODE_SYMBOL, "exclude_kinds": {"class", "job"}},
+    {"projection": GraphProjection.CODE_SYMBOL, "include_edge_kinds": {"symbol_calls_symbol"}},
+    {"projection": GraphProjection.CODE_SYMBOL, "layer": TwinLayer.CODE_CONTROLFLOW},
+    {
+        "projection": GraphProjection.CODE_SYMBOL,
+        "layer": TwinLayer.PORTFOLIO_SYSTEM,
+        "exclude_kinds": {"job"},
+        "include_edge_kinds": {"symbol_calls_symbol", "job_touches_file"},
+    },
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("case", _CASES, ids=lambda case: str(case))
+async def test_sql_projection_matches_in_memory_reference(
+    test_session: AsyncSession, case: dict[str, Any]
+) -> None:
+    scenario_id = await _seed_graph(test_session)
+    layer = case.get("layer")
+
+    nodes, edges = await _load_graph_rows(test_session, scenario_id, layer)
+    reference = _apply_graph_projection(
+        nodes,
+        edges,
+        case["projection"],
+        case.get("entity_level"),
+        _norm(case.get("include_kinds")),
+        _norm(case.get("exclude_kinds")),
+        _norm(case.get("include_edge_kinds")),
+    )
+
+    actual = await get_full_scenario_graph(
+        test_session,
+        scenario_id,
+        layer,
+        projection=case["projection"],
+        entity_level=case.get("entity_level"),
+        include_kinds=case.get("include_kinds"),
+        exclude_kinds=case.get("exclude_kinds"),
+        include_edge_kinds=case.get("include_edge_kinds"),
+    )
+
+    assert _canonical(actual) == _canonical(reference)
+    # Guard against a vacuous comparison: the seed must produce a real graph.
+    if not case.get("include_kinds") and not case.get("exclude_kinds"):
+        assert actual["nodes"]
+
+
+@pytest.mark.anyio
+async def test_seed_covers_the_interesting_branches(test_session: AsyncSession) -> None:
+    """The reference graph must contain folded edges, counts and mixed grouping."""
+    scenario_id = await _seed_graph(test_session)
+
+    architecture = await get_full_scenario_graph(
+        test_session, scenario_id, None, projection=GraphProjection.ARCHITECTURE
+    )
+    assert architecture["grouping_strategy"] == "mixed"
+    by_name = {node["name"]: node for node in architecture["nodes"]}
+    # 2 files + 4 symbols + 1 job; the two "class" nodes are hidden by default.
+    assert by_name["api"]["meta"]["member_count"] == 7
+    assert by_name["core"]["meta"]["provenance"] == "explicit"
+    weights = {
+        (edge["source_node_id"], edge["target_node_id"]): edge["meta"]
+        for edge in architecture["edges"]
+    }
+    api_to_core = weights[(by_name["api"]["id"], by_name["core"]["id"])]
+    # 2x2 calls between visible symbols + 1 reference + 1 job edge.
+    assert api_to_core["raw_edge_count"] == 6
+    assert api_to_core["sample_edge_kinds"] == [
+        "job_touches_file",
+        "symbol_calls_symbol",
+        "symbol_references_symbol",
+    ]
+
+    files = await get_full_scenario_graph(
+        test_session, scenario_id, None, projection=GraphProjection.CODE_FILE
+    )
+    counts = {node["name"]: node["meta"]["symbol_count"] for node in files["nodes"]}
+    assert counts["invoice.py"] == 4  # 3 symbols + the job that points at the file
+    assert counts["README.md"] == 1
+    assert "  " not in counts  # the blank path never becomes a file node
+    file_edges = {
+        (edge["source_node_id"], edge["target_node_id"]): edge["meta"]["weight"]
+        for edge in files["edges"]
+    }
+    ids = {node["name"]: node["id"] for node in files["nodes"]}
+    # 9 calls + 1 reference + the job edge, which resolves to invoice.py via meta.
+    assert file_edges[(ids["invoice.py"], ids["charge.py"])] == 11
+    assert file_edges[(ids["tax.py"], ids["invoice.py"])] == 1

--- a/packages/core/tests/test_twin_service.py
+++ b/packages/core/tests/test_twin_service.py
@@ -1108,6 +1108,43 @@ class TestGetScenarioGraph:
         assert result["dropped_cross_page_edges"] == 1
         assert result["warnings"]
 
+    def test_edge_aware_order_visits_components_in_sorted_order(self) -> None:
+        """Isolated nodes and separate components keep their natural-key order."""
+        from contextmine_core.twin.service import _edge_aware_node_order
+
+        nodes = [{"id": key, "natural_key": key} for key in ("a", "b", "c", "d", "e", "f")]
+        edges = [
+            {"source_node_id": "a", "target_node_id": "e"},
+            {"source_node_id": "c", "target_node_id": "f"},
+        ]
+
+        assert _edge_aware_node_order(nodes, edges) == ["a", "e", "b", "c", "f", "d"]
+
+    def test_edge_aware_order_scales_linearly_on_sparse_graphs(self) -> None:
+        """Anchor search must not rescan ordered nodes.
+
+        A 60k-node graph with mostly isolated nodes took ~40 s with the old
+        from-the-start anchor scan; linear behaviour finishes in well under a
+        second even on slow CI runners.
+        """
+        import time
+
+        from contextmine_core.twin.service import _edge_aware_node_order
+
+        count = 60_000
+        nodes = [{"id": f"n{index}", "natural_key": f"n{index:06d}"} for index in range(count)]
+        edges = [
+            {"source_node_id": f"n{index}", "target_node_id": f"n{index + 1}"}
+            for index in range(0, count - 1, 10)
+        ]
+
+        started = time.perf_counter()
+        ordered = _edge_aware_node_order(nodes, edges)
+        elapsed = time.perf_counter() - started
+
+        assert len(ordered) == count
+        assert elapsed < 5.0, f"edge-aware ordering took {elapsed:.1f}s for {count} nodes"
+
     def test_edge_aware_paging_preserves_bfs_frontier_across_pages(self) -> None:
         from contextmine_core.twin.service import paginate_graph_edge_aware
 

--- a/packages/core/tests/test_twin_service.py
+++ b/packages/core/tests/test_twin_service.py
@@ -319,6 +319,13 @@ def _scalars_all(values: list[Any]) -> MagicMock:
     return result
 
 
+def _rows_all(values: list[Any]) -> MagicMock:
+    """Result of a column-tuple select: ``.all()`` returns the rows directly."""
+    result = MagicMock()
+    result.all.return_value = values
+    return result
+
+
 # ── get_or_create_as_is_scenario ─────────────────────────────────────────
 
 
@@ -1028,8 +1035,8 @@ class TestGetScenarioGraph:
         node.meta = {}
 
         session.execute.side_effect = [
-            _scalars_all([node]),  # raw_nodes
-            _scalars_all([]),  # raw_edges
+            _rows_all([node]),  # node rows
+            _rows_all([]),  # edge rows
         ]
 
         result = await get_scenario_graph(session, scenario_id, layer=None, page=0, limit=50)
@@ -1046,16 +1053,15 @@ class TestGetScenarioGraph:
 
         session = _make_mock_session()
 
-        session.execute.side_effect = [
-            _scalars_all([]),
-            _scalars_all([]),
-        ]
+        session.execute.side_effect = [_rows_all([])]
 
         result = await get_scenario_graph(session, uuid4(), layer=None, page=0, limit=50)
 
         assert result["total_nodes"] == 0
         assert result["nodes"] == []
         assert result["edges"] == []
+        # Without nodes there is nothing to join edges to, so no edge query runs.
+        assert session.execute.await_count == 1
 
     @pytest.mark.anyio
     async def test_exposes_slice_metadata_and_hidden_cross_page_edges(self) -> None:
@@ -1079,17 +1085,12 @@ class TestGetScenarioGraph:
             name="b.py",
             meta={},
         )
-        edge = SimpleNamespace(
-            id=uuid4(),
-            source_node_id=node_a.id,
-            target_node_id=node_b.id,
-            kind="symbol_references_symbol",
-            meta={},
-        )
-
+        # The file projection is grouped in SQL: file rows, symbol counts per
+        # path, then edges folded to (source path, target path, kind, count).
         session.execute.side_effect = [
-            _scalars_all([node_a, node_b]),
-            _scalars_all([edge]),
+            _rows_all([node_a, node_b]),
+            _rows_all([]),
+            _rows_all([("a.py", "b.py", "symbol_references_symbol", 1)]),
         ]
 
         result = await get_scenario_graph(
@@ -1157,8 +1158,8 @@ class TestGetFullScenarioGraph:
             meta={},
         )
         session.execute.side_effect = [
-            _scalars_all([node]),
-            _scalars_all([edge]),
+            _rows_all([node]),
+            _rows_all([edge]),
         ]
 
         with patch(
@@ -1190,8 +1191,8 @@ class TestGetFullScenarioGraph:
             for idx in range(34000)
         ]
         session.execute.side_effect = [
-            _scalars_all(raw_nodes),
-            _scalars_all([]),
+            _rows_all(raw_nodes),
+            _rows_all([]),
         ]
 
         with patch(
@@ -1211,3 +1212,197 @@ class TestGetFullScenarioGraph:
         assert "source_node_id IN" not in edge_sql
         assert "target_node_id IN" not in edge_sql
         assert "JOIN twin_node_layers" in edge_sql
+
+    @pytest.mark.anyio
+    async def test_symbol_projection_pushes_kind_filters_into_sql(self) -> None:
+        from contextmine_core.twin.projections import GraphProjection
+        from contextmine_core.twin.service import get_full_scenario_graph
+
+        session = _make_mock_session()
+        session.execute.side_effect = [_rows_all([]), _rows_all([])]
+
+        await get_full_scenario_graph(
+            session,
+            uuid4(),
+            layer=None,
+            projection=GraphProjection.CODE_SYMBOL,
+            include_kinds={"Symbol"},
+            include_edge_kinds={"symbol_calls_symbol"},
+        )
+
+        node_sql = str(session.execute.await_args_list[0].args[0])
+        assert "lower(twin_nodes.kind) IN" in node_sql
+        # The symbol builder always hides file nodes; that predicate moves to SQL too.
+        assert "lower(twin_nodes.kind) NOT IN" in node_sql
+        # No node survived, so the edge query is skipped entirely.
+        assert session.execute.await_count == 1
+
+    @pytest.mark.anyio
+    async def test_symbol_projection_filters_edges_by_kind_in_sql(self) -> None:
+        from contextmine_core.twin.projections import GraphProjection
+        from contextmine_core.twin.service import get_full_scenario_graph
+
+        session = _make_mock_session()
+        node = SimpleNamespace(id=uuid4(), natural_key="symbol:a", kind="symbol", name="a", meta={})
+        session.execute.side_effect = [_rows_all([node]), _rows_all([])]
+
+        result = await get_full_scenario_graph(
+            session,
+            uuid4(),
+            layer=None,
+            projection=GraphProjection.CODE_SYMBOL,
+            include_edge_kinds={"symbol_contains_symbol"},
+        )
+
+        assert [n["natural_key"] for n in result["nodes"]] == ["symbol:a"]
+        edge_sql = str(session.execute.await_args_list[1].args[0])
+        assert "lower(twin_edges.kind) IN" in edge_sql
+        assert "twin_edges.meta" in edge_sql
+
+    @pytest.mark.anyio
+    async def test_architecture_projection_groups_in_sql_and_keeps_counts(self) -> None:
+        """Grouped rows carry counts; the projection must weight them, not count rows."""
+        from contextmine_core.twin.projections import GraphProjection
+        from contextmine_core.twin.service import get_full_scenario_graph
+
+        session = _make_mock_session()
+        billing = "services/billing/api/invoice.py"
+        payments = "services/payments/core/charge.py"
+        session.execute.side_effect = [
+            # (path, explicit domain, container, component, member count)
+            _rows_all(
+                [
+                    (billing, None, None, None, 3),
+                    (payments, "payments", "core", None, 2),
+                    (None, None, None, None, 7),  # nodes without a path are dropped
+                ]
+            ),
+            # (source path + arch, target path + arch, edge kind, raw edge count)
+            _rows_all(
+                [
+                    (billing, None, None, None, payments, "payments", "core", None, "calls", 4),
+                    (billing, None, None, None, billing, None, None, None, "contains", 9),
+                ]
+            ),
+        ]
+
+        result = await get_full_scenario_graph(
+            session,
+            uuid4(),
+            layer=None,
+            projection=GraphProjection.ARCHITECTURE,
+            entity_level="container",
+            exclude_kinds={"Test"},
+        )
+
+        node_sql = str(session.execute.await_args_list[0].args[0])
+        assert "GROUP BY" in node_sql
+        assert "count(*)" in node_sql
+        assert "lower(twin_nodes.kind) NOT IN" in node_sql
+        edge_sql = str(session.execute.await_args_list[1].args[0])
+        assert "GROUP BY" in edge_sql
+        assert "JOIN twin_nodes AS twin_nodes_1" in edge_sql
+
+        by_name = {node["name"]: node for node in result["nodes"]}
+        assert by_name["api"]["meta"]["member_count"] == 3
+        assert by_name["api"]["meta"]["provenance"] == "heuristic"
+        assert by_name["core"]["meta"]["member_count"] == 2
+        assert by_name["core"]["meta"]["provenance"] == "explicit"
+        assert result["grouping_strategy"] == "mixed"
+        assert "test" in result["excluded_kinds"]
+        assert "class" in result["excluded_kinds"]
+
+        assert len(result["edges"]) == 1  # the intra-group "contains" edges fold away
+        edge = result["edges"][0]
+        assert edge["source_node_id"] == by_name["api"]["id"]
+        assert edge["target_node_id"] == by_name["core"]["id"]
+        assert edge["meta"] == {
+            "weight": 4,
+            "sample_edge_kinds": ["calls"],
+            "raw_edge_count": 4,
+        }
+
+    @pytest.mark.anyio
+    async def test_architecture_projection_skips_edge_query_without_members(self) -> None:
+        from contextmine_core.twin.projections import GraphProjection
+        from contextmine_core.twin.service import get_full_scenario_graph
+
+        session = _make_mock_session()
+        session.execute.side_effect = [_rows_all([])]
+
+        result = await get_full_scenario_graph(
+            session, uuid4(), layer=None, projection=GraphProjection.ARCHITECTURE
+        )
+
+        assert result["nodes"] == []
+        assert result["edges"] == []
+        assert session.execute.await_count == 1
+
+    @pytest.mark.anyio
+    async def test_code_file_projection_counts_symbols_and_folds_edges_in_sql(self) -> None:
+        from contextmine_core.twin.projections import GraphProjection
+        from contextmine_core.twin.service import get_full_scenario_graph
+
+        session = _make_mock_session()
+        file_a = SimpleNamespace(
+            id=uuid4(), natural_key="file:a.py", kind="file", name="a.py", meta={"loc": 10}
+        )
+        file_b = SimpleNamespace(
+            id=uuid4(), natural_key="file:b.py", kind="file", name="b.py", meta={}
+        )
+        session.execute.side_effect = [
+            _rows_all([file_a, file_b]),
+            _rows_all([("a.py", 5), ("orphan.py", 2)]),
+            _rows_all(
+                [
+                    ("a.py", "b.py", "symbol_calls_symbol", 3),
+                    ("a.py", "b.py", "symbol_references_symbol", 1),
+                    ("a.py", "orphan.py", "symbol_calls_symbol", 8),  # no file node
+                ]
+            ),
+        ]
+
+        result = await get_full_scenario_graph(
+            session,
+            uuid4(),
+            layer=None,
+            projection=GraphProjection.CODE_FILE,
+            include_edge_kinds={"symbol_calls_symbol", "symbol_references_symbol"},
+        )
+
+        file_sql = str(session.execute.await_args_list[0].args[0])
+        assert "lower(twin_nodes.kind) = " in file_sql
+        count_sql = str(session.execute.await_args_list[1].args[0])
+        assert "GROUP BY" in count_sql
+        edge_sql = str(session.execute.await_args_list[2].args[0])
+        assert "twin_edges.kind !=" in edge_sql
+        assert "lower(twin_edges.kind) IN" in edge_sql
+        assert "GROUP BY" in edge_sql
+
+        by_name = {node["name"]: node for node in result["nodes"]}
+        assert by_name["a.py"]["meta"] == {"loc": 10, "symbol_count": 5}
+        assert by_name["b.py"]["meta"] == {"symbol_count": 0}
+        assert len(result["edges"]) == 1
+        assert result["edges"][0]["source_node_id"] == str(file_a.id)
+        assert result["edges"][0]["target_node_id"] == str(file_b.id)
+        assert result["edges"][0]["meta"] == {
+            "weight": 4,
+            "sample_edge_kinds": ["symbol_calls_symbol", "symbol_references_symbol"],
+            "raw_edge_count": 4,
+        }
+
+    @pytest.mark.anyio
+    async def test_code_file_projection_skips_aggregates_without_files(self) -> None:
+        from contextmine_core.twin.projections import GraphProjection
+        from contextmine_core.twin.service import get_full_scenario_graph
+
+        session = _make_mock_session()
+        session.execute.side_effect = [_rows_all([])]
+
+        result = await get_full_scenario_graph(
+            session, uuid4(), layer=None, projection=GraphProjection.CODE_FILE
+        )
+
+        assert result["nodes"] == []
+        assert result["edges"] == []
+        assert session.execute.await_count == 1


### PR DESCRIPTION
## Problem

`get_full_scenario_graph` loaded every `TwinNode` and `TwinEdge` of a scenario as ORM instances and projected them in Python. Every cockpit graph view (Topology, Deep Dive, Overview/City via the CodeCharta export) goes through it. On Apache Superset (224k nodes, 519k edges) that was 22 s of a 25 s request locally and well over 20 s inside the Docker stack, for a Topology view that ends up with 487 nodes.

## Change

The architecture and file projections only need per-path counts, so they now group in SQL:

- **architecture**: nodes and edges grouped by `(path, explicit architecture meta, kind)` with counts. The heuristic domain/container derivation runs once per distinct path (13k for Superset) instead of once per node (224k).
- **code_file**: file rows, a symbol count per path, and edges folded to `(source path, target path, kind, count)`. `file_defines_symbol` and same-file edges are excluded in the query.
- **code_symbol**: kind and edge-kind filters are pushed into SQL; rows are loaded as column tuples instead of ORM instances.

The projection builders in `projections.py` were split into a grouping step and an assembly step that takes counted groups (`assemble_architecture_projection`, `assemble_code_file_projection`), so the in-memory path and the SQL path share one output implementation. `_apply_graph_projection` still exists for in-memory graphs.

The path expression mirrors `canonical_file_path_from_node` (natural key for `file:` nodes, `meta.file_path` otherwise) using SQLAlchemy JSON path access, so it runs on PostgreSQL and on the SQLite test engine.

## Second finding: quadratic BFS anchor search in the paging step

While timing the Docker stack, the Deep Dive `contains_hierarchy` mode kept the API at 100 % CPU for minutes *after* the rows had loaded. `_edge_aware_node_order` searched for the next unvisited BFS anchor from the start of the node list every time the queue ran dry, which is quadratic on sparse graphs with many components: 40k mostly isolated nodes took 16 s, 211k symbols took minutes. The second commit keeps a monotone anchor index; 211k nodes now order in 0.4 s with an unchanged visiting order (pinned by a new test).

## Verification

- New `test_twin_graph_sql_projection.py` seeds a scenario on SQLite (mixed explicit/heuristic groups, upper-case kinds, blank paths, layers, jobs pointing at files, same-file and same-container edges) and asserts that **19 projection/filter/layer combinations** produce output identical to the in-memory reference.
- The same comparison against the real Superset and FastAPI scenarios on PostgreSQL was identical in all 22 cases (script in the session, not committed).
- Mocked service tests assert the SQL shape (GROUP BY, kind pushdown, no `IN (...)` node lists, layer joins) and that counts are weighted, not counted.
- `ruff check`, `ruff format --check`, `ty check`, full `pytest` suite (4724 passed; the one failure, `test_init_without_api_key_raises_error`, comes from real keys in the local `.env` and is unrelated).

## Timings (local, Superset, PostgreSQL; reference = row load + in-memory build)

| projection | before | after |
|---|---|---|
| architecture/container (Topology) | 13.2 s | 1.7 s |
| architecture/domain | 18.2 s | 1.5 s |
| code_file (Deep Dive default) | 16.3 s | 1.3 s |
| code_symbol, contains edges only | 17.5 s | 4.2 s |
| code_symbol, all edges | 17.7 s | 10.3 s |

End-to-end HTTP timings from the Docker stack follow in a comment.

The symbol projections still load all symbol rows (211k) because the edge-aware paging orders the whole graph; that is the next step if the symbol modes stay in use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F34wGYmJ2GQAtR9Q7eD28S

