### PR TITLE
fix(prefect): diagnose missing deployments and unhealthy connections

### DIFF
--- a/apps/api/app/routes/prefect.py
+++ b/apps/api/app/routes/prefect.py
@@ -62,17 +62,27 @@ class FlowRunsResponse(BaseModel):
 
 async def start_source_sync(source_id: str, source_url: str, sync_run_id: str) -> str:
     """Start the configured single-source deployment idempotently."""
-    flow_run = await run_deployment(
-        get_settings().prefect_sync_deployment,
-        parameters={
-            "source_id": source_id,
-            "source_url": source_url,
-            "sync_run_id": sync_run_id,
-        },
-        timeout=0,
-        as_subflow=False,
-        idempotency_key=sync_run_id,
-    )
+    deployment = get_settings().prefect_sync_deployment
+    try:
+        flow_run = await run_deployment(
+            deployment,
+            parameters={
+                "source_id": source_id,
+                "source_url": source_url,
+                "sync_run_id": sync_run_id,
+            },
+            timeout=0,
+            as_subflow=False,
+            idempotency_key=sync_run_id,
+        )
+    except Exception as exc:
+        logger.exception("Prefect scheduling failed for deployment %s", deployment)
+        if isinstance(exc, ObjectNotFound):
+            raise RuntimeError(
+                f"Prefect deployment '{deployment}' not found. "
+                "Check PREFECT_API_URL and that the worker registered its deployments."
+            ) from exc
+        raise
     return str(flow_run.id)
 
 
@@ -212,7 +222,9 @@ async def prefect_health() -> dict[str, str]:
     """Check Prefect server connectivity through the supported client."""
     try:
         async with get_client() as client:
-            await client.api_healthcheck()
+            error = await client.api_healthcheck()
+            if error is not None:
+                raise error
         return {"prefect": "ok"}
     except Exception as e:
-        return {"prefect": "error", "detail": str(e)}
+        return {"prefect": "error", "detail": str(e) or type(e).__name__}

--- a/apps/api/tests/test_routes_misc.py
+++ b/apps/api/tests/test_routes_misc.py
@@ -4,17 +4,23 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from app.routes.db import db_health_check, get_stats
 from app.routes.prefect import (
     _get_flow_run_progress,
     get_flow_runs,
     prefect_health,
+    start_source_sync,
 )
+from prefect.client.orchestration import PrefectClient
 from prefect.client.schemas.objects import StateType
+from prefect.deployments import arun_deployment
+from prefect.exceptions import ObjectNotFound
 
 pytestmark = pytest.mark.anyio
 
@@ -105,6 +111,7 @@ class TestPrefectHealth:
     @pytest.mark.anyio
     async def test_healthy(self) -> None:
         mock_client = AsyncMock()
+        mock_client.api_healthcheck.return_value = None
         client_context = MagicMock()
         client_context.__aenter__ = AsyncMock(return_value=mock_client)
         client_context.__aexit__ = AsyncMock(return_value=False)
@@ -120,6 +127,42 @@ class TestPrefectHealth:
         with patch("app.routes.prefect.get_client", return_value=client_context):
             result = await prefect_health()
         assert result["prefect"] == "error"
+
+    @pytest.mark.parametrize("error", [ConnectionError("refused"), TimeoutError()])
+    async def test_returned_error_is_unhealthy(self, error: Exception) -> None:
+        mock_client = AsyncMock()
+        mock_client.api_healthcheck.return_value = error
+        mock_client.__aenter__.return_value = mock_client
+        with patch("app.routes.prefect.get_client", return_value=mock_client):
+            result = await prefect_health()
+        assert result == {"prefect": "error", "detail": str(error) or type(error).__name__}
+
+
+async def test_missing_deployment_reports_name_and_logs_http_cause(caplog) -> None:
+    def missing(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/deployments/name/sync_single_source/default"
+        return httpx.Response(404, json={"detail": "Deployment not found"})
+
+    async with PrefectClient(
+        "http://prefect.test/api",
+        httpx_settings={"transport": httpx.MockTransport(missing)},
+    ) as client:
+        with (
+            patch("app.routes.prefect.run_deployment", partial(arun_deployment, client=client)),
+            patch(
+                "app.routes.prefect.get_settings",
+                return_value=SimpleNamespace(prefect_sync_deployment="sync_single_source/default"),
+            ),
+            pytest.raises(
+                RuntimeError, match="deployment 'sync_single_source/default' not found"
+            ) as raised,
+        ):
+            await start_source_sync("source-id", "https://example.test/repo", "sync-run-id")
+
+    assert "PREFECT_API_URL" in str(raised.value)
+    assert isinstance(raised.value.__cause__, ObjectNotFound)
+    assert raised.value.__cause__.http_exc.response.status_code == 404
+    assert any(record.exc_info for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/worker/contextmine_worker/flows.py
+++ b/apps/worker/contextmine_worker/flows.py
@@ -38,6 +38,7 @@ from git.exc import GitCommandError
 from prefect import flow, task
 from prefect.artifacts import create_progress_artifact, update_progress_artifact
 from prefect.cache_policies import INPUTS
+from prefect.exceptions import ObjectNotFound
 from prefect.tasks import exponential_backoff
 from sqlalchemy import delete, select, text
 
@@ -5136,8 +5137,15 @@ async def sync_due_sources() -> dict:
                 }
             )
         except Exception as e:
-            await _mark_scheduled_sync_failed(claim["sync_run_id"], str(e))
-            results.append({**claim, "error": str(e)})
+            logger.exception("Prefect scheduling failed for deployment %s", deployment)
+            error = str(e) or type(e).__name__
+            if isinstance(e, ObjectNotFound):
+                error = (
+                    f"Prefect deployment '{deployment}' not found. "
+                    "Check PREFECT_API_URL and that the worker registered its deployments."
+                )
+            await _mark_scheduled_sync_failed(claim["sync_run_id"], error)
+            results.append({**claim, "error": error})
 
     return {"scheduled": len(claims), "sources": results}
 

--- a/apps/worker/tests/test_flows_coverage.py
+++ b/apps/worker/tests/test_flows_coverage.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import contextmine_worker.flows as flows
 import pytest
+from prefect.exceptions import ObjectNotFound
 
 pytestmark = pytest.mark.anyio
 
@@ -2114,8 +2115,19 @@ class TestSyncDueSourcesFlowExtended:
         assert result["scheduled"] == 1
         record.assert_awaited_once_with(claim["sync_run_id"], str(flow_run.id))
 
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            (RuntimeError("prefect unavailable"), "prefect unavailable"),
+            (
+                ObjectNotFound(http_exc=RuntimeError("HTTP 404")),
+                "Prefect deployment 'sync_single_source/default' not found. "
+                "Check PREFECT_API_URL and that the worker registered its deployments.",
+            ),
+        ],
+    )
     async def test_deployment_failure_finishes_business_run(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, error: Exception, expected: str, caplog
     ) -> None:
         claim = {
             "source_id": str(uuid.uuid4()),
@@ -2126,7 +2138,7 @@ class TestSyncDueSourcesFlowExtended:
         monkeypatch.setattr(flows, "claim_due_source_runs", AsyncMock(return_value=[claim]))
         monkeypatch.setattr(
             "prefect.deployments.run_deployment",
-            AsyncMock(side_effect=RuntimeError("prefect unavailable")),
+            AsyncMock(side_effect=error),
         )
         monkeypatch.setattr(flows, "_mark_scheduled_sync_failed", mark_failed)
         monkeypatch.setattr(
@@ -2137,8 +2149,9 @@ class TestSyncDueSourcesFlowExtended:
 
         result = await flows.sync_due_sources.fn()
 
-        assert result["sources"][0]["error"] == "prefect unavailable"
-        mark_failed.assert_awaited_once_with(claim["sync_run_id"], "prefect unavailable")
+        assert result["sources"][0]["error"] == expected
+        mark_failed.assert_awaited_once_with(claim["sync_run_id"], expected)
+        assert any(record.exc_info for record in caplog.records)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When the configured Prefect deployment is missing, the SDK raises `ObjectNotFound` with the text `None`. Manual sync therefore persisted `Prefect scheduling failed: None`, and scheduled dispatch lost the same underlying cause. Both paths now identify the missing deployment, suggest checking `PREFECT_API_URL` and worker registration, and log the original exception with its traceback.

The Prefect health endpoint now handles exceptions **returned** by `api_healthcheck()`, so an unreachable server reports `error` instead of `ok`. Exceptions without a message fall back to their type name.

Validation:
- Real Prefect SDK against an HTTP mock returning 404 for deployment lookup.
- Regression checks fail against the previous implementation, then pass with the fix.
- Focused API routes and worker flow tests: **303 passed, 1 skipped** (existing skip).
- Repository-wide Ruff lint/format and `ty check`: passed.

Related to #46. This fixes diagnostics; it does not establish that the reporter's installation is repaired. #47 and #48 were merged after the issue was opened and address separate Compose configuration and worker startup defects.
